### PR TITLE
Fix Hierarchy is extends is not working second time

### DIFF
--- a/packages/core/src/hierarchy.ts
+++ b/packages/core/src/hierarchy.ts
@@ -165,7 +165,7 @@ export class Hierarchy {
    */
   private isExtends<T extends Doc>(extendsOrImplements: Ref<Interface<Doc>>[], from: Ref<Interface<T>>): boolean {
     const result: Ref<Interface<Doc>>[] = []
-    const toVisit = extendsOrImplements
+    const toVisit = [...extendsOrImplements]
     while (toVisit.length > 0) {
       const ref = toVisit.shift() as Ref<Interface<Doc>>
       if (ref === from) {


### PR DESCRIPTION
Fix Hierarchy is extends is not working second time

Signed-off-by: Andrey Sobolev [haiodo@gmail.com](mailto:haiodo@gmail.com)