### PR TITLE
Allow to provide model upgrades

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -314,6 +314,26 @@ dependencies:
 
 packages:
 
+  /@anticrm/core/0.6.13:
+    resolution: {integrity: sha512-/JvPMWJe74ePaiQKn4HJaCf1L8bnCHMuOCMAtcWtu1p9eB9Z4H/fGpw47je1xaStQAzn8V4rDFHBokWNqwLLHw==}
+    dependencies:
+      '@anticrm/platform': 0.6.5
+      just-clone: 3.2.1
+    dev: false
+
+  /@anticrm/platform/0.6.5:
+    resolution: {integrity: sha512-NwRA+s2mvqrt045NYrXXjCi/FB7uw9DFnmVqvVt4zozs8HsWtjQlQ7UPQjaqFV4rVZix6LTIGWmHAnvEGwOD5A==}
+    dependencies:
+      intl-messageformat: 9.7.1
+    dev: false
+
+  /@anticrm/workspace/0.6.0:
+    resolution: {integrity: sha512-lwAFFcWCzO+Q0nwB4i9jk1J16knNgSPmzHEoGb3Q86kLqRvVlaTH+aTk3wK1IXzMqDwZjGGWj+U4Oj2AdMswyg==}
+    dependencies:
+      '@anticrm/core': 0.6.13
+      mongodb: 4.1.3
+    dev: false
+
   /@babel/code-frame/7.12.11:
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
     dependencies:
@@ -9398,8 +9418,8 @@ packages:
         optional: true
     dev: false
 
-  /ws/8.2.3:
-    resolution: {integrity: sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==}
+  /ws/8.3.0:
+    resolution: {integrity: sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -9801,7 +9821,7 @@ packages:
       eslint-plugin-promise: 5.1.1_eslint@7.32.0
       prettier: 2.4.1
       typescript: 4.4.3
-      ws: 8.2.3
+      ws: 8.3.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -10134,7 +10154,7 @@ packages:
     dev: false
 
   file:projects/model-all.tgz_typescript@4.4.3:
-    resolution: {integrity: sha512-CmX0IDsPS79BtfPfKmxiiV8RYuxi+tx7r0UWxqk5zhln5FHF6Fi+cuuUyDmGZ6lYWp8x2q6reBcUdU8WRyJBEg==, tarball: file:projects/model-all.tgz}
+    resolution: {integrity: sha512-eIW+QawzHhuifmrQp4h14fovpjmURIYLHS5q44FP87gajgNpTs+FuNBpvlUFVnK/nmHaKjOtRFVXXO4S16cAcQ==, tarball: file:projects/model-all.tgz}
     id: file:projects/model-all.tgz
     name: '@rush-temp/model-all'
     version: 0.0.0
@@ -10243,7 +10263,7 @@ packages:
     dev: false
 
   file:projects/model-recruit.tgz_typescript@4.4.3:
-    resolution: {integrity: sha512-tvZVIcVZxLJTwI6RVvuk1XXGOGcMji5VFeDQCzhJSif+2dPJIQHEe/HrxNKArqvOXhGyOaA6zbUpftdlAxjQ+A==, tarball: file:projects/model-recruit.tgz}
+    resolution: {integrity: sha512-Ja9/9aH8v2JSQzsEtuxG7DFOOB405EoASN2ex9S31NYhYqgIqM8ZaRi5McthYz1e4gkyWFWtOCTHbBccNNOvLg==, tarball: file:projects/model-recruit.tgz}
     id: file:projects/model-recruit.tgz
     name: '@rush-temp/model-recruit'
     version: 0.0.0
@@ -10388,7 +10408,7 @@ packages:
     dev: false
 
   file:projects/model-task.tgz_typescript@4.4.3:
-    resolution: {integrity: sha512-7NTZP389oZgueMDG5WTRhgRWuT3VehxnJ5BqV2uWd/M8Yq8SGyIvyqN1vYiRBSkbksGcc+AMxbenH9eGZESB0g==, tarball: file:projects/model-task.tgz}
+    resolution: {integrity: sha512-AjQvZTFE3GR6hQkU4jFA9M0bJhQhiiBIaZdW+2ALaj3xwAzolD6eSStCUWVWIZgj9uJTSfT8oGTiIw+iISB61Q==, tarball: file:projects/model-task.tgz}
     id: file:projects/model-task.tgz
     name: '@rush-temp/model-task'
     version: 0.0.0
@@ -10735,7 +10755,7 @@ packages:
     dev: false
 
   file:projects/recruit-resources.tgz_476f694f64637160ae71e12ff57815b9:
-    resolution: {integrity: sha512-nYgz+aOKNZBwy/q+w0H+/YSchx4IUQZOsnQJka38VLb8V35Oa9HoHDH5GgF79P+af2fN/pkeaR7T0+zhLd8DFQ==, tarball: file:projects/recruit-resources.tgz}
+    resolution: {integrity: sha512-QyW+pkehvNOEfQL1YqIR/TdE3sNWqhEYYFcIUwl3hJUHG2OnQRce8WOgzFFnC9Vf4ZabkE+bMmjPREpEetOcAw==, tarball: file:projects/recruit-resources.tgz}
     id: file:projects/recruit-resources.tgz
     name: '@rush-temp/recruit-resources'
     version: 0.0.0
@@ -10955,7 +10975,7 @@ packages:
       jwt-simple: 0.5.6
       prettier: 2.4.1
       typescript: 4.4.3
-      ws: 8.2.3
+      ws: 8.3.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -10995,7 +11015,7 @@ packages:
     dev: false
 
   file:projects/setting-resources.tgz_476f694f64637160ae71e12ff57815b9:
-    resolution: {integrity: sha512-e9o9HTlJB1bBfRUN5KLhi/nJVaQqV1iFxOvISqV4hCLdMvf0+Yl7LkFqymZj9Oj277JV1HhO+VpSyPORtJcWaA==, tarball: file:projects/setting-resources.tgz}
+    resolution: {integrity: sha512-I85L1AQz7schJl8/PKyTjw+/svzxhQ9xnlHSQQnMffB1cSQ265P1v7Zt+NERnsqLGD/l3c59nqXep8JrSDf/Tw==, tarball: file:projects/setting-resources.tgz}
     id: file:projects/setting-resources.tgz
     name: '@rush-temp/setting-resources'
     version: 0.0.0
@@ -11056,7 +11076,7 @@ packages:
     dev: false
 
   file:projects/task-resources.tgz_e1367da94684b005adf08f025c517b1a:
-    resolution: {integrity: sha512-ClICw/CPw4rPYLvKabxpF44rmJKWLI61xTB4FSA75L9FamuJKV73Ncoo0/c5qhxGNcsd2fe1gHTjg6CYGqP1Lg==, tarball: file:projects/task-resources.tgz}
+    resolution: {integrity: sha512-sPfAMSXisFiYJzHMqrsXJ1hN078pUhJbhRJTTtkvnQedDSE8B49p2HwsIJ5ECPpc6Fuhr8wPP5hi4s8esRdzqw==, tarball: file:projects/task-resources.tgz}
     id: file:projects/task-resources.tgz
     name: '@rush-temp/task-resources'
     version: 0.0.0
@@ -11091,7 +11111,7 @@ packages:
     dev: false
 
   file:projects/task.tgz:
-    resolution: {integrity: sha512-yDiMMdXUoCo8/NLkpVdY8exQeuOaf18h+ICzhIEgyYjgEYmPxGCWVZ2qcOgWxEFJkEi6K7Gz5Fbz5wLpfVTD4g==, tarball: file:projects/task.tgz}
+    resolution: {integrity: sha512-Yi88o15ExlXV9xqFXzpmi4I5OjnnY7l6SiQasIC7HqKc5/lG4KFvw/dlZHsFnEbRw3Zxa+laq9MejSMqLEzEVw==, tarball: file:projects/task.tgz}
     name: '@rush-temp/task'
     version: 0.0.0
     dependencies:
@@ -11111,7 +11131,7 @@ packages:
     dev: false
 
   file:projects/telegram-resources.tgz_476f694f64637160ae71e12ff57815b9:
-    resolution: {integrity: sha512-k/x0wCwvORFOunkF3rKo5EFEPe7nWrKS75N1NBdm8owykYAie8gLNjOYcmupxe5k237nE7gEeVt4ak9lopwh6w==, tarball: file:projects/telegram-resources.tgz}
+    resolution: {integrity: sha512-ZneaA8uvCmjuSf+zjIrPM1lzhi1At5Giud4UOzKwz2o0lrC4+npRTtCIZ52ZKjjNoOTmgf/hr9RYrqwCMH+z4g==, tarball: file:projects/telegram-resources.tgz}
     id: file:projects/telegram-resources.tgz
     name: '@rush-temp/telegram-resources'
     version: 0.0.0
@@ -11242,10 +11262,11 @@ packages:
     dev: false
 
   file:projects/tool.tgz:
-    resolution: {integrity: sha512-M+CDNILEFBM+3jv4zU/2ImCQ0wcl2VfMRwI2Ls7ZhXko/+WN5VP4efG2LqK3aer/i3rpCr6gm+nDko7nWtwCZw==, tarball: file:projects/tool.tgz}
+    resolution: {integrity: sha512-trtuRv8WOxtP7g6+5hqJFhcIO/APD10wyWJN+6o/jYguz03jcGvwupR1qAu4oLv0RCtmqvJZewEHdiQ//sIL1g==, tarball: file:projects/tool.tgz}
     name: '@rush-temp/tool'
     version: 0.0.0
     dependencies:
+      '@anticrm/workspace': 0.6.0
       '@rushstack/heft': 0.41.1
       '@types/heft-jest': 1.0.2
       '@types/minio': 7.0.10
@@ -11265,10 +11286,13 @@ packages:
       prettier: 2.4.1
       ts-node: 10.2.1_8304ecd715830f7c190b4d1dea90b100
       typescript: 4.4.3
+      ws: 8.3.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
+      - bufferutil
       - supports-color
+      - utf-8-validate
     dev: false
 
   file:projects/ui.tgz_476f694f64637160ae71e12ff57815b9:

--- a/dev/client-resources/src/connection.ts
+++ b/dev/client-resources/src/connection.ts
@@ -13,14 +13,14 @@
 // limitations under the License.
 //
 
-import type { Tx, Storage, Ref, Doc, Class, DocumentQuery, FindResult, FindOptions, TxHander, ServerStorage, TxResult } from '@anticrm/core'
+import type { Tx, Storage, Ref, Doc, Class, DocumentQuery, FindResult, FindOptions, TxHander, ServerStorage, TxResult, Closable } from '@anticrm/core'
 import { DOMAIN_TX } from '@anticrm/core'
 import { createInMemoryAdapter, createInMemoryTxAdapter } from '@anticrm/dev-storage'
 import { createServerStorage, FullTextAdapter, IndexedDoc } from '@anticrm/server-core'
 import type { DbConfiguration } from '@anticrm/server-core'
 import { protoSerialize, protoDeserialize } from '@anticrm/platform'
 
-class ServerStorageWrapper implements Storage {
+class ServerStorageWrapper implements Storage, Closable {
   constructor (private readonly storage: ServerStorage, private readonly handler: TxHander) {}
 
   findAll <T extends Doc>(_class: Ref<Class<T>>, query: DocumentQuery<T>, options?: FindOptions<T>): Promise<FindResult<T>> {
@@ -33,6 +33,9 @@ class ServerStorageWrapper implements Storage {
     const [result, derived] = await this.storage.tx(_tx)
     for (const tx of derived) { this.handler(tx) }
     return result
+  }
+
+  async close (): Promise<void> {
   }
 }
 
@@ -54,7 +57,7 @@ async function createNullFullTextAdapter (): Promise<FullTextAdapter> {
   return new NullFullTextAdapter()
 }
 
-export async function connect (handler: (tx: Tx) => void): Promise<Storage> {
+export async function connect (handler: (tx: Tx) => void): Promise<Storage & Closable> {
   const conf: DbConfiguration = {
     domains: {
       [DOMAIN_TX]: 'InMemoryTx'

--- a/dev/tool/package.json
+++ b/dev/tool/package.json
@@ -39,13 +39,13 @@
     "commander": "^8.1.0",
     "@anticrm/account": "~0.6.0",
     "jwt-simple": "^0.5.6",
-    "@anticrm/contrib": "~0.6.0",
     "@anticrm/core": "~0.6.11",
     "@anticrm/contact": "~0.6.2",
-    "@anticrm/workspace": "~0.6.0",
     "minio": "^7.0.19",
     "@anticrm/model-all": "~0.6.0",
     "@anticrm/model-telegram": "~0.6.0",
-    "@anticrm/telegram": "~0.6.0"
+    "@anticrm/telegram": "~0.6.0",
+    "@anticrm/client-resources": "~0.6.4",
+    "ws": "~8.3.0"
   }
 }

--- a/dev/tool/src/connect.ts
+++ b/dev/tool/src/connect.ts
@@ -1,0 +1,19 @@
+
+import clientResources from '@anticrm/client-resources'
+import core, { TxOperations } from '@anticrm/core'
+import { encode } from 'jwt-simple'
+
+// eslint-disable-next-line
+const WebSocket = require('ws')
+
+export async function connect (transactorUrl: string, workspace: string): Promise<{ connection: TxOperations, close: () => Promise<void>}> {
+  console.log('connecting to transactor...')
+  const token = encode({ email: 'anticrm@hc.engineering', workspace }, 'secret')
+  const connection = await (await clientResources()).function.GetClient(token, transactorUrl, (url) => new WebSocket(url))
+  return {
+    connection: new TxOperations(connection, core.account.System),
+    close: async () => {
+      await connection.close()
+    }
+  }
+}

--- a/models/all/package.json
+++ b/models/all/package.json
@@ -43,6 +43,7 @@
     "@anticrm/model-server-chunter": "~0.6.0",
     "@anticrm/model-server-recruit": "~0.6.0",
     "@anticrm/model-server-view": "~0.6.0",
-    "@anticrm/model-activity": "~0.6.0"
+    "@anticrm/model-activity": "~0.6.0",
+    "@anticrm/core": "~0.6.13"
   }
 }

--- a/models/all/src/index.ts
+++ b/models/all/src/index.ts
@@ -19,7 +19,7 @@ import { createModel as coreModel } from '@anticrm/model-core'
 import { createModel as viewModel } from '@anticrm/model-view'
 import { createModel as workbenchModel } from '@anticrm/model-workbench'
 import { createModel as contactModel } from '@anticrm/model-contact'
-import { createModel as taskModel } from '@anticrm/model-task'
+import { createModel as taskModel, upgradeModel as upgradeTask } from '@anticrm/model-task'
 import { createModel as chunterModel } from '@anticrm/model-chunter'
 import { createModel as recruitModel } from '@anticrm/model-recruit'
 import { createModel as settingModel } from '@anticrm/model-setting'
@@ -32,6 +32,7 @@ import { createModel as serverViewModel } from '@anticrm/model-server-view'
 import { createModel as activityModel } from '@anticrm/model-activity'
 
 import { createDemo } from '@anticrm/model-demo'
+import { TxOperations } from '@anticrm/core'
 
 const builder = new Builder()
 
@@ -54,3 +55,5 @@ serverViewModel(builder)
 createDemo(builder)
 
 export default builder
+
+export const upgrades: ((client: TxOperations) => Promise<void>) [] = [upgradeTask]

--- a/packages/core/src/__tests__/connection.ts
+++ b/packages/core/src/__tests__/connection.ts
@@ -21,8 +21,9 @@ import { Hierarchy } from '../hierarchy'
 import { ModelDb, TxDb } from '../memdb'
 import { DOMAIN_TX } from '../tx'
 import { genMinModel } from './minmodel'
+import { Closable } from '../client'
 
-export async function connect (handler: (tx: Tx) => void): Promise<Storage> {
+export async function connect (handler: (tx: Tx) => void): Promise<Storage & Closable> {
   const txes = genMinModel()
 
   const hierarchy = new Hierarchy()
@@ -50,6 +51,7 @@ export async function connect (handler: (tx: Tx) => void): Promise<Storage> {
       const result = await Promise.all([model.tx(tx), transactions.tx(tx)])
       return result[0]
       // handler(tx) - we have only one client, should not update?
-    }
+    },
+    close: async () => {}
   }
 }

--- a/packages/presentation/src/utils.ts
+++ b/packages/presentation/src/utils.ts
@@ -1,25 +1,24 @@
 //
 // Copyright © 2020, 2021 Anticrm Platform Contributors.
 // Copyright © 2021 Hardcore Engineering Inc.
-// 
+//
 // Licensed under the Eclipse Public License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License. You may
 // obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// 
+//
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
 
 import { onDestroy } from 'svelte'
 
-import { Doc, Ref, Class, DocumentQuery, FindOptions, Client, Hierarchy, Tx, getCurrentAccount, ModelDb, TxResult } from '@anticrm/core'
-import { TxOperations } from '@anticrm/core'
+import { Doc, Ref, Class, DocumentQuery, FindOptions, Client, Hierarchy, Tx, getCurrentAccount, ModelDb, TxResult, TxOperations } from '@anticrm/core'
 import { LiveQuery as LQ } from '@anticrm/query'
-import { getMetadata  } from '@anticrm/platform'
+import { getMetadata } from '@anticrm/platform'
 
 import login from '@anticrm/login'
 
@@ -27,12 +26,11 @@ let liveQuery: LQ
 let client: Client & TxOperations
 
 class UIClient extends TxOperations implements Client {
-
   constructor (private readonly client: Client, private readonly liveQuery: LQ) {
     super(client, getCurrentAccount()._id)
   }
 
-  getHierarchy (): Hierarchy { 
+  getHierarchy (): Hierarchy {
     return this.client.getHierarchy()
   }
 
@@ -40,42 +38,46 @@ class UIClient extends TxOperations implements Client {
     return this.client.getModel()
   }
 
-  tx(tx: Tx): Promise<TxResult> {
+  async tx (tx: Tx): Promise<TxResult> {
     // return Promise.all([super.tx(tx), this.liveQuery.tx(tx)]) as unknown as Promise<void>
-    return super.tx(tx)  
+    return await super.tx(tx)
+  }
+
+  async close (): Promise<void> {
+    await client.close()
   }
 }
 
-export function getClient(): Client & TxOperations {
+export function getClient (): Client & TxOperations {
   return client
 }
 
-export function setClient(_client: Client) {
+export function setClient (_client: Client): void {
   liveQuery = new LQ(_client)
   client = new UIClient(_client, liveQuery)
   _client.notify = (tx: Tx) => {
-    liveQuery.tx(tx)
+    liveQuery.tx(tx).catch(err => console.log(err))
   }
 }
 
 export class LiveQuery {
   private unsubscribe = () => {}
 
-  constructor() { 
+  constructor () {
     onDestroy(() => { console.log('onDestroy query'); this.unsubscribe() })
   }
 
-  query<T extends Doc>(_class: Ref<Class<T>>, query: DocumentQuery<T>, callback: (result: T[]) => void, options?: FindOptions<T>) {
+  query<T extends Doc>(_class: Ref<Class<T>>, query: DocumentQuery<T>, callback: (result: T[]) => void, options?: FindOptions<T>): void {
     this.unsubscribe()
     this.unsubscribe = liveQuery.query(_class, query, callback, options)
   }
 }
 
-export function createQuery() { return new LiveQuery() }
+export function createQuery (): LiveQuery { return new LiveQuery() }
 
-export function getFileUrl(file: string): string {
+export function getFileUrl (file: string): string {
   const uploadUrl = getMetadata(login.metadata.UploadUrl)
   const token = getMetadata(login.metadata.LoginToken)
-  const url = `${uploadUrl}?file=${file}&token=${token}`
+  const url = `${uploadUrl as string}?file=${file}&token=${token as string}`
   return url
 }

--- a/packages/query/src/__tests__/connection.ts
+++ b/packages/query/src/__tests__/connection.ts
@@ -53,6 +53,7 @@ export async function connect (handler: (tx: Tx) => void): Promise<Client> {
       // Not required, since handled in client.
       // handler(tx)
       return {}
-    }
+    },
+    close: async () => {}
   }
 }

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -65,6 +65,10 @@ export class LiveQuery extends TxProcessor implements Client {
     this.client = client
   }
 
+  async close (): Promise<void> {
+    return await this.client.close()
+  }
+
   getHierarchy (): Hierarchy {
     return this.client.getHierarchy()
   }
@@ -120,12 +124,13 @@ export class LiveQuery extends TxProcessor implements Client {
       callback: callback as (result: Doc[]) => void
     }
     this.queries.push(q)
+    const stack = new Error().stack
     result
       .then((result) => {
         q.callback(result)
       })
-      .catch((err) => {
-        console.log('failed to update Live Query: ', err)
+      .catch((err: any) => {
+        console.log('failed to update Live Query: ', err, stack)
       })
 
     return () => {

--- a/plugins/client-resources/src/index.ts
+++ b/plugins/client-resources/src/index.ts
@@ -31,12 +31,12 @@ export default async () => {
 
   return {
     function: {
-      GetClient: async (token: string, endpoint: string): Promise<Client> => {
+      GetClient: async (token: string, endpoint: string, factory?: (url: string) => any): Promise<Client> => {
         if (client === undefined) {
           client = await createClient((handler: TxHander) => {
             const url = new URL(`/${token}`, endpoint)
             console.log('connecting to', url.href)
-            return connect(url.href, handler)
+            return connect(url.href, handler, factory)
           })
 
           // Check if we had dev hook for client.

--- a/plugins/client/src/index.ts
+++ b/plugins/client/src/index.ts
@@ -33,7 +33,7 @@ export type ClientHook = (client: Client) => Promise<Client>
 /**
  * @public
  */
-export type ClientFactory = (token: string, endpoint: string) => Promise<Client>
+export type ClientFactory = (token: string, endpoint: string, factory?: (url: string) => any) => Promise<Client>
 
 export default plugin(clientId,
   {

--- a/plugins/contact-resources/src/components/PersonPresenter.svelte
+++ b/plugins/contact-resources/src/components/PersonPresenter.svelte
@@ -33,10 +33,16 @@ async function onClick() {
 }
 </script>
 
-<div class="flex-row-center user-container" on:click={onClick}>
-  <Avatar size={'x-small'} avatar={value.avatar}/>
-  <div class="overflow-label user">{formatName(value.name)}</div>
-</div>
+{#if value}
+  <div class="flex-row-center user-container" on:click={onClick}>
+    <Avatar size={'x-small'} avatar={value.avatar}/>
+    <div class="overflow-label user">{formatName(value.name)}</div>
+  </div>
+{:else}
+  <div class="flex-row-center user-container" on:click={onClick}>
+    Not selected
+  </div>
+{/if}
 
 <style lang="scss">
   .user-container {

--- a/plugins/devmodel-resources/src/index.ts
+++ b/plugins/devmodel-resources/src/index.ts
@@ -78,6 +78,10 @@ class ModelClient implements Client {
     transactions.push({ tx, result })
     return result
   }
+
+  async close (): Promise<void> {
+    await this.client.close()
+  }
 }
 export async function Hook (client: Client): Promise<Client> {
   console.info('devmodel# Client HOOKED by DevModel')

--- a/server/mongo/src/__tests__/storage.test.ts
+++ b/server/mongo/src/__tests__/storage.test.ts
@@ -155,7 +155,11 @@ describe('mongo operations', () => {
     const serverStorage = await createServerStorage(conf)
 
     client = await createClient(async (handler) => {
-      return await Promise.resolve(serverStorage)
+      return {
+        findAll: async (_class, query, options) => await serverStorage.findAll(_class, query, options),
+        tx: async (tx) => await serverStorage.tx(tx),
+        close: async () => {}
+      }
     })
 
     operations = new TxOperations(client, core.account.System)

--- a/server/ws/src/server.ts
+++ b/server/ws/src/server.ts
@@ -104,9 +104,14 @@ class SessionManager {
 async function handleRequest<S> (service: S, ws: WebSocket, msg: string): Promise<void> {
   const request = readRequest(msg)
   const f = (service as any)[request.method]
-  const result = await f.apply(service, request.params)
-  const resp = { id: request.id, result }
-  ws.send(serialize(resp))
+  try {
+    const result = await f.apply(service, request.params)
+    const resp = { id: request.id, result }
+    ws.send(serialize(resp))
+  } catch (err: any) {
+    const resp = { id: request.id, error: err }
+    ws.send(serialize(resp))
+  }
 }
 
 /**


### PR DESCRIPTION
1. Allow to provide model upgrades
2. Task upgrade for public task space.
3. Client.close() to allow close of client operations.
4. Fix Task Kanban assignee display
5. Prevent server crash on document is not exists.

Signed-off-by: Andrey Sobolev [haiodo@gmail.com](mailto:haiodo@gmail.com)