### PR TITLE
Chunter model update

### DIFF
--- a/models/chunter/package.json
+++ b/models/chunter/package.json
@@ -37,6 +37,7 @@
     "@anticrm/model-attachment": "~0.6.0",
     "@anticrm/attachment": "~0.6.0",
     "@anticrm/model-workbench": "~0.6.1",
-    "@anticrm/activity": "~0.6.0"
+    "@anticrm/activity": "~0.6.0",
+    "@anticrm/workbench": "~0.6.1"
   }
 }

--- a/models/chunter/src/index.ts
+++ b/models/chunter/src/index.ts
@@ -97,19 +97,19 @@ export function createModel (builder: Builder): void {
         }
       ]
     }
-  })
+  }, chunter.app.Chunter)
   builder.createDoc(chunter.class.Channel, core.space.Model, {
     name: 'general',
     description: 'General Channel',
     private: false,
     members: []
-  })
+  }, chunter.space.General)
   builder.createDoc(chunter.class.Channel, core.space.Model, {
     name: 'random',
     description: 'Random Talks',
     private: false,
     members: []
-  })
+  }, chunter.space.Random)
 
   builder.mixin(chunter.class.Comment, core.class.Class, view.mixin.AttributePresenter, {
     presenter: chunter.component.CommentPresenter

--- a/models/chunter/src/plugin.ts
+++ b/models/chunter/src/plugin.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-import { chunterId } from '@anticrm/chunter'
+import { Channel, chunterId } from '@anticrm/chunter'
 import chunter from '@anticrm/chunter-resources/src/plugin'
 import type { IntlString } from '@anticrm/platform'
 import { mergeIds } from '@anticrm/platform'
@@ -21,6 +21,7 @@ import type { Ref } from '@anticrm/core'
 import { ViewletDescriptor } from '@anticrm/view'
 import type { AnyComponent } from '@anticrm/ui'
 import type { TxViewlet } from '@anticrm/activity'
+import { Application } from '@anticrm/workbench'
 
 export default mergeIds(chunterId, chunter, {
   component: {
@@ -40,5 +41,10 @@ export default mergeIds(chunterId, chunter, {
   },
   activity: {
     TxCommentCreate: '' as AnyComponent
-  }
+  },
+  space: {
+    General: '' as Ref<Channel>,
+    Random: '' as Ref<Channel>
+  },
+  app: { Chunter: '' as Ref<Application> }
 })


### PR DESCRIPTION
Use static IDs for chunter default spaces, to not loose message to channel mapping on upgrade

Signed-off-by: Andrey Sobolev [haiodo@gmail.com](mailto:haiodo@gmail.com)