### PR TITLE
Use latest git tag to set model version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Installing...
         run: node common/scripts/install-run-rush.js install
 
+      - name: Setting model version from git release...
+        run: node common/scripts/install-run-rush.js bump-model-version
+
       - name: Building...
         run: node common/scripts/install-run-rush.js rebuild -l --verbose
 

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -251,6 +251,14 @@
       "description": "show model version",
       "safeForSimultaneousRushProcesses": true,
       "shellCommand": "cd ./models/all/ && npx ts-node ./src/__showversion.ts"
+    },
+    {
+      "commandKind": "global",
+      "name": "bump-model-version",
+      "summary": "set model version from git + patch +1",
+      "description": "set current model version",
+      "safeForSimultaneousRushProcesses": true,
+      "shellCommand": "cd ./models/all/ && npx ts-node ./src/__bumpversion.ts"
     }  
   ],
 

--- a/dev/tool/package.json
+++ b/dev/tool/package.json
@@ -13,6 +13,7 @@
     "docker:build": "docker build -t anticrm/tool .",
     "docker:push": "docker push anticrm/tool",
     "run-local": "cross-env MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin MINIO_ENDPOINT=localhost MONGO_URL=mongodb://localhost:27017 TRANSACTOR_URL=ws:/localhost:3333 TELEGRAM_DATABASE=telegram-service ELASTIC_URL=http://localhost:9200 ts-node ./src/index.ts",
+    "run-local-node": "cross-env MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin MINIO_ENDPOINT=localhost MONGO_URL=mongodb://localhost:27017 TRANSACTOR_URL=ws:/localhost:3333 TELEGRAM_DATABASE=telegram-service ELASTIC_URL=http://localhost:9200 node ./bundle.js",
     "lint": "eslint src",
     "format": "prettier --write src && eslint --fix src"
   },

--- a/models/all/package.json
+++ b/models/all/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "eslint --fix src",
     "genmodel": "ts-node src/__genmodel.ts",
     "version": "ts-node src/__showversion.ts",
+    "bumpversion": "ts-node src/__bumpversion.ts",
     "lint": "eslint src",
     "format": "prettier --write src && eslint --fix src"
   },

--- a/models/all/src/__bumpversion.ts
+++ b/models/all/src/__bumpversion.ts
@@ -1,0 +1,40 @@
+//
+// Copyright © 2022 Anticrm Platform Contributors.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { exec } from 'child_process'
+import { writeFileSync } from 'fs'
+import currentVersion from './version.json'
+
+exec('git describe --tags --abbrev=0', (err, stdout, stderr) => {
+  if (err !== null) {
+    console.log('Error', err)
+    process.exit(1)
+  }
+  const rawVersion = stdout.trim().replace('v', '').split('.')
+  if (rawVersion.length === 3) {
+    const version = {
+      major: parseInt(rawVersion[0]),
+      minor: parseInt(rawVersion[1]),
+      patch: parseInt(rawVersion[2]) + 1 // Always use +1 version from released already.
+    }
+    const newVersion = JSON.stringify(version)
+    if (JSON.stringify(currentVersion) !== newVersion) {
+      console.log('Bumping version from', currentVersion, 'to', version)
+      writeFileSync('./src/version.json', newVersion)
+    } else {
+      console.log('same version already')
+    }
+  }
+})

--- a/models/all/src/index.ts
+++ b/models/all/src/index.ts
@@ -14,6 +14,8 @@
 //
 
 import core, { Data, Version } from '@anticrm/core'
+import jsonVersion from './version.json'
+
 import { Builder } from '@anticrm/model'
 import { createModel as activityModel } from '@anticrm/model-activity'
 import { createModel as attachmentModel } from '@anticrm/model-attachment'
@@ -37,6 +39,8 @@ import { createModel as textEditorModel } from '@anticrm/model-text-editor'
 import { createModel as viewModel } from '@anticrm/model-view'
 import { createModel as workbenchModel } from '@anticrm/model-workbench'
 import { createModel as notificationModel } from '@anticrm/model-notification'
+
+export const version: Data<Version> = jsonVersion as Data<Version>
 
 const builder = new Builder()
 
@@ -68,12 +72,6 @@ const builders = [
 
 for (const b of builders) {
   b(builder)
-}
-
-export const version: Data<Version> = {
-  major: 0,
-  minor: 6,
-  patch: 0
 }
 
 builder.createDoc(core.class.Version, core.space.Model, version, core.version.Model)

--- a/models/all/src/version.json
+++ b/models/all/src/version.json
@@ -1,0 +1,1 @@
+{"major":0,"minor":6,"patch":0}

--- a/models/all/tsconfig.json
+++ b/models/all/tsconfig.json
@@ -4,6 +4,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
-    "types": ["node"]
+    "types": ["node"],
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
Use latest git tag to set model version

So, when we create a git tag 0.6.4, every next build will automatically set intermediate version to 0.6.5.

Signed-off-by: Andrey Sobolev [haiodo@gmail.com](mailto:haiodo@gmail.com)