### PR TITLE
minor improve fulltext perfomance

### DIFF
--- a/server/core/src/fulltext.ts
+++ b/server/core/src/fulltext.ts
@@ -172,12 +172,7 @@ export class FullTextIndex implements WithFind {
       const size = options.limit
       while (true) {
         const ids = resultIds.splice(0, size)
-        const orderMap = new Map<Ref<Doc>, number>()
-        for (let index = 0; index < resultIds.length; index++) {
-          orderMap.set(resultIds[index], index)
-        }
         const res = await this.getResult(ctx, _class, ids, mainQuery as DocumentQuery<T>, options)
-        res.sort((a, b) => (orderMap.get(a._id) ?? 0) - (orderMap.get(b._id) ?? 0))
         result.push(...res)
         if (result.length >= size || res.length < size) {
           break

--- a/server/core/src/fulltext.ts
+++ b/server/core/src/fulltext.ts
@@ -156,14 +156,9 @@ export class FullTextIndex implements WithFind {
       }
     }
     const resultIds = getResultIds(ids, _id)
-    const { limit, ...otherOptions } = options ?? { }
-    const result = await this.dbStorage.findAll(ctx, _class, { _id: { $in: resultIds }, ...mainQuery }, otherOptions)
+    const result = await this.dbStorage.findAll(ctx, _class, { _id: { $in: resultIds }, ...mainQuery }, options)
     const total = result.total
     result.sort((a, b) => resultIds.indexOf(a._id) - resultIds.indexOf(b._id))
-    if (limit !== undefined) {
-      const res = toFindResult(result.splice(0, limit), total)
-      return res
-    }
     return toFindResult(result, total)
   }
 

--- a/server/core/src/types.ts
+++ b/server/core/src/types.ts
@@ -100,6 +100,7 @@ export interface IndexedDoc {
   modifiedOn: Timestamp
   modifiedBy: Ref<Account>
   attachedTo?: Ref<Doc>
+  attachedToClass?: Ref<Class<Doc>>
 
   [key: string]: any
 }

--- a/server/elastic/src/adapter.ts
+++ b/server/elastic/src/adapter.ts
@@ -43,6 +43,12 @@ class ElasticAdapter implements FullTextAdapter {
               _class: _classes.map((c) => c.toLowerCase()),
               boost: 10.0
             }
+          },
+          {
+            terms: {
+              attachedToClass: _classes.map((c) => c.toLowerCase()),
+              boost: 5.0
+            }
           }
         ]
       }


### PR DESCRIPTION
For example su3 `c++` query 2.5s instead 5.5 Rebuild elastic is not necessary, but recommended Signed-off-by: Denis Bykhov [80476319+BykhovDenis@users.noreply.github.com](mailto:80476319+BykhovDenis@users.noreply.github.com)