### PR TITLE
Fix clipboard write for Safari

### DIFF
--- a/plugins/tracker-resources/src/issues.ts
+++ b/plugins/tracker-resources/src/issues.ts
@@ -47,7 +47,18 @@ export async function copyToClipboard (object: Issue, ev: Event, { type }: { typ
     default:
       return
   }
-  await navigator.clipboard.writeText(text)
+
+  try {
+    // Chromium
+    await navigator.clipboard.writeText(text)
+  } catch {
+    // Safari specific behavior
+    // see https://bugs.webkit.org/show_bug.cgi?id=222262
+    const clipboardItem = new ClipboardItem({
+      'text/plain': Promise.resolve(text)
+    })
+    await navigator.clipboard.write([clipboardItem])
+  }
 }
 
 export function generateIssueShortLink (issueId: string): string {


### PR DESCRIPTION
# Contribution checklist

## Brief description

Cromium and Safari handles clipboard write in a different way:
- Safari does not allow to do `await` before writing to clipboard hence we have to use `write` with promise
- Chromium does not support async `write` with promise, so we have to use `writeText`


## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [x] - Does the translations are up to date?
* [x] - Does it well tested?
* [x] - Tested for Chrome.
* [x] - Tested for Safari.
* [x] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [x] - Rebase your branch onto master and upstream branch
* [x] - Is there any redundant or duplicate code?
* [x] - Are required links are linked to PR?
* [x] - Does new code is well documented ?

## Related issues

TSK-257
