### PR TITLE
Correct estimation circle behavior

### DIFF
--- a/plugins/tracker-resources/src/components/issues/timereport/EstimationStatsPresenter.svelte
+++ b/plugins/tracker-resources/src/components/issues/timereport/EstimationStatsPresenter.svelte
@@ -32,7 +32,10 @@
 
 <div class="estimation-container" on:click>
   <div class="icon">
-    <EstimationProgressCircle value={Math.max(value.reportedTime, childReportTime)} max={value.estimation} />
+    <EstimationProgressCircle
+      value={Math.max(value.reportedTime, childReportTime)}
+      max={childEstimationTime || value.estimation}
+    />
   </div>
   <span class="overflow-label label flex-row-center flex-nowrap text-md">
     {#if value.reportedTime > 0 || childReportTime > 0}


### PR DESCRIPTION
Signed-off-by: muhtimur <timur.mukhamedishin@xored.com>

# Contribution checklist

## Brief description

Progress circle should be shown for subtask estimations only set

![image](https://user-images.githubusercontent.com/84380737/200498787-fd28ca1b-a600-4d9c-80f9-b53d998855a8.png)

## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [ ] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

[TSK-374](https://front.hc.engineering/workbench/platform/tracker/my-issues#tracker%3Acomponent%3AEditIssue%7C6360bae353771b80d8393041%7Ctracker%3Aclass%3AIssue%7Ccontent)