### PR TITLE
Add close New Issue confirmation dialog

### DIFF
--- a/packages/presentation/src/components/Card.svelte
+++ b/packages/presentation/src/components/Card.svelte
@@ -26,6 +26,7 @@
   export let canSave: boolean = false
   export let createMore: boolean | undefined = undefined
   export let okLabel: IntlString = presentation.string.Create
+  export let onCancel: Function | undefined = undefined
 
   const dispatch = createEventDispatcher()
 
@@ -54,7 +55,11 @@
         icon={IconClose}
         kind={'transparent'}
         on:click={() => {
-          dispatch('close')
+          if (onCancel) {
+            onCancel()
+          } else {
+            dispatch('close')
+          }
         }}
       />
     </div>

--- a/plugins/tracker-assets/lang/en.json
+++ b/plugins/tracker-assets/lang/en.json
@@ -100,6 +100,8 @@
     "IssueTitlePlaceholder": "Issue title",
     "IssueDescriptionPlaceholder": "Add description",
     "AddIssueTooltip": "Add issue...",
+    "NewIssueDialogClose": "Do you want to close this dialog?",
+    "NewIssueDialogCloseNote": "All changes will be lost",
     "DueDatePopupTitle": "Due on {value}",
     "DueDatePopupOverdueTitle": "Was due on {value}",
     "DueDatePopupDescription": "{value, plural, =0 {Today} =1 {Tomorrow} other {# days remaining}}",

--- a/plugins/tracker-assets/lang/ru.json
+++ b/plugins/tracker-assets/lang/ru.json
@@ -100,6 +100,8 @@
     "IssueTitlePlaceholder": "Имя задачи",
     "IssueDescriptionPlaceholder": "Описание задачи",
     "AddIssueTooltip": "Добавить задачу\u2026",
+    "NewIssueDialogClose": "Вы действительно хотите закрыть окно?",
+    "NewIssueDialogCloseNote": "Все внесенные изменения будут потеряны",
     "DueDatePopupTitle": "Срок {value}",
     "DueDatePopupOverdueTitle": "Должна была завершится {value}",
     "DueDatePopupDescription": "{value, plural, =0 {Сегодня} =1 {Завтра} other {# дней осталось}}",

--- a/plugins/tracker-resources/src/components/CreateIssue.svelte
+++ b/plugins/tracker-resources/src/components/CreateIssue.svelte
@@ -300,7 +300,6 @@
       sprint: null,
       subIssues: [],
       template: undefined,
-      team: null,
       title: ''
     }
 
@@ -329,13 +328,7 @@
     return true
   }
 
-  export async function onOutsideClick () {
-    if (!shouldSaveDraft) {
-      return
-    }
-
-    await descriptionBox?.createAttachments()
-
+  function createDraftFromObject () {
     const newDraft: Data<IssueDraft> = {
       issueId: objectId,
       title: getTitle(object.title),
@@ -354,6 +347,17 @@
       subIssues
     }
 
+    return newDraft
+  }
+
+  export async function onOutsideClick () {
+    if (!shouldSaveDraft) {
+      return
+    }
+
+    await descriptionBox?.createAttachments()
+
+    const newDraft = createDraftFromObject()
     const isEmpty = await isDraftEmpty(newDraft)
 
     if (isEmpty) {
@@ -610,6 +614,29 @@
       }
     )
   }
+
+  async function showConfirmationDialog () {
+    const newDraft = createDraftFromObject()
+    const isFormEmpty = await isDraftEmpty(newDraft)
+
+    if (isFormEmpty) {
+      dispatch('close')
+    } else {
+      showPopup(
+        MessageBox,
+        {
+          label: tracker.string.NewIssueDialogClose,
+          message: tracker.string.NewIssueDialogCloseNote
+        },
+        'top',
+        (result?: boolean) => {
+          if (result === true) {
+            dispatch('close')
+          }
+        }
+      )
+    }
+  }
 </script>
 
 <Card
@@ -617,9 +644,7 @@
   okAction={createIssue}
   {canSave}
   okLabel={tracker.string.SaveIssue}
-  on:close={() => {
-    dispatch('close')
-  }}
+  on:close={showConfirmationDialog}
   createMore={false}
 >
   <svelte:fragment slot="header">

--- a/plugins/tracker-resources/src/components/CreateIssue.svelte
+++ b/plugins/tracker-resources/src/components/CreateIssue.svelte
@@ -620,6 +620,7 @@
     const isFormEmpty = await isDraftEmpty(newDraft)
 
     if (isFormEmpty) {
+      console.log('isFormEmpty')
       dispatch('close')
     } else {
       showPopup(
@@ -644,8 +645,9 @@
   okAction={createIssue}
   {canSave}
   okLabel={tracker.string.SaveIssue}
-  on:close={showConfirmationDialog}
+  on:close={() => dispatch('close')}
   createMore={false}
+  onCancel={showConfirmationDialog}
 >
   <svelte:fragment slot="header">
     <div class="flex-row-center">

--- a/plugins/tracker-resources/src/plugin.ts
+++ b/plugins/tracker-resources/src/plugin.ts
@@ -163,6 +163,8 @@ export default mergeIds(trackerId, tracker, {
     IssueDescriptionPlaceholder: '' as IntlString,
     Unassigned: '' as IntlString,
     AddIssueTooltip: '' as IntlString,
+    NewIssueDialogClose: '' as IntlString,
+    NewIssueDialogCloseNote: '' as IntlString, 
 
     CopyIssueUrl: '' as IntlString,
     CopyIssueId: '' as IntlString,

--- a/plugins/tracker-resources/src/plugin.ts
+++ b/plugins/tracker-resources/src/plugin.ts
@@ -164,7 +164,7 @@ export default mergeIds(trackerId, tracker, {
     Unassigned: '' as IntlString,
     AddIssueTooltip: '' as IntlString,
     NewIssueDialogClose: '' as IntlString,
-    NewIssueDialogCloseNote: '' as IntlString, 
+    NewIssueDialogCloseNote: '' as IntlString,
 
     CopyIssueUrl: '' as IntlString,
     CopyIssueId: '' as IntlString,


### PR DESCRIPTION
Signed-off-by: muhtimur <timur.mukhamedishin@xored.com>

# Contribution checklist

## Brief description

Now when you try to click X on "New Issue" dialog you see confirmation dialog. It appears only when form is not empty

![image](https://user-images.githubusercontent.com/84380737/200764581-11c431e6-c5c6-487b-8497-10c1970e1d00.png)

## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [x] - Does the translations are up to date?
* [x] - Does it well tested?
* [x] - Tested for Chrome.
* [x] - Tested for Safari.
* [x] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [x] - Rebase your branch onto master and upstream branch
* [x] - Is there any redundant or duplicate code?
* [x] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

[TSK-398](https://front.hc.engineering/workbench/platform/tracker/my-issues#tracker%3Acomponent%3AEditIssue%7C6363625f177e4be4b28b2fbc%7Ctracker%3Aclass%3AIssue%7Ccontent)