### PR TITLE
TSK-1452: Revert sprint statistics display

### DIFF
--- a/plugins/tracker-resources/src/components/issues/timereport/EstimationEditor.svelte
+++ b/plugins/tracker-resources/src/components/issues/timereport/EstimationEditor.svelte
@@ -18,7 +18,7 @@
   import { getClient } from '@hcengineering/presentation'
   import { Issue, IssueDraft } from '@hcengineering/tracker'
   import { Button, ButtonKind, ButtonSize, eventToHTMLElement, showPopup } from '@hcengineering/ui'
-  import { EditBoxPopup } from '@hcengineering/view-resources'
+  import { EditBoxPopup, FixedColumn } from '@hcengineering/view-resources'
   import { createEventDispatcher } from 'svelte'
   import tracker from '../../../plugin'
   import EstimationPopup from './EstimationPopup.svelte'
@@ -74,7 +74,9 @@
 
 {#if value}
   {#if kind === 'list' && '_class' in value}
-    <EstimationStatsPresenter {value} {kind} on:click={handleestimationEditorOpened} />
+    <FixedColumn key="estimation-editor-total">
+      <EstimationStatsPresenter {value} {kind} on:click={handleestimationEditorOpened} />
+    </FixedColumn>
   {:else}
     <Button
       {focusIndex}

--- a/plugins/tracker-resources/src/components/issues/timereport/TimePresenter.svelte
+++ b/plugins/tracker-resources/src/components/issues/timereport/TimePresenter.svelte
@@ -29,13 +29,15 @@
   on:click
   use:tooltip={{
     component: Label,
-    props: { label: tracker.string.TimeSpendHours, params: { value: floorFractionDigits(value * 8, 2) } }
+    props: { label: tracker.string.TimeSpendHours, params: { value: floorFractionDigits(value * 8, 3) } }
   }}
 >
   {#if noSymbol}
-    {floorFractionDigits(value, 3)}
+    {floorFractionDigits(value, 1)}
+  {:else if value > 0 && value < 1}
+    <Label label={tracker.string.TimeSpendHours} params={{ value: floorFractionDigits(value * 8, 1) }} />
   {:else}
-    <Label label={tracker.string.TimeSpendValue} params={{ value: floorFractionDigits(value, 3) }} />
+    <Label label={tracker.string.TimeSpendValue} params={{ value: floorFractionDigits(value, 1) }} />
   {/if}
 </span>
 

--- a/plugins/tracker-resources/src/components/sprints/IssueStatistics.svelte
+++ b/plugins/tracker-resources/src/components/sprints/IssueStatistics.svelte
@@ -20,8 +20,10 @@
   import { statusStore } from '@hcengineering/presentation'
   import EstimationProgressCircle from '../issues/timereport/EstimationProgressCircle.svelte'
   import TimePresenter from '../issues/timereport/TimePresenter.svelte'
+  import { FixedColumn } from '@hcengineering/view-resources'
   export let docs: Issue[] | undefined = undefined
   export let capacity: number | undefined = undefined
+  export let category: string | undefined = undefined
 
   $: ids = new Set(docs?.map((it) => it._id) ?? [])
 
@@ -60,7 +62,7 @@
       .reduce((it, cur) => {
         return it + cur
       }, 0),
-    3
+    1
   )
   $: totalReported = floorFractionDigits(
     (noParents ?? [{ reportedTime: 0, childInfo: [] } as unknown as Issue])
@@ -76,22 +78,24 @@
       .reduce((it, cur) => {
         return it + cur
       }, 0),
-    3
+    1
   )
 </script>
 
-{#if docs}
-  <!-- <Label label={tracker.string.SprintDay} value={}/> -->
-  <div class="flex-row-center flex-no-shrink h-6" class:showWarning={totalEstimation > (capacity ?? 0)}>
-    <EstimationProgressCircle value={totalReported} max={totalEstimation} />
-    <div class="w-2 min-w-2" />
-    {#if totalReported > 0}
-      <TimePresenter value={totalReported} />
-      /
-    {/if}
-    <TimePresenter value={totalEstimation} />
-    {#if capacity}
-      <Label label={tracker.string.CapacityValue} params={{ value: capacity }} />
-    {/if}
-  </div>
+{#if docs && (category === 'sprint' || category === 'assignee')}
+  <FixedColumn key="estimation-editor">
+    <!-- <Label label={tracker.string.SprintDay} value={}/> -->
+    <div class="flex-row-center flex-no-shrink h-6" class:showWarning={totalEstimation > (capacity ?? 0)}>
+      <EstimationProgressCircle value={totalReported} max={totalEstimation} />
+      <div class="w-2 min-w-2" />
+      {#if totalReported > 0}
+        <TimePresenter value={totalReported} />
+        /
+      {/if}
+      <TimePresenter value={totalEstimation} />
+      {#if capacity}
+        <Label label={tracker.string.CapacityValue} params={{ value: capacity }} />
+      {/if}
+    </div>
+  </FixedColumn>
 {/if}

--- a/plugins/view-resources/src/components/list/ListHeader.svelte
+++ b/plugins/view-resources/src/components/list/ListHeader.svelte
@@ -19,6 +19,7 @@
     ActionIcon,
     AnyComponent,
     Button,
+    Component,
     IconAdd,
     IconBack,
     IconCheck,
@@ -98,7 +99,7 @@
     }}
     on:click={() => dispatch('collapse')}
   >
-    <div class="flex-row-center clear-mins">
+    <div class="flex-row-center clear-mins flex-grow">
       {#if level === 0}
         <div class="chevron"><IconCollapseArrow size={'small'} /></div>
       {/if}
@@ -152,6 +153,11 @@
       {:else}
         <span class="antiSection-header__counter ml-2">{items.length}</span>
       {/if}
+      <div class="flex-row-center flex-reverse flex-grow">
+        {#each extraHeaders ?? [] as extra}
+          <Component is={extra} props={{ ...props, value: category, category: groupByKey, docs: items }} />
+        {/each}
+      </div>
     </div>
     {#if createItemDialog !== undefined && createItemLabel !== undefined}
       <div class:on-hover={!mouseOver} class="flex-row-center">
@@ -190,7 +196,7 @@
     position: relative;
     position: sticky;
     top: 0;
-    padding: 0 0.75rem 0 0.75rem;
+    padding: 0 2.5rem 0 0.75rem;
     height: 2.75rem;
     min-height: 2.75rem;
     min-width: 0;

--- a/tests/sanity/tests/tracker.spec.ts
+++ b/tests/sanity/tests/tracker.spec.ts
@@ -120,6 +120,18 @@ test('my-issues', async ({ page }) => {
   await expect(page.locator('.antiPanel-component')).not.toContainText(name)
 })
 
+function floorFractionDigits (n: number | string, amount: number): number {
+  return Number(Number(n).toFixed(amount))
+}
+
+function toTime (value: number): string {
+  if (value > 0 && value < 1) {
+    return `${floorFractionDigits(value * 8, 1)}h`
+  } else {
+    return `${floorFractionDigits(value, 1)}d`
+  }
+}
+
 test('report-time-from-issue-card', async ({ page }) => {
   await navigate(page)
   const assignee = 'Chen Rosamund'
@@ -144,7 +156,7 @@ test('report-time-from-issue-card', async ({ page }) => {
     await page.click('button:has-text("Create")')
     await page.click('#card-close')
 
-    await expect(page.locator('#ReportedTimeEditor')).toContainText(`${time}d`)
+    await expect(page.locator('#ReportedTimeEditor')).toContainText(toTime(time))
   }
 })
 
@@ -190,7 +202,7 @@ test('report-time-from-main-view', async ({ page }) => {
     await page.click('button:has-text("Create")')
     await page.click('#card-close')
 
-    await expect(page.locator('.estimation-container >> span').first()).toContainText(`${Number(count.toFixed(2))}d`)
+    await expect(page.locator('.estimation-container >> span').first()).toContainText(toTime(count))
   }
 })
 


### PR DESCRIPTION
# Contribution checklist

## Brief description

Return sprint and assignee statistics to list categories.

<img width="1336" alt="Screenshot 2023-05-05 at 00 16 36" src="https://user-images.githubusercontent.com/477235/236278338-a52a0d75-04f1-4216-8494-2611f4ec841b.png">


## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [x] - Does the code work? Check whether function and logic are correct.
* [x] - Does Changelog.md is updated with changes?
* [x] - Does the translations are up to date?
* [x] - Does it well tested?
* [x] - Tested for Chrome.
* [x] - Tested for Safari.
* [x] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [x] - Rebase your branch onto master and upstream branch
* [x] - Is there any redundant or duplicate code?
* [x] - Are required links are linked to PR?
* [x] - Does new code is well documented ?

## Related issues

A list of closed updated issues
