### PR TITLE
UBER-56: check if title is hidden for Candidate (Talent) in Kanban and Application. Fix Talent card width in Application

### DIFF
--- a/plugins/recruit-resources/src/components/CandidateCard.svelte
+++ b/plugins/recruit-resources/src/components/CandidateCard.svelte
@@ -55,7 +55,10 @@
     </DocNavLink>
     {#if client.getHierarchy().hasMixin(candidate, recruit.mixin.Candidate)}
       {@const cand = client.getHierarchy().as(candidate, recruit.mixin.Candidate)}
-      <div class="description lines-limit-2">{cand.title ?? ''}</div>
+      {@const titleAttribute = client.getHierarchy().getAttribute(recruit.mixin.Candidate, 'title')}
+      {#if !titleAttribute.hidden}
+        <div class="description lines-limit-2">{cand.title ?? ''}</div>
+      {/if}
     {/if}
     <div class="description overflow-label">{candidate.city ?? ''}</div>
     <div class="footer flex flex-reverse flex-grow">
@@ -95,6 +98,7 @@
     user-select: text;
     min-width: 15rem;
     min-height: 15rem;
+    max-width: 25rem;
 
     &:hover {
       background-color: var(--theme-button-hovered);

--- a/plugins/recruit-resources/src/components/KanbanCard.svelte
+++ b/plugins/recruit-resources/src/components/KanbanCard.svelte
@@ -35,6 +35,7 @@
   const client = getClient()
   const hierarchy = client.getHierarchy()
   const assigneeAttribute = hierarchy.getAttribute(recruit.class.Applicant, 'assignee')
+  const isTitleHidden = client.getHierarchy().getAttribute(recruit.mixin.Candidate, 'title').hidden
 
   function showCandidate () {
     showPanel(view.component.EditDoc, object._id, Hierarchy.mixinOrClass(object), 'content')
@@ -62,7 +63,9 @@
         <div class="fs-title over-underline lines-limit-2">
           {object.$lookup?.attachedTo ? getName(object.$lookup.attachedTo) : ''}
         </div>
-        <div class="text-sm lines-limit-2">{object.$lookup?.attachedTo?.title ?? ''}</div>
+        {#if !isTitleHidden}
+          <div class="text-sm lines-limit-2">{object.$lookup?.attachedTo?.title ?? ''}</div>
+        {/if}
       </div>
     </div>
     <div class="tool mr-1 flex-row-center">


### PR DESCRIPTION

# Contribution checklist

## Brief description
Talent card width fix
![image](https://github.com/hcengineering/anticrm/assets/37306501/372916c1-0f17-4d81-98e9-3a31c707ddd4)

Hiding title
![image](https://github.com/hcengineering/anticrm/assets/37306501/803a0fed-5648-4137-ac3c-135b95867695)

## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [x] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues
