### PR TITLE
[UBER-242] Fix breadcrumbs sizing in Safari

### DIFF
--- a/packages/presentation/src/components/breadcrumbs/BreadcrumbsElement.svelte
+++ b/packages/presentation/src/components/breadcrumbs/BreadcrumbsElement.svelte
@@ -13,21 +13,18 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  import { resizeObserver } from '@hcengineering/ui'
-
   export let label: string | undefined = undefined
   export let title: string | undefined = undefined
   export let position: 'start' | 'middle' | 'end' | undefined = undefined
   export let selected = false
   export let color = 'var(--body-color)'
 
-  let lenght = 0
+  let clientWidth = 0
+
+  $: lenght = clientWidth + 32 > 300 ? 300 : clientWidth + 32
 </script>
 
-<div
-  class="hidden-text text-md font-medium pointer-events-none content-pointer-events-none"
-  use:resizeObserver={(element) => (lenght = element.clientWidth + 32 > 300 ? 300 : element.clientWidth + 32)}
->
+<div class="hidden-text text-md font-medium pointer-events-none content-pointer-events-none" bind:clientWidth>
   {#if $$slots.default}
     <slot />
   {:else}
@@ -45,6 +42,7 @@
     on:click
   >
     <svg
+      style={`width: ${lenght}px;`}
       class="asb-bar__back"
       viewBox="0 0 {lenght} 24"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/theme/styles/components.scss
+++ b/packages/theme/styles/components.scss
@@ -327,7 +327,6 @@
     width: auto;
 
     &__back {
-      width: auto;
       padding: 1px 0.5px;
       height: calc(1.5rem + 2px);
       // height: 1.5rem;


### PR DESCRIPTION
# Contribution checklist
Before:
<img width="240" alt="Screenshot 2023-05-26 at 17 44 02" src="https://github.com/hcengineering/anticrm/assets/105148288/44b2c926-4184-4ab5-a613-fdfc35de048c">
After:
<img width="368" alt="Screenshot 2023-05-26 at 18 00 39" src="https://github.com/hcengineering/anticrm/assets/105148288/c5d217bb-32ae-4ed8-8c75-fba5e5df2148">

## Brief description

## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [x] - Does the translations are up to date?
* [x] - Does it well tested?
* [x] - Tested for Chrome.
* [x] - Tested for Safari.
* [x] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [x] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [x] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

[UBER-242](https://front.hc.engineering/workbench/platform/tracker/UBER-242)
