### PR TITLE
fix: do not shrink expand/collapse icon in tree

### DIFF
--- a/plugins/view-resources/src/components/navigator/TreeElement.svelte
+++ b/plugins/view-resources/src/components/navigator/TreeElement.svelte
@@ -75,7 +75,7 @@
 
     {#if node}
       <div class="an-element__icon-arrow" class:collapsed>
-        <svg fill="currentColor" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+        <svg class="svg-small" fill="currentColor" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
           <polygon points="11.3,5.8 8,9.1 4.7,5.8 4,6.5 8,10.5 12,6.5 " />
         </svg>
       </div>


### PR DESCRIPTION
Fixes an issue with expand/collapse icon in sidebar. When an item name is long, the icon becomes small. Adding the class name fixes the issue.

# Contribution checklist

## Brief description

## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [ ] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues
