### PR TITLE
UBER-762: Fix editor popup menu behavior

### DIFF
--- a/packages/text-editor/src/components/StyleButton.svelte
+++ b/packages/text-editor/src/components/StyleButton.svelte
@@ -27,6 +27,7 @@
 <button
   class="button {size}"
   class:selected
+  class:disabled
   {disabled}
   use:tooltip={showTooltip}
   tabindex="0"
@@ -68,6 +69,15 @@
     &.large {
       width: 1.5rem;
       height: 1.5rem;
+    }
+
+    &.disabled {
+      opacity: 0.5;
+
+      &:hover {
+        color: var(--theme-darker-color);
+        cursor: default;
+      }
     }
   }
 </style>


### PR DESCRIPTION
# Contribution checklist

## Brief description

Ballon now opens not only on selection, but also on click. This works pretty good because it's a kind of natural behaviour to put cursor somewhere before insert something. 

## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [x] - Does it well tested?
* [x] - Tested for Chrome.
* [x] - Tested for Safari.
* [x] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [x] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [x] - Does new code is well documented ?

## Related issues

A list of closed updated issues
