### PR TITLE
fix: trim cookie string before extracting values

### DIFF
--- a/server/front/src/index.ts
+++ b/server/front/src/index.ts
@@ -230,7 +230,7 @@ export function start (
   const filesHandler = async (req: any, res: Response): Promise<void> => {
     try {
       console.log(req.headers)
-      const cookies = ((req?.headers?.cookie as string) ?? '').split(';').map((it) => it.split('='))
+      const cookies = ((req?.headers?.cookie as string) ?? '').split(';').map((it) => it.trim().split('='))
 
       const token = cookies.find((it) => it[0] === 'presentation-metadata-Token')?.[1]
       const payload =


### PR DESCRIPTION
# Contribution checklist

## Brief description

Files API has been broken doe to cookie changes.
Cookies are separated by `; ` in a cookie string, so due to extra whitespace in the cookie name, the token was not parsed properly.

## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [x] - Does it well tested?
* [x] - Tested for Chrome.
* [ ] - Tested for Safari.
* [x] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [x] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues
