### PR TITLE
UBER-744: show only attachment button for comment's input in popup

### DIFF
--- a/packages/text-editor/src/components/ReferenceInput.svelte
+++ b/packages/text-editor/src/components/ReferenceInput.svelte
@@ -48,6 +48,7 @@
   export let placeholder: IntlString | undefined = undefined
   export let extraActions: RefAction[] | undefined = undefined
   export let loading: boolean = false
+  export let basicInput: boolean = false
 
   const client = getClient()
 
@@ -110,6 +111,7 @@
     }
     actions = defActions.concat(...cont).sort((a, b) => a.order - b.order)
   })
+  $: actionsToShow = basicInput ? [defActions[0]] : actions
 
   export function submit (): void {
     textEditor.submit()
@@ -210,7 +212,7 @@
   </div>
   <div class="flex-between clear-mins" style:margin={'.75rem .75rem 0'}>
     <div class="buttons-group medium-gap">
-      {#each actions as a}
+      {#each actionsToShow as a}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <div
           class="icon-button"
@@ -224,7 +226,7 @@
         {/if}
       {/each}
     </div>
-    {#if extraActions && extraActions.length > 0}
+    {#if extraActions && extraActions.length > 0 && !basicInput}
       <div class="buttons-group {shrinkButtons ? 'medium-gap' : 'large-gap'}">
         {#each extraActions as a}
           <!-- svelte-ignore a11y-click-events-have-key-events -->

--- a/plugins/attachment-resources/src/components/AttachmentRefInput.svelte
+++ b/plugins/attachment-resources/src/components/AttachmentRefInput.svelte
@@ -41,6 +41,7 @@
   }
   export let placeholder: IntlString | undefined = undefined
   export let extraActions: RefAction[] | undefined = undefined
+  export let basicInput: boolean = false
 
   let refInput: ReferenceInput
 
@@ -286,6 +287,7 @@
       {labelSend}
       {showSend}
       {loading}
+      {basicInput}
       on:focus
       on:blur
       on:message={onMessage}

--- a/plugins/chunter-resources/src/components/CommentInput.svelte
+++ b/plugins/chunter-resources/src/components/CommentInput.svelte
@@ -23,6 +23,7 @@
   export let object: Doc
   export let shouldSaveDraft: boolean = true
   export let focusIndex: number = -1
+  export let basicInput: boolean = false
 
   const client = getClient()
   const _class = chunter.class.Comment
@@ -124,6 +125,7 @@
   space={object.space}
   bind:objectId={_id}
   {shouldSaveDraft}
+  {basicInput}
   on:message={onMessage}
   on:update={onUpdate}
   on:focus

--- a/plugins/chunter-resources/src/components/CommentPopup.svelte
+++ b/plugins/chunter-resources/src/components/CommentPopup.svelte
@@ -87,6 +87,7 @@
   {#if withInput}
     <div class="max-w-120 input">
       <CommentInput
+        basicInput
         {object}
         on:focus={(evt) => {
           commentMode = true


### PR DESCRIPTION
# Contribution checklist

## Brief description

Prevent overlap tooltips/popups when comments popup is used, by removing them there

![](https://github.com/hcengineering/anticrm/assets/37306501/86e24743-d5b0-40f6-910d-ab047bf24594)

## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [x] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [x] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues