### PR TITLE
UBER-880 Use space presenter for starred spaces

### DIFF
--- a/plugins/workbench-resources/src/components/Navigator.svelte
+++ b/plugins/workbench-resources/src/components/Navigator.svelte
@@ -1,5 +1,5 @@
 <!--
-// Copyright © 2022 Hardcore Engineering Inc.
+// Copyright © 2022, 2023 Hardcore Engineering Inc.
 //
 // Licensed under the Eclipse Public License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License. You may
@@ -162,7 +162,15 @@
       on:select={(res) => (menuSelection = res.detail)}
     />
     {#if starred.length}
-      <StarredNav label={preference.string.Starred} spaces={starred} on:space {currentSpace} />
+      <StarredNav
+        label={preference.string.Starred}
+        spaces={starred}
+        models={model.spaces}
+        on:space
+        {currentSpace}
+        {currentSpecial}
+        deselect={menuSelection}
+      />
     {/if}
 
     {#each model.spaces as m, i (m.label)}

--- a/plugins/workbench-resources/src/components/navigator/SpacesNav.svelte
+++ b/plugins/workbench-resources/src/components/navigator/SpacesNav.svelte
@@ -1,5 +1,6 @@
 <!--
 // Copyright © 2020 Anticrm Platform Contributors.
+// Copyright © 2023 Hardcore Engineering Inc.
 // 
 // Licensed under the Eclipse Public License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License. You may
@@ -13,7 +14,7 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  import type { Class, Doc, Ref, Space } from '@hcengineering/core'
+  import type { Doc, Ref, Space } from '@hcengineering/core'
   import core from '@hcengineering/core'
   import { DocUpdates } from '@hcengineering/notification'
   import { NotificationClientImpl } from '@hcengineering/notification-resources'
@@ -23,7 +24,6 @@
   import {
     Action,
     AnyComponent,
-    AnySvelteComponent,
     IconAdd,
     IconEdit,
     IconSearch,
@@ -31,12 +31,11 @@
     navigate,
     showPopup
   } from '@hcengineering/ui'
-  import view from '@hcengineering/view'
   import { NavLink, TreeItem, TreeNode, getActions as getContributedActions } from '@hcengineering/view-resources'
   import { SpacesNavModel } from '@hcengineering/workbench'
   import { createEventDispatcher } from 'svelte'
   import plugin from '../../plugin'
-  import { classIcon, getSpaceName } from '../../utils'
+  import { classIcon, getSpaceName, getSpacePresenter } from '../../utils'
   import TreeSeparator from './TreeSeparator.svelte'
 
   export let model: SpacesNavModel
@@ -100,7 +99,6 @@
 
   const notificationClient = NotificationClientImpl.getClient()
   const docUpdates = notificationClient.docUpdatesStore
-  const hierarchy = client.getHierarchy()
 
   function isChanged (space: Space, docUpdates: Map<Ref<Doc>, DocUpdates>): boolean {
     const update = docUpdates.get(space._id)
@@ -114,13 +112,6 @@
       result.push(addSpace(model.addSpaceLabel, model.createComponent))
     }
     return result
-  }
-
-  async function getPresenter (_class: Ref<Class<Doc>>): Promise<AnySvelteComponent | undefined> {
-    const value = hierarchy.classHierarchyMixin(_class, view.mixin.SpacePresenter)
-    if (value?.presenter !== undefined) {
-      return await getResource(value.presenter)
-    }
   }
 
   let visibleIf: ((space: Space) => Promise<boolean>) | undefined
@@ -157,7 +148,7 @@
   shortDropbox={model.specials !== undefined}
 >
   {#each filteredSpaces as space, i (space._id)}
-    {#await getPresenter(space._class) then presenter}
+    {#await getSpacePresenter(client, space._class) then presenter}
       {#if separate && model.specials && i !== 0}<TreeSeparator line />{/if}
       {#if model.specials && presenter}
         <svelte:component this={presenter} {space} {model} {currentSpace} {currentSpecial} {getActions} {deselect} />

--- a/plugins/workbench-resources/src/utils.ts
+++ b/plugins/workbench-resources/src/utils.ts
@@ -1,6 +1,6 @@
 //
 // Copyright © 2020, 2021 Anticrm Platform Contributors.
-// Copyright © 2021 Hardcore Engineering Inc.
+// Copyright © 2021, 2023 Hardcore Engineering Inc.
 //
 // Licensed under the Eclipse Public License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License. You may
@@ -22,6 +22,7 @@ import { getResource, setMetadata } from '@hcengineering/platform'
 import preference from '@hcengineering/preference'
 import { closeClient, getClient } from '@hcengineering/presentation'
 import {
+  AnySvelteComponent,
   closePanel,
   fetchMetadataLocalStorage,
   getCurrentLocation,
@@ -204,4 +205,14 @@ export function signOut (): void {
   setMetadataLocalStorage(login.metadata.LoginEmail, null)
   void closeClient()
   navigate({ path: [loginId] })
+}
+
+export async function getSpacePresenter (
+  client: Client,
+  _class: Ref<Class<Doc>>
+): Promise<AnySvelteComponent | undefined> {
+  const value = client.getHierarchy().classHierarchyMixin(_class, view.mixin.SpacePresenter)
+  if (value?.presenter !== undefined) {
+    return await getResource(value.presenter)
+  }
 }


### PR DESCRIPTION
# Contribution checklist

## Brief description
Follow up for space starring fix. We should use the same space presenter for both starred and not starred spaces. Otherwise, starred spaces will be unusable.

Before:
<img width="900" alt="Screenshot 2023-09-19 at 23 26 05" src="https://github.com/hcengineering/anticrm/assets/5876715/eb57f14f-e14a-49d0-add8-a12d552f574d">
After:
<img width="900" alt="Screenshot 2023-09-19 at 23 26 23" src="https://github.com/hcengineering/anticrm/assets/5876715/a9a70842-8bbe-4072-8af7-105a54ae3ef0">


## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [ ] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues
