### PR TITLE
Background Dimming for Clarity

### DIFF
--- a/packages/ui/src/popups.ts
+++ b/packages/ui/src/popups.ts
@@ -33,7 +33,7 @@ export interface PopupResult {
 
 export const popupstore = writable<CompAndProps[]>([])
 
-export function updatePopup (id: string, props: Partial<CompAndProps>): void {
+export function updatePopup(id: string, props: Partial<CompAndProps>): void {
   popupstore.update((popups) => {
     const popupIndex = popups.findIndex((p) => p.id === id)
     if (popupIndex !== -1) {
@@ -43,14 +43,14 @@ export function updatePopup (id: string, props: Partial<CompAndProps>): void {
   })
 }
 
-function addPopup (props: CompAndProps): void {
+function addPopup(props: CompAndProps): void {
   popupstore.update((popups) => {
     popups.push(props)
     return popups
   })
 }
 let popupId: number = 0
-export function showPopup (
+export function showPopup(
   component: AnySvelteComponent | AnyComponent | ComponentType,
   props: any,
   element?: PopupAlignment,
@@ -87,7 +87,7 @@ export function showPopup (
   }
 }
 
-export function closePopup (category?: string): void {
+export function closePopup(category?: string): void {
   popupstore.update((popups) => {
     if (category !== undefined) {
       popups = popups.filter((p) => p.options.category !== category)
@@ -105,7 +105,7 @@ export function closePopup (category?: string): void {
  *
  * return boolean to show or not modal overlay.
  */
-export function fitPopupPositionedElement (
+export function fitPopupPositionedElement(
   modalHTML: HTMLElement,
   alignment: PopupPositionElement,
   newProps: Record<string, string | number>
@@ -181,7 +181,7 @@ export function fitPopupPositionedElement (
  *
  * return boolean to show or not modal overlay.
  */
-export function fitPopupElement (
+export function fitPopupElement(
   modalHTML: HTMLElement,
   device: DeviceOptions,
   element?: PopupAlignment,
@@ -345,11 +345,11 @@ export function fitPopupElement (
   return { props: newProps, showOverlay: show, direction: '' }
 }
 
-export function eventToHTMLElement (evt: MouseEvent): HTMLElement {
+export function eventToHTMLElement(evt: MouseEvent): HTMLElement {
   return evt.target as HTMLElement
 }
 
-export function getEventPopupPositionElement (
+export function getEventPopupPositionElement(
   e?: Event,
   position?: { v: VerticalAlignment, h: HorizontalAlignment }
 ): PopupAlignment | undefined {
@@ -360,7 +360,7 @@ export function getEventPopupPositionElement (
   return getPopupPositionElement(target, position)
 }
 
-export function getPopupPositionElement (
+export function getPopupPositionElement(
   el: HTMLElement | undefined,
   position?: { v: VerticalAlignment, h: HorizontalAlignment }
 ): PopupAlignment | undefined {
@@ -374,7 +374,7 @@ export function getPopupPositionElement (
 
   return undefined
 }
-export function getEventPositionElement (evt: MouseEvent): PopupAlignment | undefined {
+export function getEventPositionElement(evt: MouseEvent): PopupAlignment | undefined {
   const rect = DOMRect.fromRect({ width: 1, height: 1, x: evt.clientX, y: evt.clientY })
   return {
     getBoundingClientRect: () => rect

--- a/packages/ui/src/popups.ts
+++ b/packages/ui/src/popups.ts
@@ -171,7 +171,7 @@ export function fitPopupPositionedElement(
       direction += '|center'
     }
   }
-  return { props: newProps, showOverlay: false, direction }
+  return { props: newProps, showOverlay: true, direction }
 }
 
 /**
@@ -192,7 +192,6 @@ export function fitPopupElement(
   let show = true
   const newProps: Record<string, string | number> = {}
   if (element != null) {
-    show = false
     newProps.left = newProps.right = newProps.top = newProps.bottom = ''
     newProps.maxHeight = newProps.height = ''
     newProps.maxWidth = newProps.width = newProps.minWidth = ''
@@ -293,7 +292,6 @@ export function fitPopupElement(
       newProps.right = '0'
       // newProps.width = '100vw'
       newProps.height = '100vh'
-      show = false
     } else if (element === 'full' && contentPanel !== undefined) {
       const rect = contentPanel.getBoundingClientRect()
       newProps.top = `${rect.top + 4}px`

--- a/packages/ui/src/popups.ts
+++ b/packages/ui/src/popups.ts
@@ -33,7 +33,7 @@ export interface PopupResult {
 
 export const popupstore = writable<CompAndProps[]>([])
 
-export function updatePopup(id: string, props: Partial<CompAndProps>): void {
+export function updatePopup (id: string, props: Partial<CompAndProps>): void {
   popupstore.update((popups) => {
     const popupIndex = popups.findIndex((p) => p.id === id)
     if (popupIndex !== -1) {
@@ -43,14 +43,14 @@ export function updatePopup(id: string, props: Partial<CompAndProps>): void {
   })
 }
 
-function addPopup(props: CompAndProps): void {
+function addPopup (props: CompAndProps): void {
   popupstore.update((popups) => {
     popups.push(props)
     return popups
   })
 }
 let popupId: number = 0
-export function showPopup(
+export function showPopup (
   component: AnySvelteComponent | AnyComponent | ComponentType,
   props: any,
   element?: PopupAlignment,
@@ -87,7 +87,7 @@ export function showPopup(
   }
 }
 
-export function closePopup(category?: string): void {
+export function closePopup (category?: string): void {
   popupstore.update((popups) => {
     if (category !== undefined) {
       popups = popups.filter((p) => p.options.category !== category)
@@ -105,7 +105,7 @@ export function closePopup(category?: string): void {
  *
  * return boolean to show or not modal overlay.
  */
-export function fitPopupPositionedElement(
+export function fitPopupPositionedElement (
   modalHTML: HTMLElement,
   alignment: PopupPositionElement,
   newProps: Record<string, string | number>
@@ -181,7 +181,7 @@ export function fitPopupPositionedElement(
  *
  * return boolean to show or not modal overlay.
  */
-export function fitPopupElement(
+export function fitPopupElement (
   modalHTML: HTMLElement,
   device: DeviceOptions,
   element?: PopupAlignment,
@@ -343,11 +343,11 @@ export function fitPopupElement(
   return { props: newProps, showOverlay: show, direction: '' }
 }
 
-export function eventToHTMLElement(evt: MouseEvent): HTMLElement {
+export function eventToHTMLElement (evt: MouseEvent): HTMLElement {
   return evt.target as HTMLElement
 }
 
-export function getEventPopupPositionElement(
+export function getEventPopupPositionElement (
   e?: Event,
   position?: { v: VerticalAlignment, h: HorizontalAlignment }
 ): PopupAlignment | undefined {
@@ -358,7 +358,7 @@ export function getEventPopupPositionElement(
   return getPopupPositionElement(target, position)
 }
 
-export function getPopupPositionElement(
+export function getPopupPositionElement (
   el: HTMLElement | undefined,
   position?: { v: VerticalAlignment, h: HorizontalAlignment }
 ): PopupAlignment | undefined {
@@ -372,7 +372,7 @@ export function getPopupPositionElement(
 
   return undefined
 }
-export function getEventPositionElement(evt: MouseEvent): PopupAlignment | undefined {
+export function getEventPositionElement (evt: MouseEvent): PopupAlignment | undefined {
   const rect = DOMRect.fromRect({ width: 1, height: 1, x: evt.clientX, y: evt.clientY })
   return {
     getBoundingClientRect: () => rect

--- a/plugins/calendar-resources/src/components/CreateReminder.svelte
+++ b/plugins/calendar-resources/src/components/CreateReminder.svelte
@@ -37,7 +37,7 @@
   const client = getClient()
 
   export function canClose (): boolean {
-    return _title !== undefined && _title.trim().length === 0 && participants.length === 0
+    return value == null
   }
 
   async function saveReminder () {

--- a/plugins/inventory-resources/src/components/CreateCategory.svelte
+++ b/plugins/inventory-resources/src/components/CreateCategory.svelte
@@ -34,7 +34,7 @@
   const inventoryId = generateId() as Ref<Category>
 
   export function canClose (): boolean {
-    return name !== ''
+    return name === ''
   }
 
   async function create () {


### PR DESCRIPTION
# Contribution checklist

## Brief description

## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [x] - Does it well tested?
* [x] - Tested for Chrome.
* [x] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues
We have an unselected popup on the page that blocks any buttons and is covered 
by a very small area on the screen - the close icon; 



<img width="1147" alt="problem" src="https://github.com/hcengineering/anticrm/assets/12935413/cfc3381c-6409-4a50-997e-418921b87571">



This is a little confusing, especially when you get distracted and forget that you opened the popup.

I don’t see a problem in giving an overlay to all popups since there is no multiwindow mode.
Now all popups have the same overlay, and in several I have fixed the closing by clicking on it.



<img width="1146" alt="solution" src="https://github.com/hcengineering/anticrm/assets/12935413/54631269-99cf-46ab-846d-62932e33215e">



In the future, it would be nice to package the `canClose` method
of popups in [packages/ui/src/components/PopupInstance.svelte](https://github.com/hcengineering/anticrm/blob/main/packages/ui/src/components/PopupInstance.svelte)


