### PR TITLE
TSK-1660 Get rid of ListSelectionProvider.Pop

### DIFF
--- a/plugins/tracker-resources/src/components/issues/edit/SubIssueSelector.svelte
+++ b/plugins/tracker-resources/src/components/issues/edit/SubIssueSelector.svelte
@@ -28,11 +28,11 @@
     themeStore,
     tooltip
   } from '@hcengineering/ui'
-  import { ListSelectionProvider, statusStore } from '@hcengineering/view-resources'
+  import { statusStore } from '@hcengineering/view-resources'
   import { getIssueId, issueLinkFragmentProvider } from '../../../issues'
   import tracker from '../../../plugin'
-  import IssueStatusIcon from '../IssueStatusIcon.svelte'
   import { listIssueStatusOrder } from '../../../utils'
+  import IssueStatusIcon from '../IssueStatusIcon.svelte'
 
   export let issue: WithLookup<Issue>
 
@@ -58,7 +58,6 @@
   function openParentIssue () {
     if (parentIssue) {
       closeTooltip()
-      ListSelectionProvider.Pop()
       openIssue(parentIssue)
     }
   }

--- a/plugins/tracker-resources/src/components/issues/edit/SubIssuesSelector.svelte
+++ b/plugins/tracker-resources/src/components/issues/edit/SubIssuesSelector.svelte
@@ -20,7 +20,7 @@
   import { statusStore } from '@hcengineering/view-resources'
   import { getIssueId } from '../../../issues'
   import tracker from '../../../plugin'
-  import { listIssueStatusOrder, subIssueListProvider } from '../../../utils'
+  import { listIssueStatusOrder } from '../../../utils'
   import IssueStatusIcon from '../IssueStatusIcon.svelte'
 
   export let value: WithLookup<Issue>
@@ -95,7 +95,6 @@
 
   function openIssue (target: Ref<Issue>) {
     if (target !== value._id) {
-      subIssueListProvider(subIssues, target)
       showPanel(tracker.component.EditIssue, target, value._class, 'content')
     }
   }


### PR DESCRIPTION
# Contribution checklist

## Brief description

This PR fixes bug with destroying wrong selection provider when closing a child issue.

This approach is buggy and does not properly work now:
1. it is used in kanban only for up/down navigation by subissues, in list we use different approach
2. Up/down navigation uses the "current" provider that is the latest created provider, not necessary this one, it breaks when opened issue has subissues
3. ListSelectionProvider.Pop removes the top provider, that is not necessary the created one. We pop it in different place so cannot be sure what the proper provider has been destroyed.



## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [ ] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues
