### PR TITLE
Fix Escape key propagation from `MentionList`/`MentionPopup`

### DIFF
--- a/packages/text-editor/src/components/extensions.ts
+++ b/packages/text-editor/src/components/extensions.ts
@@ -22,6 +22,7 @@ import MentionList from './MentionList.svelte'
 import { NodeUuidExtension } from './extension/nodeUuid'
 import { SvelteRenderer } from './node-view'
 import { CodemarkExtension } from './extension/codemark'
+import type { SuggestionKeyDownProps, SuggestionProps } from './extension/suggestion'
 
 export const tableExtensions = [
   Table.configure({
@@ -157,14 +158,14 @@ export const completionConfig: Partial<CompletionOptions> = {
     class: 'reference'
   },
   suggestion: {
-    items: async (query: { query: string }) => {
+    items: async () => {
       return []
     },
     render: () => {
       let component: any
 
       return {
-        onStart: (props: any) => {
+        onStart: (props: SuggestionProps) => {
           component = new SvelteRenderer(MentionList, {
             element: document.body,
             props: {
@@ -175,10 +176,13 @@ export const completionConfig: Partial<CompletionOptions> = {
             }
           })
         },
-        onUpdate (props: any) {
+        onUpdate (props: SuggestionProps) {
           component.updateProps(props)
         },
-        onKeyDown (props: any) {
+        onKeyDown (props: SuggestionKeyDownProps) {
+          if (props.event.key === 'Escape') {
+            props.event.stopPropagation()
+          }
           return component.onKeyDown(props)
         },
         onExit () {


### PR DESCRIPTION
# Contribution checklist

## Brief description

Fixes Escape propagation so that Escape closes currently open Mentions Popup, but doesn't close any parent popups. Consider a New Issue popup, for instance:

<img width="797" alt="Screenshot 2023-11-22 at 00 13 01" src="https://github.com/hcengineering/anticrm/assets/222219/1bc03304-c749-454e-93ac-40993ed950dd">

## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [x] - Tested for Chrome.
* [X] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [x] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [x] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

* Probably fixes https://github.com/hcengineering/anticrm/issues/3926 (assigned to @mixerka)
