### PR TITLE
Qfix: fix asterisk usage in forms

### DIFF
--- a/packages/text-editor/src/components/StyledTextArea.svelte
+++ b/packages/text-editor/src/components/StyledTextArea.svelte
@@ -81,7 +81,7 @@
   {#if label}
     <div>
       <span class="label"><Label {label} /></span>
-      {#if required}<span class="error-color">&ast</span>{/if}
+      {#if required}<span class="error-color">&ast;</span>{/if}
     </div>
   {/if}
   <StyledTextEditor

--- a/packages/ui/src/components/EditBox.svelte
+++ b/packages/ui/src/components/EditBox.svelte
@@ -150,7 +150,7 @@
   {#if label}
     <div class="mb-1 text-sm font-medium caption-color select-text">
       <Label {label} />
-      {#if required}<span class="error-color">&ast</span>{/if}
+      {#if required}<span class="error-color">&ast;</span>{/if}
     </div>
   {/if}
   <div class="{kind} flex-row-center clear-mins" class:focusable class:disabled class:w-full={fullSize}>


### PR DESCRIPTION
# Contribution checklist

## Brief description
<img width="904" alt="Screenshot 2023-11-27 at 23 36 09" src="https://github.com/hcengineering/anticrm/assets/38680236/a109713d-d4e0-4259-87ff-7288595c2b6a">


Fix usage asterisk symbol in forms `text-editor/src/components/StyledTextArea.svelte` and `ui/src/components/EditBox.svelte`
## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [x] - Does a local formatting is applied (rush format)
* [x] - Does a local svele-check is applied (rush svelte check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [x] - Tested for Chrome.
* [x] - Tested for Safari.
* [x] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [x] - Rebase your branch onto master and upstream branch
* [x] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues

## Contributor requirements

* [x] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [x] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
