### PR TITLE
Added radio button marker visibility customization in disabled state

### DIFF
--- a/packages/theme/styles/components.scss
+++ b/packages/theme/styles/components.scss
@@ -431,6 +431,15 @@
       }
     }
   }
+  &.marker-visible.checked {
+    .marker {
+      background-color: var(--primary-button-disabled);
+
+      &::after {
+        content: '';
+      }
+    }
+  }
   &.disabled {
     cursor: not-allowed;
 

--- a/packages/ui/src/components/RadioButton.svelte
+++ b/packages/ui/src/components/RadioButton.svelte
@@ -29,6 +29,7 @@
   export let action: () => void = () => {}
   export let gap: 'large' | 'small' | 'medium' | 'none' = 'none'
   export let labelGap: 'large' | 'medium' = 'medium'
+  export let isMarkerVisible: boolean = false
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -38,6 +39,7 @@
   class:disabled
   class:checked={group === value}
   tabindex="-1"
+  class:marker-visible={isMarkerVisible}
   on:click={() => {
     if (!disabled && group !== value) action()
   }}


### PR DESCRIPTION
# Contribution checklist

## Brief description
Added a possibility to display selected radio button in `disabled` state

## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [ ] - Does a local formatting is applied (rush format)
* [ ] - Does a local svele-check is applied (rush svelte check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [x] - Does the translations are up to date?
* [x] - Does it well tested?
* [x] - Tested for Chrome.
* [ ] - Tested for Safari.
* [x] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [x] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues

## Contributor requirements

* [x] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [x] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
