### PR TITLE
UBERF-4526: Elastic bulk error on re-indexing

### DIFF
--- a/server/core/src/indexer/field.ts
+++ b/server/core/src/indexer/field.ts
@@ -37,7 +37,8 @@ import {
   getFullTextIndexableAttributes,
   getFullTextContext,
   isFullTextAttribute,
-  loadIndexStageStage
+  loadIndexStageStage,
+  getCustomAttrKeys
 } from './utils'
 
 /**
@@ -146,7 +147,15 @@ export class IndexedFieldStage implements FullTextPipelineStage {
             }
           }
 
+          const customAttrValues: any = []
           for (const [, v] of Object.entries(content)) {
+            if (v.attr.isCustom === true && v.value !== '' && v.value !== undefined) {
+              // No need to put localized text as attributes. We do not use it at all
+              // Just put all content for custom attribute inside one custom field
+              customAttrValues.push([v.attr.label, v.value])
+              continue
+            }
+
             // Check for content changes and collect update
             const dKey = docKey(v.attr.name, { _class: v.attr.attributeOf })
             const dUKey = docUpdKey(v.attr.name, { _class: v.attr.attributeOf })
@@ -159,6 +168,16 @@ export class IndexedFieldStage implements FullTextPipelineStage {
               }
             }
           }
+
+          const { customAttrKey, customAttrUKey } = getCustomAttrKeys()
+          if (
+            (docState.attributes[customAttrKey] !== undefined || customAttrValues.length > 0) &&
+            !deepEqual(docState.attributes[customAttrKey], customAttrValues)
+          ) {
+            changes++
+            ;(docUpdate as any)[customAttrUKey] = customAttrValues
+          }
+
           if (docState.attachedTo != null && changes > 0) {
             const ctx = getFullTextContext(pipeline.hierarchy, objClass)
             if (ctx.parentPropagate ?? true) {

--- a/server/core/src/indexer/field.ts
+++ b/server/core/src/indexer/field.ts
@@ -152,7 +152,7 @@ export class IndexedFieldStage implements FullTextPipelineStage {
             if (v.attr.isCustom === true && v.value !== '' && v.value !== undefined) {
               // No need to put localized text as attributes. We do not use it at all
               // Just put all content for custom attribute inside one custom field
-              customAttrValues.push([v.attr.label, v.value])
+              customAttrValues.push({ label: v.attr.label, value: v.value })
               continue
             }
 

--- a/server/core/src/indexer/fulltextPush.ts
+++ b/server/core/src/indexer/fulltextPush.ts
@@ -40,7 +40,14 @@ import {
   FullTextPipelineStage,
   fullTextPushStageId
 } from './types'
-import { collectPropagate, collectPropagateClasses, docKey, getFullTextContext, IndexKeyOptions, isCustomAttr } from './utils'
+import {
+  collectPropagate,
+  collectPropagateClasses,
+  docKey,
+  getFullTextContext,
+  IndexKeyOptions,
+  isCustomAttr
+} from './utils'
 import { updateDocWithPresenter } from '../mapper'
 
 /**

--- a/server/core/src/indexer/fulltextPush.ts
+++ b/server/core/src/indexer/fulltextPush.ts
@@ -40,7 +40,7 @@ import {
   FullTextPipelineStage,
   fullTextPushStageId
 } from './types'
-import { collectPropagate, collectPropagateClasses, docKey, getFullTextContext, IndexKeyOptions } from './utils'
+import { collectPropagate, collectPropagateClasses, docKey, getFullTextContext, IndexKeyOptions, isCustomAttr } from './utils'
 import { updateDocWithPresenter } from '../mapper'
 
 /**
@@ -283,7 +283,7 @@ function updateDoc2Elastic (
 
     docId = docIdOverride ?? docId
     if (docId === undefined) {
-      if (typeof vv !== 'object') {
+      if (typeof vv !== 'object' || isCustomAttr(k)) {
         doc[k] = vv
       }
       continue

--- a/server/core/src/indexer/summary.ts
+++ b/server/core/src/indexer/summary.ts
@@ -33,7 +33,13 @@ import { translate } from '@hcengineering/platform'
 import { convert } from 'html-to-text'
 import { IndexedDoc } from '../types'
 import { contentStageId, DocUpdateHandler, fieldStateId, FullTextPipeline, FullTextPipelineStage } from './types'
-import { collectPropagate, collectPropagateClasses, getFullTextContext, loadIndexStageStage, isCustomAttr } from './utils'
+import {
+  collectPropagate,
+  collectPropagateClasses,
+  getFullTextContext,
+  loadIndexStageStage,
+  isCustomAttr
+} from './utils'
 
 /**
  * @public
@@ -241,9 +247,11 @@ export async function extractIndexedValues (
       }
 
       if (isCustomAttr(attr)) {
-        const str = v.map((pair: string[]) => {
-          return `${pair[0]} is ${pair[1]}`
-        }).join(' ')
+        const str = v
+          .map((pair: string[]) => {
+            return `${pair[0]} is ${pair[1]}`
+          })
+          .join(' ')
         const cl = doc.objectClass
         attributes[cl] = { ...attributes[cl], [k]: str }
       }

--- a/server/core/src/indexer/summary.ts
+++ b/server/core/src/indexer/summary.ts
@@ -33,7 +33,7 @@ import { translate } from '@hcengineering/platform'
 import { convert } from 'html-to-text'
 import { IndexedDoc } from '../types'
 import { contentStageId, DocUpdateHandler, fieldStateId, FullTextPipeline, FullTextPipelineStage } from './types'
-import { collectPropagate, collectPropagateClasses, getFullTextContext, loadIndexStageStage } from './utils'
+import { collectPropagate, collectPropagateClasses, getFullTextContext, loadIndexStageStage, isCustomAttr } from './utils'
 
 /**
  * @public
@@ -238,6 +238,14 @@ export async function extractIndexedValues (
       }
       if (sourceContent.length === 0) {
         continue
+      }
+
+      if (isCustomAttr(attr)) {
+        const str = v.map((pair: string[]) => {
+          return `${pair[0]} is ${pair[1]}`
+        }).join(' ')
+        const cl = doc.objectClass
+        attributes[cl] = { ...attributes[cl], [k]: str }
       }
 
       if (_class === undefined) {

--- a/server/core/src/indexer/summary.ts
+++ b/server/core/src/indexer/summary.ts
@@ -248,7 +248,7 @@ export async function extractIndexedValues (
 
       if (isCustomAttr(attr)) {
         const str = v
-          .map((pair: { label: string, value: string } ) => {
+          .map((pair: { label: string, value: string }) => {
             return `${pair.label} is ${pair.value}`
           })
           .join(' ')

--- a/server/core/src/indexer/summary.ts
+++ b/server/core/src/indexer/summary.ts
@@ -248,8 +248,8 @@ export async function extractIndexedValues (
 
       if (isCustomAttr(attr)) {
         const str = v
-          .map((pair: string[]) => {
-            return `${pair[0]} is ${pair[1]}`
+          .map((pair: { label: string, value: string } ) => {
+            return `${pair.label} is ${pair.value}`
           })
           .join(' ')
         const cl = doc.objectClass

--- a/server/core/src/indexer/types.ts
+++ b/server/core/src/indexer/types.ts
@@ -102,7 +102,7 @@ export const contentStageId = 'cnt-v2b'
 /**
  * @public
  */
-export const fieldStateId = 'fld-v9'
+export const fieldStateId = 'fld-v10'
 
 /**
  * @public

--- a/server/core/src/indexer/utils.ts
+++ b/server/core/src/indexer/utils.ts
@@ -309,8 +309,8 @@ export function collectPropagateClasses (pipeline: FullTextPipeline, objectClass
   return Array.from(propagate.values())
 }
 
-const CUSTOM_ATTR_KEY = '_custom_attr'
-const CUSTOM_ATTR_UPDATE_KEY = 'attributes._custom_attr'
+const CUSTOM_ATTR_KEY = 'customAttributes'
+const CUSTOM_ATTR_UPDATE_KEY = 'attributes.customAttributes'
 
 /**
  * @public

--- a/server/core/src/indexer/utils.ts
+++ b/server/core/src/indexer/utils.ts
@@ -315,13 +315,13 @@ const CUSTOM_ATTR_UPDATE_KEY = 'attributes._custom_attr'
 /**
  * @public
  */
-export function getCustomAttrKeys (): { customAttrKey: string,customAttrUKey: string } {
+export function getCustomAttrKeys (): { customAttrKey: string, customAttrUKey: string } {
   return { customAttrKey: CUSTOM_ATTR_KEY, customAttrUKey: CUSTOM_ATTR_UPDATE_KEY }
 }
 
 /**
  * @public
  */
-export function isCustomAttr(attr: string): boolean {
+export function isCustomAttr (attr: string): boolean {
   return attr === CUSTOM_ATTR_KEY
 }

--- a/server/core/src/indexer/utils.ts
+++ b/server/core/src/indexer/utils.ts
@@ -308,3 +308,20 @@ export function collectPropagateClasses (pipeline: FullTextPipeline, objectClass
 
   return Array.from(propagate.values())
 }
+
+const CUSTOM_ATTR_KEY = '_custom_attr'
+const CUSTOM_ATTR_UPDATE_KEY = 'attributes._custom_attr'
+
+/**
+ * @public
+ */
+export function getCustomAttrKeys (): { customAttrKey: string,customAttrUKey: string } {
+  return { customAttrKey: CUSTOM_ATTR_KEY, customAttrUKey: CUSTOM_ATTR_UPDATE_KEY }
+}
+
+/**
+ * @public
+ */
+export function isCustomAttr(attr: string): boolean {
+  return attr === CUSTOM_ATTR_KEY
+}

--- a/server/elastic/src/adapter.ts
+++ b/server/elastic/src/adapter.ts
@@ -416,7 +416,10 @@ class ElasticAdapter implements FullTextAdapter {
         const errorIds = new Set(errors.map((it: any) => it.index._id))
         const erroDocs = docs.filter((it) => errorIds.has(it.id))
         // Collect only errors
-        const errs = Array.from(errors.map((it: any) => it.index.error.reason as string)).join('\n')
+        const errs = Array.from(errors.map((it: any) => {
+          return `${it.index.error.reason}: ${it.index.error.caused_by?.reason}`
+        })).join('\n')
+
         console.error(`Failed to process bulk request: ${errs} ${JSON.stringify(erroDocs)}`)
       }
     }

--- a/server/elastic/src/adapter.ts
+++ b/server/elastic/src/adapter.ts
@@ -416,9 +416,11 @@ class ElasticAdapter implements FullTextAdapter {
         const errorIds = new Set(errors.map((it: any) => it.index._id))
         const erroDocs = docs.filter((it) => errorIds.has(it.id))
         // Collect only errors
-        const errs = Array.from(errors.map((it: any) => {
-          return `${it.index.error.reason}: ${it.index.error.caused_by?.reason}`
-        })).join('\n')
+        const errs = Array.from(
+          errors.map((it: any) => {
+            return `${it.index.error.reason}: ${it.index.error.caused_by?.reason}`
+          })
+        ).join('\n')
 
         console.error(`Failed to process bulk request: ${errs} ${JSON.stringify(erroDocs)}`)
       }


### PR DESCRIPTION
# Contribution checklist

## Brief description

The error we have is "Limit of total fields [1000] has been exceeded while adding new fields [1]". Added this text to error log to make such errors visible.

This is happens in index with a lot of custom fields and is about the amount off custom field names we have overall in one elastic index among all the elastic documents. 

Although it is possible just to increase this limit, I would rather prefer not to do that due to performance risks. 
And because we do not use actual field name in searching or filtering I suggest to move from field names like `638611f18894c91979399ef3%Источник_6386125d8894c91979399eff` to have one custom attribute field and have all custom fields there as nested label-value objects. 

## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [x] - Does a local formatting is applied (rush format)
* [x] - Does a local svele-check is applied (rush svelte check)
* [x] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [x] - Does it well tested?
* [x] - Tested for Chrome.
* [x] - Tested for Safari.
* [x] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [x] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues

## Contributor requirements

* [x] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [x] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
