### PR TITLE
EZQMS-435 Hide text editor border

### DIFF
--- a/packages/text-editor/src/components/StyledTextEditor.svelte
+++ b/packages/text-editor/src/components/StyledTextEditor.svelte
@@ -270,12 +270,8 @@
     &.focusable {
       border: 0.0625rem solid transparent;
       border-radius: 0.375rem;
-      margin: -0.25rem -0.5rem;
-      padding: 0.25rem 0.5rem;
-
-      &:focus-within {
-        border-color: var(--primary-edit-border-color);
-      }
+      margin: -0.25rem -1.25rem;
+      padding: 0.25rem 1.25rem;
     }
   }
 </style>


### PR DESCRIPTION
# Contribution checklist

## Brief description

Hide blue border in text editor. This border overlaps table decorations inside editor which does not look good. It is used in this place only so we can remove it to make consistent with other places. Discussed with Marina and Alex.

## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [ ] - Does a local formatting is applied (rush format)
* [ ] - Does a local svele-check is applied (rush svelte check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [ ] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues

## Contributor requirements

* [ ] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [ ] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
