### PR TITLE
UBERF-4304 UBER-1135 Fix nodeUuid extension exception when clicking below document

### DIFF
--- a/packages/text-editor/src/components/extension/nodeUuid.ts
+++ b/packages/text-editor/src/components/extension/nodeUuid.ts
@@ -115,8 +115,10 @@ export const NodeUuidExtension = Mark.create<NodeUuidOptions, NodeUuidStorage>({
         key: new PluginKey('handle-node-uuid-click-plugin'),
         props: {
           handleClick (view, pos) {
+            const from = Math.max(0, pos - 1)
+            const to = Math.min(view.state.doc.content.size, pos + 1)
             const markRanges =
-              getMarksBetween(Math.max(0, pos - 1), pos + 1, view.state.doc)?.filter(
+              getMarksBetween(from, to, view.state.doc)?.filter(
                 (markRange) => markRange.mark.type.name === NAME && markRange.from <= pos && markRange.to >= pos
               ) ?? []
             let nodeUuid: string | null = null


### PR DESCRIPTION
# Contribution checklist

## Brief description

Required for https://github.com/hcengineering/uberflow/pull/439

When clicking outside of the document, position is set after the end of the content, so we have to ensure we don't go out of document bounds.

## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [ ] - Does a local formatting is applied (rush format)
* [ ] - Does a local svele-check is applied (rush svelte check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [ ] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues

## Contributor requirements

* [ ] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [ ] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
