### PR TITLE
Radio button marker is always displayed in disabled state

### DIFF
--- a/packages/theme/styles/components.scss
+++ b/packages/theme/styles/components.scss
@@ -431,27 +431,17 @@
       }
     }
   }
-  &.marker-visible.checked {
-    .marker {
-      background-color: var(--primary-button-disabled);
-
-      &::after {
-        content: '';
-      }
-    }
-  }
   &.disabled {
     cursor: not-allowed;
 
-    .marker {
-      background-color: var(--primary-button-disabled);
-      border-color: transparent;
-    }
-
     &.checked {
-      marker::after {
-        content: '';
-        opacity: 0.4;
+      .marker {
+        background-color: var(--primary-button-disabled);
+
+        &::after {
+          content: '';
+          background-color: var(--primary-button-disabled-color);
+        }
       }
     }
 

--- a/packages/ui/src/components/RadioButton.svelte
+++ b/packages/ui/src/components/RadioButton.svelte
@@ -29,7 +29,6 @@
   export let action: () => void = () => {}
   export let gap: 'large' | 'small' | 'medium' | 'none' = 'none'
   export let labelGap: 'large' | 'medium' = 'medium'
-  export let isMarkerVisible: boolean = false
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -39,7 +38,6 @@
   class:disabled
   class:checked={group === value}
   tabindex="-1"
-  class:marker-visible={isMarkerVisible}
   on:click={() => {
     if (!disabled && group !== value) action()
   }}


### PR DESCRIPTION
# Contribution checklist

## Brief description
Radio button marker is always displayed in disabled state if selected
![radio-btn-disabled](https://github.com/hcengineering/platform/assets/94829167/1d45b2df-d9f9-4b8b-9119-87fd2e71cb2e)

## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [x] - Does a local formatting is applied (rush format)
* [ ] - Does a local svele-check is applied (rush svelte check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [x] - Does it well tested?
* [x] - Tested for Chrome.
* [ ] - Tested for Safari.
* [x] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [x] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues

## Contributor requirements

* [x] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [x] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
