### PR TITLE
EZQMS-457: Added optional ModeSelector to SpecialView

### DIFF
--- a/plugins/workbench-resources/src/components/SpecialView.svelte
+++ b/plugins/workbench-resources/src/components/SpecialView.svelte
@@ -15,7 +15,18 @@
 <script lang="ts">
   import { Class, Doc, DocumentQuery, Ref, Space, WithLookup } from '@hcengineering/core'
   import { IntlString } from '@hcengineering/platform'
-  import { AnyComponent, Button, Component, IconAdd, Label, Loading, SearchEdit, showPopup } from '@hcengineering/ui'
+  import {
+    AnyComponent,
+    Button,
+    Component,
+    IconAdd,
+    IModeSelector,
+    Label,
+    Loading,
+    ModeSelector,
+    SearchEdit,
+    showPopup
+  } from '@hcengineering/ui'
   import { ViewOptions, Viewlet, ViewletDescriptor, ViewletPreference } from '@hcengineering/view'
   import { FilterBar, FilterButton, ViewletSelector, ViewletSettingButton } from '@hcengineering/view-resources'
 
@@ -29,6 +40,7 @@
   export let isCreationDisabled = false
   export let descriptors: Array<Ref<ViewletDescriptor>> | undefined = undefined
   export let baseQuery: DocumentQuery<Doc> | undefined = undefined
+  export let modes: IModeSelector | undefined = undefined
 
   let search = ''
   let viewlet: WithLookup<Viewlet> | undefined
@@ -41,15 +53,18 @@
   $: searchQuery = search === '' ? query : { ...query, $search: search }
   $: resultQuery = searchQuery
 
-  function showCreateDialog () {
+  function showCreateDialog (): void {
     if (createComponent === undefined) return
     showPopup(createComponent, createComponentProps, 'top')
   }
 </script>
 
-<div class="ac-header full divide caption-height">
+<div class="ac-header full divide caption-height" class:header-with-mode-selector={modes !== undefined}>
   <div class="ac-header__wrap-title mr-3">
     <span class="ac-header__title"><Label {label} /></span>
+    {#if modes !== undefined}
+      <ModeSelector props={modes} />
+    {/if}
   </div>
 
   <div class="ac-header-full medium-gap mb-1">


### PR DESCRIPTION
# Contribution checklist

## Brief description

We have a pretty common UI/UX pattern where browser/table/list view has mode tabs in the header. Added support for this in SpecialView

<img width="633" alt="Screenshot 2024-01-18 at 12 07 59" src="https://github.com/hcengineering/platform/assets/222219/64ea5fff-fbd8-404e-accd-bd4258b1a41a">

## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [ ] - Does a local formatting is applied (rush format)
* [ ] - Does a local svele-check is applied (rush svelte-check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [ ] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues

## Contributor requirements

* [x] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [x] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
