### PR TITLE
UBERF-5044 Pass workspace name as part of collaborative document name

### DIFF
--- a/packages/collaborator-client/src/utils.ts
+++ b/packages/collaborator-client/src/utils.ts
@@ -15,10 +15,10 @@
 
 import { Doc, Domain, Ref } from '@hcengineering/core'
 
-export function minioDocumentId (docId: Ref<Doc>, attribute?: string): string {
-  return attribute !== undefined ? `minio://${docId}%${attribute}` : `minio://${docId}`
+export function minioDocumentId (workspace: string, docId: Ref<Doc>, attribute?: string): string {
+  return attribute !== undefined ? `minio://${workspace}/${docId}%${attribute}` : `minio://${workspace}/${docId}`
 }
 
-export function mongodbDocumentId (domain: Domain, docId: Ref<Doc>, attribute: string): string {
-  return `mongodb://${domain}/${docId}/${attribute}`
+export function mongodbDocumentId (workspace: string, domain: Domain, docId: Ref<Doc>, attribute: string): string {
+  return `mongodb://${workspace}/${domain}/${docId}/${attribute}`
 }

--- a/packages/presentation/src/collaborator.ts
+++ b/packages/presentation/src/collaborator.ts
@@ -14,8 +14,9 @@
 //
 
 import { type CollaboratorClient, getClient as getCollaborator } from '@hcengineering/collaborator-client'
-import type { Class, Doc, Markup, Ref } from '@hcengineering/core'
+import { getWorkspaceId, type Class, type Doc, type Markup, type Ref } from '@hcengineering/core'
 import { getMetadata } from '@hcengineering/platform'
+import { getCurrentLocation } from '@hcengineering/ui'
 
 import { getClient } from '.'
 import presentation from './plugin'
@@ -24,11 +25,12 @@ import presentation from './plugin'
  * @public
  */
 export function getCollaboratorClient (): CollaboratorClient {
+  const workspaceId = getWorkspaceId(getCurrentLocation().path[1] ?? '')
   const hierarchy = getClient().getHierarchy()
   const token = getMetadata(presentation.metadata.Token) ?? ''
   const collaboratorURL = getMetadata(presentation.metadata.CollaboratorUrl) ?? ''
 
-  return getCollaborator(hierarchy, token, collaboratorURL)
+  return getCollaborator(hierarchy, workspaceId, token, collaboratorURL)
 }
 
 /**

--- a/packages/text-editor/src/components/CollaborativeTextEditor.svelte
+++ b/packages/text-editor/src/components/CollaborativeTextEditor.svelte
@@ -150,7 +150,7 @@
     return commandHandler
   }
 
-  export function takeSnapshot (snapshotId: string): void {
+  export function takeSnapshot (snapshotId: DocumentId): void {
     copyDocumentContent(documentId, snapshotId, { provider: remoteProvider }, initialContentId)
   }
 

--- a/packages/text-editor/src/components/CollaboratorEditor.svelte
+++ b/packages/text-editor/src/components/CollaboratorEditor.svelte
@@ -56,7 +56,7 @@
     return collaborativeEditor?.commands()
   }
 
-  export function takeSnapshot (snapshotId: string): void {
+  export function takeSnapshot (snapshotId: DocumentId): void {
     collaborativeEditor?.takeSnapshot(snapshotId)
   }
 

--- a/packages/text-editor/src/index.ts
+++ b/packages/text-editor/src/index.ts
@@ -69,6 +69,7 @@ export { ImageExtension, type ImageOptions } from './components/extension/imageE
 export { TodoItemExtension, TodoListExtension } from './components/extension/todo'
 
 export {
+  type DocumentId,
   TiptapCollabProvider,
   type TiptapCollabProviderConfiguration,
   createTiptapCollaborationData

--- a/packages/text-editor/src/provider/minio.ts
+++ b/packages/text-editor/src/provider/minio.ts
@@ -44,6 +44,10 @@ export class MinioProvider extends Observable<EVENTS> {
 
     if (name.startsWith('minio://')) {
       name = name.split('://', 2)[1]
+      if (name.includes('/')) {
+        // drop workspace part
+        name = name.split('/', 2)[1]
+      }
     }
 
     void fetchContent(doc, name).then(() => {

--- a/packages/text-editor/src/provider/tiptap.ts
+++ b/packages/text-editor/src/provider/tiptap.ts
@@ -15,7 +15,7 @@
 import { Doc as Ydoc } from 'yjs'
 import { HocuspocusProvider, type HocuspocusProviderConfiguration } from '@hocuspocus/provider'
 
-export type DocumentId = string
+export type DocumentId = string & { __documentId: true }
 
 export type TiptapCollabProviderConfiguration = HocuspocusProviderConfiguration &
 Required<Pick<HocuspocusProviderConfiguration, 'token'>> &

--- a/packages/text-editor/src/provider/utils.ts
+++ b/packages/text-editor/src/provider/utils.ts
@@ -15,18 +15,28 @@
 
 import type { Doc, Ref } from '@hcengineering/core'
 import { type KeyedAttribute, getClient } from '@hcengineering/presentation'
+import { getCurrentLocation } from '@hcengineering/ui'
 
 import { type DocumentId } from './tiptap'
 
+function getWorkspace (): string {
+  return getCurrentLocation().path[1] ?? ''
+}
+
 export function minioDocumentId (docId: Ref<Doc>, attr?: KeyedAttribute): DocumentId {
-  return attr !== undefined ? `minio://${docId}%${attr.key}` : `minio://${docId}`
+  const workspace = getWorkspace()
+  return attr !== undefined
+    ? (`minio://${workspace}/${docId}%${attr.key}` as DocumentId)
+    : (`minio://${workspace}/${docId}` as DocumentId)
 }
 
 export function platformDocumentId (docId: Ref<Doc>, attr: KeyedAttribute): DocumentId {
-  return `platform://${attr.attr.attributeOf}/${docId}/${attr.key}`
+  const workspace = getWorkspace()
+  return `platform://${workspace}/${attr.attr.attributeOf}/${docId}/${attr.key}` as DocumentId
 }
 
 export function mongodbDocumentId (docId: Ref<Doc>, attr: KeyedAttribute): DocumentId {
+  const workspace = getWorkspace()
   const domain = getClient().getHierarchy().getDomain(attr.attr.attributeOf)
-  return `mongodb://${domain}/${docId}/${attr.key}`
+  return `mongodb://${workspace}/${domain}/${docId}/${attr.key}` as DocumentId
 }

--- a/packages/text-editor/src/utils.ts
+++ b/packages/text-editor/src/utils.ts
@@ -88,7 +88,7 @@ export function copyDocumentField (
 
 export function copyDocumentContent (
   documentId: DocumentId,
-  snapshotId: string,
+  snapshotId: DocumentId,
   providerData: ProviderData,
   initialContentId?: DocumentId
 ): void {

--- a/server/collaborator/src/server.ts
+++ b/server/collaborator/src/server.ts
@@ -143,7 +143,24 @@ export async function start (
 
     async onAuthenticate (data: onAuthenticatePayload): Promise<Context> {
       ctx.measure('authenticate', 1)
-      return buildContext(data, controller)
+      const context = buildContext(data, controller)
+
+      // verify document name
+      let documentName = data.documentName
+      if (documentName.includes('://')) {
+        documentName = documentName.split('://', 2)[1]
+      }
+
+      if (documentName.includes('/')) {
+        const [workspace] = documentName.split('/', 2)
+        if (workspace !== context.workspaceId.name) {
+          throw new Error('documentName must include workspace')
+        }
+      } else {
+        throw new Error('documentName must include workspace')
+      }
+
+      return context
     },
 
     async onDestroy (data: onDestroyPayload): Promise<void> {


### PR DESCRIPTION
# Contribution checklist

## Brief description

Make workspace name a part of collaborative document name. Example for Minio: `ws-1/12345@description`

## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [ ] - Does a local formatting is applied (rush format)
* [ ] - Does a local svele-check is applied (rush svelte-check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [ ] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues

## Contributor requirements

* [ ] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [ ] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)