### PR TITLE
put comment input field on top when the newest activity is first

### DIFF
--- a/plugins/activity-resources/src/components/Activity.svelte
+++ b/plugins/activity-resources/src/components/Activity.svelte
@@ -85,7 +85,12 @@
     bind:isNewestFirst
   />
 </div>
-<div class="p-activity select-text" id={activity.string.Activity}>
+{#if isNewestFirst && showCommenInput}
+  <div class="ref-input newest-first">
+    <ActivityExtensionComponent kind="input" {extensions} props={{ object, boundary, focusIndex }} />
+  </div>
+{/if}
+<div class="p-activity select-text" id={activity.string.Activity} class:newest-first={isNewestFirst}>
   {#if filteredMessages.length}
     <Grid column={1} rowGap={0}>
       {#each filteredMessages as message}
@@ -102,8 +107,8 @@
     </Grid>
   {/if}
 </div>
-{#if showCommenInput}
-  <div class="ref-input">
+{#if showCommenInput && !isNewestFirst}
+  <div class="ref-input oldest-first">
     <ActivityExtensionComponent kind="input" {extensions} props={{ object, boundary, focusIndex }} />
   </div>
 {/if}
@@ -111,12 +116,22 @@
 <style lang="scss">
   .ref-input {
     flex-shrink: 0;
-    margin-top: 1.75rem;
-    padding-bottom: 2.5rem;
+    &.newest-first {
+      margin-bottom: 1rem;
+      padding-top: 1rem;
+    }
+    &.oldest-first {
+      padding-bottom: 2.5rem;
+    }
   }
 
   .p-activity {
-    margin-top: 1.75rem;
+    &.newest-first {
+      padding-bottom: 1.75rem;
+    }
+    &:not(.newest-first) {
+      margin: 1.75rem 0;
+    }
   }
 
   .invisible {


### PR DESCRIPTION
# Contribution checklist

## Brief description

![image](https://github.com/hcengineering/platform/assets/37306501/3f064b05-a6e1-4e8b-87b8-a053cbbfcb0d)

## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [x] - Does a local formatting is applied (rush format)
* [x] - Does a local svele-check is applied (rush svelte-check)
* [x] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [ ] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues

## Contributor requirements

* [ ] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [ ] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)