### PR TITLE
Fixes ugly looked image selection

### DIFF
--- a/packages/theme/styles/_text-editor.scss
+++ b/packages/theme/styles/_text-editor.scss
@@ -193,6 +193,12 @@
   }
 }
 
+@supports (selector(:has(.text-editor-image-container))) {
+  p:has(> .text-editor-image-container) {
+    user-select: none;
+  }
+}
+
 .text-editor-image-container {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
# Contribution checklist

## Brief description

Fixes #4466 The new pseudo-class :has is used because only latest version of Safari is affected by the error. If support is required in older browsers, I can add the css-has-pseudo plugin for postcss.

## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [ ] - Does a local formatting is applied (rush format)
* [ ] - Does a local svelte-check is applied (rush svelte-check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [ ] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Contributor requirements

* [ ] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [ ] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)