### PR TITLE
fix: broken checkbox behavior

### DIFF
--- a/packages/ui/src/components/CheckBox.svelte
+++ b/packages/ui/src/components/CheckBox.svelte
@@ -24,7 +24,7 @@
 
   const dispatch = createEventDispatcher()
 
-  let oldChecked = checked
+  $: oldChecked = checked
 
   const handleValueChanged = (event: Event): void => {
     if (readonly) {
@@ -52,7 +52,7 @@
   class:checked
   on:click|stopPropagation
 >
-  <input class="chBox" disabled={readonly} type="checkbox" bind:checked on:change={handleValueChanged} />
+  <input class="chBox" disabled={readonly} type="checkbox" bind:checked on:change|capture={handleValueChanged} />
   <svg class="checkSVG" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
     {#if checked}
       {#if symbol === 'minus'}


### PR DESCRIPTION
# Contribution checklist

## Brief description

The problem is that we save the previous value (`oldChecked`) only when handling the checkbox events. And we don’t update it when we change it programmatically. Because of this, the component doesn't dispatch the event and the checkbox behavior breaks.

I suggest to make `oldChecked` reactive. And to make everything work without unnecessary events we will listen for checkbox events in the capture phase, before `oldChecked` is updated.

**Screencast of fixed behavior:**

https://github.com/hcengineering/platform/assets/5614115/28edcc9e-f3bd-4f05-a557-910b1955834d

## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [x] - Does a local formatting is applied (rush format)
* [x] - Does a local svelte-check is applied (rush svelte-check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [x] - Tested for Chrome.
* [x] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [x] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

Resolves #4508

## Contributor requirements

* [x] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [x] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)