### PR TITLE
fix: popup glitches caused by long calculations

### DIFF
--- a/packages/ui/src/components/PopupInstance.svelte
+++ b/packages/ui/src/components/PopupInstance.svelte
@@ -112,8 +112,8 @@
   let oldModalHTML: HTMLElement | undefined = undefined
 
   $: if (modalHTML !== undefined && oldModalHTML !== modalHTML) {
-    clientWidth = -1
-    clientHeight = -1
+    clientWidth = modalHTML.clientWidth
+    clientHeight = modalHTML.clientHeight
     oldModalHTML = modalHTML
     fitPopup(modalHTML, element, contentPanel)
     showing = true
@@ -127,7 +127,9 @@
   }
 
   export function fitPopupInstance (): void {
-    if (modalHTML) fitPopup(modalHTML, element, contentPanel)
+    if (modalHTML) {
+      fitPopup(modalHTML, element, contentPanel)
+    }
   }
 
   $: if ($deviceInfo.docWidth <= 900 && !docSize) docSize = true


### PR DESCRIPTION
# Contribution checklist

## Brief description

When we open a popup, `fitPopupPositionedElement` is called several times for multiple reasons, which calculates the position of the popup on the screen:

1. Once after the DOM element is rendered and we have the reference.
2. Twice after dispatching the `changeContent` event from the `CreateIssue` component.
3. Once after calling `resizeObserver` from `PopupInstance`.

The problem is that we get the popup sizes too late, just from `resizeObserver`. This causes incorrect calculations of the `left: calc(50% - -0.5px)` parameter.

I suggest setting the initial sizes as soon as the DOM element is ready.

**Screencast**

https://github.com/hcengineering/platform/assets/5614115/d8175380-f2c0-464b-adfa-396101777b7d

## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [x] - Does a local formatting is applied (rush format)
* [x] - Does a local svelte-check is applied (rush svelte-check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [x] - Tested for Chrome.
* [x] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [x] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

Resolves #4510

## Contributor requirements

* [x] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [x] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)