### PR TITLE
added more precise try/catch error message while logging in platform

### DIFF
--- a/plugins/login-resources/src/utils.ts
+++ b/plugins/login-resources/src/utils.ts
@@ -67,6 +67,9 @@ export async function doLogin (email: string, password: string): Promise<[Status
       },
       body: JSON.stringify(request)
     })
+    if (!response.ok) {
+      throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`)
+    }
     const result = await response.json()
     console.log('login result', result)
     return [result.error ?? OK, result.result]


### PR DESCRIPTION
I have added more precise try/catch emulating error, which will be more informative user-friendly for users when server will be down for example with 504 error