### PR TITLE
added email validation for signUp users in Platform

### DIFF
--- a/plugins/login-resources/src/utils.ts
+++ b/plugins/login-resources/src/utils.ts
@@ -67,6 +67,9 @@ export async function doLogin (email: string, password: string): Promise<[Status
       },
       body: JSON.stringify(request)
     })
+    if (!emailValidator(email)) {
+      throw new Error('Please enter a valid email')
+    }
     const result = await response.json()
     console.log('login result', result)
     return [result.error ?? OK, result.result]
@@ -74,6 +77,11 @@ export async function doLogin (email: string, password: string): Promise<[Status
     console.log('login error', err)
     return [unknownError(err), undefined]
   }
+}
+
+function emailValidator (value: string): boolean {
+  return ((value !== '') && !(value.match(
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/) == null))
 }
 
 export async function signUp (
@@ -109,6 +117,10 @@ export async function signUp (
       },
       body: JSON.stringify(request)
     })
+
+    if (!emailValidator(email)) {
+      throw new Error('Please enter a valid email')
+    }
     const result = await response.json()
     return [result.error ?? OK, result.result]
   } catch (err) {


### PR DESCRIPTION
Users previously could use fake non-email fields like 123, 321 e.t.c

Example curl:

```
curl --location 'https://account.bold.ru/' \
--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:123.0) Gecko/20100101 Firefox/123.0' \
--header 'Accept: */*' \
--header 'Accept-Language: en' \
--header 'Accept-Encoding: gzip, deflate, br' \
--header 'Referer: https://app.bold.ru/' \
--header 'Content-Type: application/json' \
--header 'Origin: https://app.bold.ru' \
--header 'Connection: keep-alive' \
--header 'Sec-Fetch-Dest: empty' \
--header 'Sec-Fetch-Mode: cors' \
--header 'Sec-Fetch-Site: same-site' \
--header 'Sec-GPC: 1' \
--header 'TE: trailers' \
--data '{"method":"createAccount","params":["1234","4343","test","test"]}'
```

now added from Svelte dev validation for email link [https://svelte.dev/repl/54d159b954d9412c8247807125d9fe1b?version=3.12.1]