### PR TITLE
UBERF-5886: fix todo reorder on click

### DIFF
--- a/packages/presentation/src/components/SpaceSelector.svelte
+++ b/packages/presentation/src/components/SpaceSelector.svelte
@@ -42,7 +42,7 @@
 
   export let create: ObjectCreate | undefined = undefined
   const dispatch = createEventDispatcher()
-  $: oldSpace = space
+  let oldSpace = space
   $: if (oldSpace !== space) {
     oldSpace = space
     dispatch('change', space)

--- a/packages/presentation/src/components/SpaceSelector.svelte
+++ b/packages/presentation/src/components/SpaceSelector.svelte
@@ -42,9 +42,9 @@
 
   export let create: ObjectCreate | undefined = undefined
   const dispatch = createEventDispatcher()
-  let _space = space
-  $: if (_space !== space) {
-    _space = space
+  $: oldSpace = space
+  $: if (oldSpace !== space) {
+    oldSpace = space
     dispatch('change', space)
   }
 </script>

--- a/plugins/time-resources/src/components/EditToDo.svelte
+++ b/plugins/time-resources/src/components/EditToDo.svelte
@@ -173,7 +173,7 @@
             autoSelect={false}
             readonly={object._class === time.class.ProjectToDo}
             space={object.attachedSpace}
-            on:object={e => spaceChange(e.detail)}
+            on:object={(e) => spaceChange(e.detail)}
           />
         </div>
       </div>

--- a/plugins/time-resources/src/components/EditToDo.svelte
+++ b/plugins/time-resources/src/components/EditToDo.svelte
@@ -101,9 +101,11 @@
     object.visibility = visibility
   }
 
-  async function spaceChange (space: Ref<Space>) {
-    await client.update(object, { attachedSpace: space })
-    object.attachedSpace = space
+  async function spaceChange (space: Space | undefined) {
+    if (space?._id !== object.attachedSpace) {
+      await client.update(object, { attachedSpace: space?._id })
+      object.attachedSpace = space?._id
+    }
   }
 </script>
 
@@ -171,7 +173,7 @@
             autoSelect={false}
             readonly={object._class === time.class.ProjectToDo}
             space={object.attachedSpace}
-            on:change={(e) => spaceChange(e.detail)}
+            on:object={e => spaceChange(e.detail)}
           />
         </div>
       </div>

--- a/plugins/time-resources/src/components/EditToDo.svelte
+++ b/plugins/time-resources/src/components/EditToDo.svelte
@@ -101,10 +101,12 @@
     object.visibility = visibility
   }
 
-  async function spaceChange (space: Space | undefined) {
-    if (space?._id != object.attachedSpace) {
-      await client.update(object, { attachedSpace: space?._id })
-      object.attachedSpace = space?._id
+  async function spaceChange (space: Space | null) {
+    const oldSpace = object.attachedSpace ?? undefined
+    const newSpace = space?._id ?? undefined
+    if (newSpace !== oldSpace) {
+      await client.update(object, { attachedSpace: newSpace })
+      object.attachedSpace = newSpace
     }
   }
 </script>

--- a/plugins/time-resources/src/components/EditToDo.svelte
+++ b/plugins/time-resources/src/components/EditToDo.svelte
@@ -102,7 +102,7 @@
   }
 
   async function spaceChange (space: Space | undefined) {
-    if (space?._id !== object.attachedSpace) {
+    if (space?._id != object.attachedSpace) {
       await client.update(object, { attachedSpace: space?._id })
       object.attachedSpace = space?._id
     }


### PR DESCRIPTION
# Contribution checklist

## Brief description

The problem was because `space` property values were incorrectly compared. This caused the todo to be updated every time the todo item was closed.

### Screencast

https://github.com/hcengineering/platform/assets/5614115/4778c58a-bc7a-4dd3-9cc4-bf17c6042f9b

## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [x] - Does a local formatting is applied (rush format)
* [x] - Does a local svelte-check is applied (rush svelte-check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [x] - Tested for Chrome.
* [x] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

#4881

## Contributor requirements

* [x] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [x] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

<sub>View in Huly <a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NWVhZWM4ZTM5ODYwOTRkMDgxY2Y3M2EiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.7Zri4ykP-P4_SohRlsUj9kJ4W3zYE5my6aKwyfhbrFM">UBERF-5924</a></sub>