### PR TITLE
fix: unexpected undefined size of icon

### DIFF
--- a/packages/ui/src/components/Icon.svelte
+++ b/packages/ui/src/components/Icon.svelte
@@ -34,6 +34,9 @@
   $: url = isAsset(icon) ? getMetadata(toAsset(icon)) ?? 'https://anticrm.org/logo.svg' : ''
 
   $: _fill = iconProps?.fill ?? fill
+
+  // workaround to prevent sveltejs bug in `svelte:component`: https://github.com/sveltejs/svelte/issues/9177
+  $: _iconProps = { size, fill: _fill, ...iconProps }
 </script>
 
 {#if isAsset(icon)}
@@ -41,5 +44,5 @@
     <use href={url} />
   </svg>
 {:else if typeof icon !== 'string'}
-  <svelte:component this={icon} {size} fill={_fill} {...iconProps} />
+  <svelte:component this={icon} {..._iconProps} />
 {/if}


### PR DESCRIPTION
# Contribution checklist

## Brief description

This bug is caused by a bug in sveltejs, but we have a workaround

* sveltejs/svelte#9177

### Screencast

https://github.com/hcengineering/platform/assets/5614115/00065c8d-5e44-4b27-9a71-599f95c9355d

## Checklist

* [ ] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [x] - Does a local formatting is applied (rush format)
* [x] - Does a local svelte-check is applied (rush svelte-check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [x] - Tested for Chrome.
* [x] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

Resolves #4960

## Contributor requirements

* [x] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [x] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

<sub>View in Huly <a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NWYzNjA0YzEwZmE5NTk0M2NlZTU5MzUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.JotledcDlEFmmhnpTFoyi36fmt2GjC5rjqRMc-OI_js">UBERF-6023</a></sub>