### PR TITLE
UBERF-5837 Automatically create snapshots when collaborative doc is edited

### DIFF
--- a/packages/collaborator-client/src/client.ts
+++ b/packages/collaborator-client/src/client.ts
@@ -85,7 +85,7 @@ export interface RemoveDocumentResponse {}
 export interface TakeSnapshotRequest {
   documentId: DocumentURI
   collaborativeDoc: CollaborativeDoc
-  createdBy: string
+  createdBy: Ref<Account>
   snapshotName: string
 }
 
@@ -94,7 +94,7 @@ export interface TakeSnapshotResponse {
   versionId: string
   name: string
 
-  createdBy: string
+  createdBy: Ref<Account>
   createdOn: Timestamp
 }
 

--- a/packages/core/src/__tests__/collaboration.test.ts
+++ b/packages/core/src/__tests__/collaboration.test.ts
@@ -17,7 +17,8 @@ import {
   CollaborativeDoc,
   formatCollaborativeDoc,
   formatCollaborativeDocVersion,
-  parseCollaborativeDoc
+  parseCollaborativeDoc,
+  updateCollaborativeDoc
 } from '../collaboration'
 
 describe('collaborative-doc', () => {
@@ -26,14 +27,14 @@ describe('collaborative-doc', () => {
       expect(parseCollaborativeDoc('minioDocumentId:HEAD:0' as CollaborativeDoc)).toEqual({
         documentId: 'minioDocumentId',
         versionId: 'HEAD',
-        revisionId: '0'
+        lastVersionId: '0'
       })
     })
     it('parses collaborative doc version id', async () => {
       expect(parseCollaborativeDoc('minioDocumentId:main' as CollaborativeDoc)).toEqual({
         documentId: 'minioDocumentId',
         versionId: 'main',
-        revisionId: 'main'
+        lastVersionId: 'main'
       })
     })
   })
@@ -44,7 +45,7 @@ describe('collaborative-doc', () => {
         formatCollaborativeDoc({
           documentId: 'minioDocumentId',
           versionId: 'HEAD',
-          revisionId: '0'
+          lastVersionId: '0'
         })
       ).toEqual('minioDocumentId:HEAD:0')
     })
@@ -58,6 +59,14 @@ describe('collaborative-doc', () => {
           versionId: 'versionId'
         })
       ).toEqual('minioDocumentId:versionId')
+    })
+  })
+
+  describe('updateCollaborativeDoc', () => {
+    it('returns valid collaborative doc id', async () => {
+      expect(updateCollaborativeDoc('minioDocumentId:HEAD:0' as CollaborativeDoc, '1')).toEqual(
+        'minioDocumentId:HEAD:1'
+      )
     })
   })
 })

--- a/packages/core/src/collaboration.ts
+++ b/packages/core/src/collaboration.ts
@@ -42,7 +42,7 @@ export function getCollaborativeDoc (documentId: string): CollaborativeDoc {
   return formatCollaborativeDoc({
     documentId,
     versionId: CollaborativeDocVersionHead,
-    revisionId: '0'
+    lastVersionId: '0'
   })
 }
 
@@ -50,25 +50,35 @@ export function getCollaborativeDoc (documentId: string): CollaborativeDoc {
 export interface CollaborativeDocData {
   documentId: string
   versionId: CollaborativeDocVersion
-  revisionId: string
+  lastVersionId: string
 }
 
 /** @public */
 export function parseCollaborativeDoc (id: CollaborativeDoc): CollaborativeDocData {
-  const [documentId, versionId, revisionId] = id.split(':')
-  return { documentId, versionId, revisionId: revisionId ?? versionId }
+  const [documentId, versionId, lastVersionId] = id.split(':')
+  return { documentId, versionId, lastVersionId: lastVersionId ?? versionId }
 }
 
 /** @public */
-export function formatCollaborativeDoc ({ documentId, versionId, revisionId }: CollaborativeDocData): CollaborativeDoc {
-  return `${documentId}:${versionId}:${revisionId}` as CollaborativeDoc
+export function formatCollaborativeDoc ({
+  documentId,
+  versionId,
+  lastVersionId
+}: CollaborativeDocData): CollaborativeDoc {
+  return `${documentId}:${versionId}:${lastVersionId}` as CollaborativeDoc
+}
+
+/** @public */
+export function updateCollaborativeDoc (collaborativeDoc: CollaborativeDoc, lastVersionId: string): CollaborativeDoc {
+  const { documentId, versionId } = parseCollaborativeDoc(collaborativeDoc)
+  return formatCollaborativeDoc({ documentId, versionId, lastVersionId })
 }
 
 /** @public */
 export function formatCollaborativeDocVersion ({
   documentId,
   versionId
-}: Omit<CollaborativeDocData, 'revisionId'>): CollaborativeDoc {
+}: Omit<CollaborativeDocData, 'lastVersionId'>): CollaborativeDoc {
   return `${documentId}:${versionId}` as CollaborativeDoc
 }
 

--- a/server/collaboration/src/history/__tests__/history.test.ts
+++ b/server/collaboration/src/history/__tests__/history.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-import { generateId } from '@hcengineering/core'
+import { Account, Ref, generateId } from '@hcengineering/core'
 import { Doc as YDoc, encodeStateAsUpdate } from 'yjs'
 
 import { YDocVersion, addVersion, deleteVersion, getVersion, getVersionData, listVersions } from '../history'
@@ -153,7 +153,7 @@ function yDocVersion (versionId: string): YDocVersion {
   return {
     versionId,
     name: versionId,
-    createdBy: 'unit test',
+    createdBy: 'unit test' as Ref<Account>,
     createdOn: Date.now()
   }
 }

--- a/server/collaboration/src/history/__tests__/snapshot.test.ts
+++ b/server/collaboration/src/history/__tests__/snapshot.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-import { generateId } from '@hcengineering/core'
+import { Account, Ref, generateId } from '@hcengineering/core'
 import { Doc as YDoc } from 'yjs'
 
 import { createYdocSnapshot, restoreYdocSnapshot } from '../snapshot'
@@ -103,7 +103,7 @@ function yDocVersion (versionId: string): YDocVersion {
   return {
     versionId,
     name: versionId,
-    createdBy: 'unit test',
+    createdBy: 'unit test' as Ref<Account>,
     createdOn: Date.now()
   }
 }

--- a/server/collaboration/src/history/history.ts
+++ b/server/collaboration/src/history/history.ts
@@ -13,10 +13,9 @@
 // limitations under the License.
 //
 
-import { Timestamp } from '@hcengineering/core'
+import { Account, Ref, Timestamp } from '@hcengineering/core'
 import { fromByteArray, toByteArray } from 'base64-js'
-import { Doc as YDoc } from 'yjs'
-import { YArray, YMap } from 'yjs/dist/src/internals'
+import { Array as YArray, Doc as YDoc, Map as YMap } from 'yjs'
 
 /**
  * This module provides utils for document version storage based on YDoc
@@ -46,7 +45,7 @@ export interface YDocVersion {
   versionId: string
   name: string
 
-  createdBy: string
+  createdBy: Ref<Account>
   createdOn: Timestamp
 }
 

--- a/server/collaboration/src/utils/__tests__/collaborative-doc.test.ts
+++ b/server/collaboration/src/utils/__tests__/collaborative-doc.test.ts
@@ -32,7 +32,7 @@ describe('collaborative-doc', () => {
       const doc = formatCollaborativeDoc({
         documentId: 'example',
         versionId: 'HEAD',
-        revisionId: '0'
+        lastVersionId: '0'
       })
       expect(isEditableDoc(doc)).toBeTruthy()
     })
@@ -41,7 +41,7 @@ describe('collaborative-doc', () => {
       const doc = formatCollaborativeDoc({
         documentId: 'example',
         versionId: 'main',
-        revisionId: '0'
+        lastVersionId: '0'
       })
       expect(isEditableDoc(doc)).toBeFalsy()
     })

--- a/server/collaboration/src/utils/minio.ts
+++ b/server/collaboration/src/utils/minio.ts
@@ -25,7 +25,7 @@ export async function yDocFromMinio (
   workspace: WorkspaceId,
   minioDocumentId: string,
   ydoc?: YDoc
-): Promise<YDoc> {
+): Promise<YDoc | undefined> {
   // no need to apply gc because we load existing document
   // it is either already gc-ed, or gc not needed and it is disabled
   ydoc ??= new YDoc({ gc: false })
@@ -33,8 +33,11 @@ export async function yDocFromMinio (
   try {
     const buffer = await minio.read(workspace, minioDocumentId)
     return yDocFromBuffer(Buffer.concat(buffer), ydoc)
-  } catch (err) {
-    throw new Error('Failed to load ydoc from minio', { cause: err })
+  } catch (err: any) {
+    if (err?.code === 'NoSuchKey' || err?.code === 'NotFound') {
+      return undefined
+    }
+    throw err
   }
 }
 

--- a/server/collaborator/src/extensions/storage.ts
+++ b/server/collaborator/src/extensions/storage.ts
@@ -106,6 +106,7 @@ export class StorageExtension implements Extension {
     const { adapter, ctx } = this.configuration
 
     try {
+      await ctx.info('load document content', { documentId })
       const ydoc = await adapter.loadDocument(documentId, context)
       if (ydoc !== undefined) {
         return ydoc
@@ -142,6 +143,7 @@ export class StorageExtension implements Extension {
 
     let snapshot: YDocVersion | undefined
     try {
+      await ctx.info('take document snapshot', { documentId })
       snapshot = await ctx.with('take-snapshot', {}, async () => {
         return await adapter.takeSnapshot(documentId, document, context)
       })
@@ -150,6 +152,7 @@ export class StorageExtension implements Extension {
     }
 
     try {
+      await ctx.info('save document content', { documentId })
       await ctx.with('save-document', {}, async () => {
         await adapter.saveDocument(documentId, document, snapshot, context)
       })

--- a/server/collaborator/src/rpc/methods/takeSnapshot.ts
+++ b/server/collaborator/src/rpc/methods/takeSnapshot.ts
@@ -55,13 +55,10 @@ export async function takeSnapshot (
   try {
     // load history document directly from minio
     const historyDocumentId = collaborativeHistoryDocId(minioDocumentId)
-    const yHistory = await ctx.with('yDocFromMinio', {}, async () => {
-      try {
+    const yHistory =
+      (await ctx.with('yDocFromMinio', {}, async () => {
         return await yDocFromMinio(minio, workspaceId, historyDocumentId)
-      } catch {
-        return new YDoc()
-      }
-    })
+      })) ?? new YDoc()
 
     await ctx.with('createYdocSnapshot', {}, async () => {
       await connection.transact((yContent) => {

--- a/server/collaborator/src/server.ts
+++ b/server/collaborator/src/server.ts
@@ -105,7 +105,7 @@ export async function start (
     /**
      * Makes sure to call `onStoreDocument` at least in the given amount of time (ms).
      */
-    maxDebounce: 30000,
+    maxDebounce: 60000,
     /**
      * options to pass to the ydoc document
      */

--- a/server/collaborator/src/storage/adapter.ts
+++ b/server/collaborator/src/storage/adapter.ts
@@ -13,12 +13,19 @@
 // limitations under the License.
 //
 
+import { YDocVersion } from '@hcengineering/collaboration'
 import { Doc as YDoc } from 'yjs'
 import { Context } from '../context'
 
 export interface StorageAdapter {
   loadDocument: (documentId: string, context: Context) => Promise<YDoc | undefined>
-  saveDocument: (documentId: string, document: YDoc, context: Context) => Promise<void>
+  saveDocument: (
+    documentId: string,
+    document: YDoc,
+    snapshot: YDocVersion | undefined,
+    context: Context
+  ) => Promise<void>
+  takeSnapshot: (documentId: string, document: YDoc, context: Context) => Promise<YDocVersion | undefined>
 }
 
 export type StorageAdapters = Record<string, StorageAdapter>

--- a/server/collaborator/src/storage/minio.ts
+++ b/server/collaborator/src/storage/minio.ts
@@ -13,8 +13,13 @@
 // limitations under the License.
 //
 
-import { loadCollaborativeDoc, saveCollaborativeDocVersion } from '@hcengineering/collaboration'
 import {
+  YDocVersion,
+  loadCollaborativeDoc,
+  saveCollaborativeDocVersion,
+  takeCollaborativeDocSnapshot
+} from '@hcengineering/collaboration'
+import core, {
   CollaborativeDocVersion,
   CollaborativeDocVersionHead,
   MeasureContext,
@@ -72,7 +77,12 @@ export class MinioStorageAdapter implements StorageAdapter {
     })
   }
 
-  async saveDocument (documentId: string, document: YDoc, context: Context): Promise<void> {
+  async saveDocument (
+    documentId: string,
+    document: YDoc,
+    snapshot: YDocVersion | undefined,
+    context: Context
+  ): Promise<void> {
     const { workspaceId } = context
 
     const { minioDocumentId, versionId } = parseDocumentId(documentId)
@@ -85,5 +95,27 @@ export class MinioStorageAdapter implements StorageAdapter {
     await this.ctx.with('save-document', {}, async (ctx) => {
       await saveCollaborativeDocVersion(this.minio, workspaceId, minioDocumentId, versionId, document, ctx)
     })
+  }
+
+  async takeSnapshot (documentId: string, document: YDoc, context: Context): Promise<YDocVersion | undefined> {
+    const { workspaceId } = context
+
+    const timestamp = Date.now()
+
+    const yDocVersion: YDocVersion = {
+      versionId: `${timestamp}`,
+      name: 'Automatic snapshot',
+      createdBy: core.account.System,
+      createdOn: timestamp
+    }
+
+    const { minioDocumentId, versionId } = parseDocumentId(documentId)
+    const collaborativeDoc = formatCollaborativeDocVersion({ documentId: minioDocumentId, versionId })
+
+    await this.ctx.with('take-snapshot', {}, async (ctx) => {
+      await takeCollaborativeDocSnapshot(this.minio, workspaceId, collaborativeDoc, document, yDocVersion, ctx)
+    })
+
+    return yDocVersion
   }
 }

--- a/server/collaborator/src/storage/minio.ts
+++ b/server/collaborator/src/storage/minio.ts
@@ -19,7 +19,7 @@ import {
   saveCollaborativeDocVersion,
   takeCollaborativeDocSnapshot
 } from '@hcengineering/collaboration'
-import core, {
+import {
   CollaborativeDocVersion,
   CollaborativeDocVersionHead,
   MeasureContext,
@@ -98,14 +98,15 @@ export class MinioStorageAdapter implements StorageAdapter {
   }
 
   async takeSnapshot (documentId: string, document: YDoc, context: Context): Promise<YDocVersion | undefined> {
-    const { workspaceId } = context
+    const { clientFactory, workspaceId } = context
 
+    const client = await clientFactory({ derived: false })
     const timestamp = Date.now()
 
     const yDocVersion: YDocVersion = {
       versionId: `${timestamp}`,
       name: 'Automatic snapshot',
-      createdBy: core.account.System,
+      createdBy: client.user,
       createdOn: timestamp
     }
 

--- a/server/collaborator/src/storage/mongodb.ts
+++ b/server/collaborator/src/storage/mongodb.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 
+import { YDocVersion } from '@hcengineering/collaboration'
 import { Doc, MeasureContext, Ref, toWorkspaceString } from '@hcengineering/core'
 import { Transformer } from '@hocuspocus/transformer'
 import { MongoClient } from 'mongodb'
@@ -74,7 +75,17 @@ export class MongodbStorageAdapter implements StorageAdapter {
     })
   }
 
-  async saveDocument (documentId: string, _document: YDoc, _context: Context): Promise<void> {
+  async saveDocument (
+    documentId: string,
+    _document: YDoc,
+    snapshot: YDocVersion | undefined,
+    _context: Context
+  ): Promise<void> {
     await this.ctx.error('saving documents into mongodb not supported', { documentId })
+  }
+
+  async takeSnapshot (documentId: string, document: YDoc, context: Context): Promise<YDocVersion | undefined> {
+    await this.ctx.error('taking snapshotsin mongodb not supported', { documentId })
+    return undefined
   }
 }

--- a/server/collaborator/src/storage/router.ts
+++ b/server/collaborator/src/storage/router.ts
@@ -13,10 +13,9 @@
 // limitations under the License.
 //
 
+import { YDocVersion } from '@hcengineering/collaboration'
 import { Doc as YDoc } from 'yjs'
-
 import { Context } from '../context'
-
 import { StorageAdapter, StorageAdapters } from './adapter'
 
 function parseDocumentName (documentId: string): { schema: string, documentName: string } {
@@ -44,9 +43,20 @@ export class RouterStorageAdapter implements StorageAdapter {
     return await adapter?.loadDocument?.(documentName, context)
   }
 
-  async saveDocument (documentId: string, document: YDoc, context: Context): Promise<void> {
+  async saveDocument (
+    documentId: string,
+    document: YDoc,
+    snapshot: YDocVersion | undefined,
+    context: Context
+  ): Promise<void> {
     const { schema, documentName } = parseDocumentName(documentId)
     const adapter = this.getStorageAdapter(schema)
-    await adapter?.saveDocument?.(documentName, document, context)
+    await adapter?.saveDocument?.(documentName, document, snapshot, context)
+  }
+
+  async takeSnapshot (documentId: string, document: YDoc, context: Context): Promise<YDocVersion | undefined> {
+    const { schema, documentName } = parseDocumentName(documentId)
+    const adapter = this.getStorageAdapter(schema)
+    return await adapter?.takeSnapshot?.(documentName, document, context)
   }
 }


### PR DESCRIPTION
# Contribution checklist

## Brief description

Added automatic snapshots for collaborative documents. When a collaborative document is saved, we take snapshot and save its id as part of collaborative document id. So the document always refers to some snapshot.

## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [ ] - Does a local formatting is applied (rush format)
* [ ] - Does a local svelte-check is applied (rush svelte-check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [ ] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues

## Contributor requirements

* [ ] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [ ] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

<sub>View in Huly <a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NWYzYzM5ZTEwZmE5NTk0M2NlZTVhNGYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.9s97cBHdMmTB-rcX8Cbf0NWvrBih59pp7wjO9aaX83I">UBERF-6028</a></sub>