### PR TITLE
fix: `Panel` glitches on opening

### DIFF
--- a/packages/ui/src/components/Panel.svelte
+++ b/packages/ui/src/components/Panel.svelte
@@ -64,13 +64,19 @@
 
   const dispatch = createEventDispatcher()
 
+  let el: HTMLElement
   let asideFloat: boolean = false
   let asideShown: boolean = selectedAside !== false
   let hideAside: boolean = !asideShown
   let fullSize: boolean = false
   let oldAside: string | boolean = selectedAside
+
   $: if (typeof selectedAside === 'string' && oldAside !== selectedAside) oldAside = selectedAside
   $: setAside(selectedAside)
+  $: if (el !== undefined) {
+    panelWidth = el.clientWidth
+    checkPanel()
+  }
 
   let oldWidth = ''
   let hideTimer: any | undefined
@@ -97,6 +103,7 @@
       }
     }
   }
+
   afterUpdate(() => {
     if (hideTimer) {
       clearTimeout(hideTimer)
@@ -114,6 +121,7 @@
     asideShown = !asideShown
     hideAside = !asideShown
   }
+
   const handleSelectAside = (result: { detail: any }, sw: boolean = true): void => {
     selectedAside = result.detail
     if (sw) {
@@ -125,6 +133,7 @@
 </script>
 
 <div
+  bind:this={el}
   class="popupPanel panel {kind}"
   class:embedded
   use:resizeObserver={(element) => {


### PR DESCRIPTION
# Contribution checklist

## Brief description

Sometimes you can see the sidebar open and then instantly close when you try to open todo in Planner.

<img width="778" src="https://github.com/hcengineering/platform/assets/5614115/00fc09dc-f419-42dc-8bef-156cf7499153" alt="Screenshot 2024-03-21 at 18 16 26">

### Screencast before

https://github.com/hcengineering/platform/assets/5614115/0581bd6e-d72c-4cd1-b526-598442724f82

### Screencast after

https://github.com/hcengineering/platform/assets/5614115/28ce8c13-0774-4418-9850-1628a834a6c9

## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [ ] - Does a local formatting is applied (rush format)
* [ ] - Does a local svelte-check is applied (rush svelte-check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [ ] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

A list of closed updated issues

## Contributor requirements

* [x] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [x] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

<sub>View in Huly <a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NWZjNTAxNDkyYjg2MmVjNDNhZDBiZDAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.TqIBTT-7z_ylnRhzpt-sBoQluRYieErSnWe3HyAP7vA">UBERF-6131</a></sub>