### PR TITLE
Fix login form issue when using password auto-fill

### DIFF
--- a/plugins/login-resources/package.json
+++ b/plugins/login-resources/package.json
@@ -6,10 +6,12 @@
   "license": "EPL-2.0",
   "scripts": {
     "build": "compile ui",
+    "test": "jest --passWithNoTests --silent",
     "build:docs": "api-extractor run --local",
     "format": "format src",
     "build:watch": "compile ui",
     "_phase:build": "compile ui",
+    "_phase:test": "jest --passWithNoTests --silent",
     "_phase:format": "format src",
     "_phase:validate": "compile validate"
   },

--- a/plugins/login-resources/src/__tests__/mutex.test.ts
+++ b/plugins/login-resources/src/__tests__/mutex.test.ts
@@ -1,0 +1,28 @@
+import { makeSequential } from '../mutex'
+
+describe('mutex', () => {
+  let results: number[]
+
+  beforeEach(() => {
+    results = []
+  })
+
+  async function waitAndPushResult (millis: number): Promise<void> {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, millis)
+    })
+    results.push(millis)
+  }
+
+  it('expect sequential execution', async () => {
+    const myUpdate = makeSequential(waitAndPushResult)
+    await Promise.all([myUpdate(50), myUpdate(30), myUpdate(40), myUpdate(10), myUpdate(20)])
+    expect(results).toEqual([50, 30, 40, 10, 20])
+  })
+
+  it('expect parallel execution', async () => {
+    const myUpdate = waitAndPushResult
+    await Promise.all([myUpdate(50), myUpdate(30), myUpdate(40), myUpdate(10), myUpdate(20)])
+    expect(results).toEqual([10, 20, 30, 40, 50])
+  })
+})

--- a/plugins/login-resources/src/mutex.ts
+++ b/plugins/login-resources/src/mutex.ts
@@ -1,0 +1,64 @@
+//
+// Copyright © 2022 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/**
+  Class that allows synchronization of async functions to prevent race conditions.
+  Inspired by https://stackoverflow.com/a/51086893
+**/
+export class Mutex {
+  currentLock: Promise<void>
+
+  constructor () {
+    // initially the lock is not held
+    this.currentLock = Promise.resolve()
+  }
+
+  /**
+    Acquires the lock. Usage example:
+
+    ```
+    let mutex = new Mutex()
+
+    async function synchronizedFunction() {
+      const unlockMutex = await mutex.lock()
+      try {
+        // critical section
+      } finally {
+        unlockMutex()
+      }
+    }
+    ```
+
+    @return {Promise<VoidFunction>} promise that must be awaited in order to acquire the lock.
+    When the promise is fulfulled it returns a function that must be invoked to release the lock.
+  **/
+  async lock (): Promise<VoidFunction> {
+    // function which invocation releases the lock
+    let releaseLock: VoidFunction
+    // this Promise is fulfilled as soon as the function above is invoked
+    const afterReleasePromise = new Promise<void>((resolve) => {
+      releaseLock = () => {
+        resolve()
+      }
+    })
+    // Caller gets a promise that resolves
+    // only after the current outstanding lock resolves
+    const blockingPromise = this.currentLock.then(() => releaseLock)
+    // Don't allow the next request until the new promise is done
+    this.currentLock = afterReleasePromise
+    // Return the new promise
+    return await blockingPromise
+  }
+}


### PR DESCRIPTION
# Contribution checklist

## Brief description

### Non-technical issue description

This PR fixes a minor UI issue with the login form when using Firefox password auto-fill feature. This video illustrates the issue.

https://github.com/hcengineering/platform/assets/11474041/20c093c1-0c07-4610-94c4-7fbdc61eb503

**Steps to reproduce:**

1. Use Firefox password manager to remember the login credentials.
2. Log in using the saved credentials.
3. Log out.

**Expected behavior:**

"Log in" button is enabled and allows to log in again using the saved credentials.

**Observed behavior:**

"Log in" button is disabled. It is possible to make it enabled again by editing the password field, e.g. by entering a dummy character and then removing it.

**Impact:**

This issue causes a minor inconvenience for a user who is affected and aware of it, and may confuse/block a new user who encounters it for the first time. I was not able to reproduce the issue in Chrome, and had no possibility to test in Safari. The issue might also affect users who use browser extensions to fill the password instead of the built-in browser functionality.

### Technical issue description

Input is validated using function `validate` https://github.com/hcengineering/platform/blob/18e8dcab5782ce159c2754f3bcd794c8143ed1d5/plugins/login-resources/src/components/Form.svelte#L189

This function is asynchronous, and prone to a race condition. The race condition happens when the password manager fills username and then fills the password. This creates two simultaneous validation events: the first one validates the form where the password is still empty, whereas the second validation call validates the complete form with non-empty password. Unfortunately, the first validation finishes after the second validation and flags the form as invalid https://github.com/hcengineering/platform/blob/18e8dcab5782ce159c2754f3bcd794c8143ed1d5/plugins/login-resources/src/components/Form.svelte#L75-L77

### Proposed solution

The proposed solution introduces a `Mutex` class that allows to synchronize async functions. In this case the Mutex is applied to the form validation function. It eliminates the race condition and fixes the problem described and illustrated above.

### Further thoughts

As a follow-up, the introduced class may be extracted to a better place to be reused by other components.

As an alternative solution, I considered using the existing library https://www.npmjs.com/package/async-mutex .

## Checklist

* [x] - UI test added to added/changed functionality?
* [x] - Screenshot is added to PR if applicable ?
* [x] - Does a local formatting is applied (rush format)
* [x] - Does a local svelte-check is applied (rush svelte-check)
* [x] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [x] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [x] - Does the translations are up to date?
* [x] - Does it well tested?
* [x] - Tested for Chrome.
* [ ] - Tested for Safari.
* [x] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [x] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [x] - Are required links are linked to PR?
* [x] - Does new code is well documented ?

## Related issues

None

## Contributor requirements

* [x] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [x] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjAwN2Q2MzdmZTg3NDA1MTFhYWVkNGYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.WMzGROWiIYEwfNk41HZFjWiidve9_knIB5WrsENw18A">Huly&reg;: <b>UBERF-6159</b></a></sub>