### PR TITLE
EZQMS-612: Quick fix to let `TypedSpace` instances have non-configured roles (`undefined`)

### DIFF
--- a/plugins/view-resources/src/utils.ts
+++ b/plugins/view-resources/src/utils.ts
@@ -1362,7 +1362,7 @@ permissionsQuery.query(core.class.Space, {}, (res) => {
 
       const asMixin = hierarchy.as(s, mixin)
       const roles = client.getModel().findAllSync(core.class.Role, { attachedTo: type._id })
-      const myRoles = roles.filter((r) => (asMixin as any)[r._id].includes(me._id))
+      const myRoles = roles.filter((r) => ((asMixin as any)[r._id] ?? []).includes(me._id))
       permissionsBySpace[s._id] = new Set(myRoles.flatMap((r) => r.permissions))
     } else {
       whitelistedSpaces.add(s._id)


### PR DESCRIPTION
# Contribution checklist

## Brief description

Quick fix to let `TypedSpace` instances have non-configured roles (`undefined`)

## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [ ] - Does a local formatting is applied (rush format)
* [ ] - Does a local svelte-check is applied (rush svelte-check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [ ] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [ ] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [ ] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [ ] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

* https://front.hc.engineering/workbench/platform/tracker/EZQMS-612

## Contributor requirements

* [ ] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [ ] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

<sub>View in Huly <a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjA0ZGM1NTlmYTE1ODMyNDcyOWY1YzAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.9mJc8ztP8QxUwEprRJVNTkMzJEuB8C0qmIB1W95T6Ec">UBERF-6219</a></sub>