### PR TITLE
EZQMS-663: More info in permissions store, fix tree element actions

### DIFF
--- a/plugins/view-resources/src/components/navigator/TreeElement.svelte
+++ b/plugins/view-resources/src/components/navigator/TreeElement.svelte
@@ -58,6 +58,8 @@
   })
 
   async function onMenuClick (ev: MouseEvent): Promise<void> {
+    // Read actual popup actions on open as visibility might have been changed
+    popupMenuActions = await actions().then((res) => res.filter((action) => action.inline !== true))
     showPopup(Menu, { actions: popupMenuActions, ctx: _id }, ev.target as HTMLElement, () => {
       hovered = false
     })

--- a/plugins/view-resources/src/utils.ts
+++ b/plugins/view-resources/src/utils.ts
@@ -1332,13 +1332,16 @@ async function getAttrEditor (key: KeyedAttribute, hierarchy: Hierarchy): Promis
 }
 
 type PermissionsBySpace = Record<Ref<Space>, Set<Ref<Permission>>>
+type AccountsByPermission = Record<Ref<Space>, Record<Ref<Permission>, Set<Ref<Account>>>>
 interface PermissionsStore {
   ps: PermissionsBySpace
+  ap: AccountsByPermission
   whitelist: Set<Ref<Space>>
 }
 
 export const permissionsStore = writable<PermissionsStore>({
   ps: {},
+  ap: {},
   whitelist: new Set()
 })
 const permissionsQuery = createQuery(true)
@@ -1346,6 +1349,7 @@ const permissionsQuery = createQuery(true)
 permissionsQuery.query(core.class.Space, {}, (res) => {
   const whitelistedSpaces = new Set<Ref<Space>>()
   const permissionsBySpace: PermissionsBySpace = {}
+  const accountsByPermission: AccountsByPermission = {}
   const client = getClient()
   const hierarchy = client.getHierarchy()
   const me = getCurrentAccount()
@@ -1364,6 +1368,24 @@ permissionsQuery.query(core.class.Space, {}, (res) => {
       const roles = client.getModel().findAllSync(core.class.Role, { attachedTo: type._id })
       const myRoles = roles.filter((r) => ((asMixin as any)[r._id] ?? []).includes(me._id))
       permissionsBySpace[s._id] = new Set(myRoles.flatMap((r) => r.permissions))
+
+      accountsByPermission[s._id] = {}
+
+      for (const role of roles) {
+        const assignment: Array<Ref<Account>> = (asMixin as any)[role._id] ?? []
+
+        if (assignment.length === 0) {
+          continue
+        }
+
+        for (const permissionId of role.permissions) {
+          if (accountsByPermission[s._id][permissionId] === undefined) {
+            accountsByPermission[s._id][permissionId] = new Set()
+          }
+
+          assignment.forEach((acc) => accountsByPermission[s._id][permissionId].add(acc))
+        }
+      }
     } else {
       whitelistedSpaces.add(s._id)
     }
@@ -1371,6 +1393,7 @@ permissionsQuery.query(core.class.Space, {}, (res) => {
 
   permissionsStore.set({
     ps: permissionsBySpace,
+    ap: accountsByPermission,
     whitelist: whitelistedSpaces
   })
 })


### PR DESCRIPTION
# Contribution checklist

* Adds permission->accounts map to the permissions store
* Fixes issue with tree element menu actions not being re-evaluated on menu opening to take visibilityChecker into account

## Brief description

## Checklist

* [ ] - UI test added to added/changed functionality?
* [ ] - Screenshot is added to PR if applicable ?
* [X] - Does a local formatting is applied (rush format)
* [X] - Does a local svelte-check is applied (rush svelte-check)
* [ ] - Does a local UI tests are executed [UI Testing](../tests/readme.md)
* [X] - Does the code work? Check whether function and logic are correct.
* [ ] - Does Changelog.md is updated with changes?
* [ ] - Does the translations are up to date?
* [ ] - Does it well tested?
* [X] - Tested for Chrome.
* [ ] - Tested for Safari.
* [ ] - Go through the changed code looking for typos, TODOs, commented LOCs, debugging pieces of code, etc.
* [X] - Rebase your branch onto master and upstream branch
* [ ] - Is there any redundant or duplicate code?
* [X] - Are required links are linked to PR?
* [ ] - Does new code is well documented ?

## Related issues

https://front.hc.engineering/workbench/platform/tracker/EZQMS-663

## Contributor requirements

* [ ] - Sign-off is provided. [DCO](https://github.com/apps/dco)
* [ ] - GPG Signature is provided. [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
