### PR TITLE
Set last name as empty if not found for GitHub login

### DIFF
--- a/pods/authProviders/src/github.ts
+++ b/pods/authProviders/src/github.ts
@@ -43,7 +43,8 @@ export function registerGithub (
     passport.authenticate('github', { failureRedirect: concatLink(frontUrl, '/login'), session: true }),
     async (ctx, next) => {
       const email = ctx.state.user.emails?.[0]?.value ?? `github:${ctx.state.user.username}`
-      const [first, last] = ctx.state.user.displayName.split(' ')
+      let [first, last] = ctx.state.user.displayName.split(' ')
+      last = last ?? ''
       if (email !== undefined) {
         if (ctx.query?.state != null) {
           const loginInfo = await joinWithProvider(ctx, db, productId, email, first, last, ctx.query.state, {


### PR DESCRIPTION
Hi, the last name shows as null when logging in with GitHub. This happens in cases where the last name is not set on the GitHub profile. This PR sets the last name as an empty string in such cases. Changes have been verified by logging in with GitHub locally with the same account.

Production Env:

<img width="1440" src="https://github.com/hcengineering/platform/assets/37538929/6576b2cc-0097-4964-a1a5-280b6bbd374a" alt="image">

Local Env:

<img width="1440" src="https://github.com/hcengineering/platform/assets/37538929/23548459-6dc2-4335-8f6a-0c1ed53ef58d" alt="image">

<sub>View in Huly <a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjA5Y2NhN2UwYzE0NzA5ZWRjNWRiMjIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.1dmedFtUks9lVilNE0tM0f6Acbvfpt9yCXo8EJoaKdc">UBERF-6239</a></sub>