### PR TITLE
fix(google): added fallback values for first and last name

### DIFF
--- a/pods/authProviders/src/google.ts
+++ b/pods/authProviders/src/google.ts
@@ -43,8 +43,8 @@ export function registerGoogle (
     passport.authenticate('google', { failureRedirect: concatLink(frontUrl, '/login'), session: true }),
     async (ctx, next) => {
       const email = ctx.state.user.emails?.[0]?.value
-      const first = ctx.state.user.name.givenName ?? ""
-      const last = ctx.state.user.name.familyName ?? ""
+      const first = ctx.state.user.name.givenName ?? ''
+      const last = ctx.state.user.name.familyName ?? ''
       if (email !== undefined) {
         try {
           if (ctx.query?.state != null) {

--- a/pods/authProviders/src/google.ts
+++ b/pods/authProviders/src/google.ts
@@ -43,8 +43,8 @@ export function registerGoogle (
     passport.authenticate('google', { failureRedirect: concatLink(frontUrl, '/login'), session: true }),
     async (ctx, next) => {
       const email = ctx.state.user.emails?.[0]?.value
-      const first = ctx.state.user.name.givenName
-      const last = ctx.state.user.name.familyName
+      const first = ctx.state.user.name.givenName ?? ""
+      const last = ctx.state.user.name.familyName ?? ""
       if (email !== undefined) {
         try {
           if (ctx.query?.state != null) {


### PR DESCRIPTION
**Pull Request Requirements:**

* Added a fallback value when the first or last name is empty.

## Issue

* When I logged in through my Google account, `null` was added because my Google account didn't have a last name

  ![image](https://github.com/hcengineering/platform/assets/77210185/ad9b9d71-9943-4b62-bdba-95090bceee1d)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBhNTNjMGUwYzE0NzA5ZWRjNWRlNzUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.iDxNHKzug9boE0CVLCShUnqyRERC2yBE4ljEFK9S50A">Huly&reg;: <b>UBERF-6245</b></a></sub>