### PR TITLE
feat/add/add indication of copied url in `IssueNotification.svelte`

### DIFF
--- a/plugins/tracker-resources/src/components/issues/IssueNotification.svelte
+++ b/plugins/tracker-resources/src/components/issues/IssueNotification.svelte
@@ -17,6 +17,7 @@
 
   let issue: Issue | undefined = undefined
   let status: IssueStatus | undefined = undefined
+  let copiedSuccessfully : boolean = false
 
   const { subTitle, params } = notification
 
@@ -47,8 +48,21 @@
   }
 
   function handleCopyUrl (): void {
+    copiedSuccessfully=true
+
+  
+    
     if (issue !== undefined) {
       void copyTextToClipboard(params?.issueUrl)
+      .then(() => {
+        copiedSuccessfully=true
+      })
+      .catch((error) => {
+          console.error('Failed to copy URL to clipboard:', error);
+          copiedSuccessfully = false;
+        });
+       
+   
     }
   }
 </script>
@@ -74,5 +88,10 @@
   <svelte:fragment slot="buttons">
     <Button label={tracker.string.ViewIssue} on:click={handleIssueOpened} />
     <Button icon={view.icon.CopyLink} label={tracker.string.CopyIssueUrl} on:click={handleCopyUrl} />
+
+    {#if copiedSuccessfully}
+    <div class="alert alert-success">Copied to clipboard successfully!</div>
+  {/if}
+   
   </svelte:fragment>
 </NotificationToast>

--- a/rush.json
+++ b/rush.json
@@ -62,7 +62,7 @@
      * The default value is false to avoid legacy compatibility issues.
      * It is strongly recommended to set strictPeerDependencies=true.
      */
-    "strictPeerDependencies": false,
+    "strictPeerDependencies": false
 
     /**
      * Configures the strategy used to select versions during installation.
@@ -247,14 +247,12 @@
     //   "[^@]+@users\\.noreply\\.github\\.com",
     //   "travis@example\\.org"
     // ],
-
     /**
      * When Rush reports that the address is malformed, the notice can include an example
      * of a recommended email.  Make sure it conforms to one of the allowedEmailRegExps
      * expressions.
      */
     // "sampleEmail": "mrexample@users.noreply.github.com",
-
     /**
      * The commit message to use when committing changes during 'rush publish'.
      *
@@ -263,7 +261,6 @@
      * in the commit message, and then customize Rush's message to contain that string.
      */
     // "versionBumpCommitMessage": "Applying package updates. [skip-ci]",
-
     /**
      * The commit message to use when committing changes during 'rush version'.
      *
@@ -1087,7 +1084,7 @@
       "shouldPublish": false
     },
     {
-    "packageName": "@hcengineering/tags",
+      "packageName": "@hcengineering/tags",
       "projectFolder": "plugins/tags",
       "shouldPublish": true
     },


### PR DESCRIPTION
**Pull Request Requirements:**

Add feature of indication of copy issue URL.

<img width="477" src="https://github.com/hcengineering/platform/assets/86048784/affeb143-a387-4d06-bcd2-8319a8cc4461" alt="Screenshot 2024-04-01 at 10 54 33 PM">

* Provide a brief description of the changeset.
* Include a screenshots if applicable
* Ensure that the changeset adheres to the [DCO guidelines](https://github.com/apps/dco).

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBhZWU4ZGU1MGZjYjI5NThiMDU1MGQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.rsR4jiWWxfVIhPpXpovtpdfp86YWAgQ1YJR7_QO24Kc">Huly&reg;: <b>UBERF-6259</b></a></sub>