### PR TITLE
Feature: Creatable dropdown feature with create category in product

### DIFF
--- a/packages/ui/src/components/DropdownLabels.svelte
+++ b/packages/ui/src/components/DropdownLabels.svelte
@@ -29,6 +29,7 @@
   export let placeholder: IntlString | undefined = ui.string.SearchDots
   export let items: DropdownTextItem[]
   export let multiselect = false
+  export let creatable = false
   export let selected: DropdownTextItem['id'] | Array<DropdownTextItem['id']> | undefined = multiselect ? [] : undefined
   export let allowDeselect: boolean = false
   export let showDropdownIcon: boolean = false
@@ -46,15 +47,25 @@
 
   export let enableSearch: boolean = true
 
+  export let newoption: boolean = false
+
   let container: HTMLElement
   let opened: boolean = false
+  const dispatch = createEventDispatcher()
+  function getSelectedItem(items: DropdownTextItem[],creatable: boolean,selected?: string | string[]) {
+    if(creatable && selected && !items.some(item => item.id === selected)) {
+      dispatch('newoption', selected)
+      newoption = true
+      return { id: selected, label: selected }
+    }
+    return multiselect ? items.filter((p) => selected?.includes(p.id)) : items.find((x) => x.id === selected)
+  }
 
-  $: selectedItem = multiselect ? items.filter((p) => selected?.includes(p.id)) : items.find((x) => x.id === selected)
+  $: selectedItem = getSelectedItem(items, creatable, selected)
   $: if (autoSelect && selected === undefined && items[0] !== undefined) {
     selected = multiselect ? [items[0].id] : items[0].id
   }
 
-  const dispatch = createEventDispatcher()
   const mgr = getFocusManager()
 </script>
 
@@ -73,7 +84,7 @@
         opened = true
         showPopup(
           DropdownLabelsPopup,
-          { placeholder, items, multiselect, selected, enableSearch },
+          { placeholder, items, multiselect,creatable, selected, enableSearch },
           container,
           (result) => {
             if (result != null) {

--- a/packages/ui/src/components/DropdownLabelsPopup.svelte
+++ b/packages/ui/src/components/DropdownLabelsPopup.svelte
@@ -27,6 +27,7 @@
   export let placeholder: IntlString = plugin.string.SearchDots
   export let placeholderParam: any | undefined = undefined
   export let items: DropdownTextItem[]
+  export let creatable: boolean = false
   export let selected: DropdownTextItem['id'] | Array<DropdownTextItem['id']> | undefined = undefined
   export let multiselect: boolean = false
   export let enableSearch = true
@@ -37,7 +38,17 @@
   let selection = 0
   let list: ListView
 
-  $: objects = items.filter((x) => x.label.toLowerCase().includes(search.toLowerCase()))
+  function getFilteredObjects(items:DropdownTextItem[] , search: string, creatable: boolean) {
+    const filteredItems = items.filter((x) => x.label.toLowerCase().includes(search.toLowerCase()));
+    const isNewObject = creatable && search && !filteredItems.some(item => item.label.toLowerCase() === search.toLowerCase());
+
+    return [
+        ...filteredItems,
+        ...(isNewObject ? [{ id: search, label: `Create "${search}"` }] : [])
+    ];
+}
+
+  $: objects = getFilteredObjects(items, search, creatable)
 
   async function handleSelection (evt: Event | undefined, selection: number): Promise<void> {
     const item = objects[selection]

--- a/plugins/inventory-resources/src/components/CreateProduct.svelte
+++ b/plugins/inventory-resources/src/components/CreateProduct.svelte
@@ -32,7 +32,7 @@
     modifiedOn: Date.now(),
     modifiedBy: '' as Ref<Account>
   }
-
+  export let newCategory = false;
   const dispatch = createEventDispatcher()
   const client = getClient()
 
@@ -41,11 +41,23 @@
   }
 
   async function create () {
-    const categoryInstance = await client.findOne(inventory.class.Category, { _id: doc.attachedTo as Ref<Category> })
+    let id = doc.attachedTo;
+   
+    if(newCategory) {
+      id = await client.addCollection(
+        inventory.class.Category,
+        inventory.space.Category,
+        inventory.global.Category,
+        inventory.class.Category,
+        'categories',
+        { name: doc.attachedTo },
+        generateId()
+      )
+    }
+    const categoryInstance = await client.findOne(inventory.class.Category, { _id: id as Ref<Category> })
     if (categoryInstance === undefined) {
       throw new Error('category not found')
     }
-
     await client.addCollection(
       inventory.class.Product,
       doc.space,
@@ -87,6 +99,8 @@
       items={categories}
       kind={'regular'}
       size={'large'}
+      creatable={true}
+      bind:newoption={newCategory}
       bind:selected={doc.attachedTo}
       placeholder={inventory.string.Categories}
       label={inventory.string.Category}


### PR DESCRIPTION
**Pull Request Requirements:**

<img width="844" src="https://github.com/hcengineering/platform/assets/33999269/0b761c2d-7dc2-43da-a8fb-24f7f9a689c8" alt="Screenshot 2024-04-02 at 12 58 01 AM">

Added functionality for creating new element in the dropdown if doesn't exist, it can be used for creating thing which only require single string like a category, tags, skills and so on.

* Added creatable flag in DropdownLabelsPopup which add option to add new item based on specific condition when creatable flag is passed as props, search has some value and if that element already doesn't exist in the dropdown
* Updated DropdownLabels with same flag creatable and modified the logic to update the selected item and also trigged the newoption binding if new element is created i.e parent element can handle it as we are only passing single string in dropdown.
* Updated CreateProduct component to pass the createable flag and created the category in case it's created from dropdown when creating new product.

There can still be multiple bugs in this, so please guide me through it if you find any.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBiMGU0OGU1MGZjYjI5NThiMDU3MDQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.gDCGNbLdVKJiTf-M8lo_F9ecBf1__pLFlfQ8N7Xt7RE">Huly&reg;: <b>UBERF-6260</b></a></sub>