### PR TITLE
Fix a undefined error on search modal

### DIFF
--- a/plugins/view-resources/src/components/ActionsPopup.svelte
+++ b/plugins/view-resources/src/components/ActionsPopup.svelte
@@ -157,7 +157,7 @@
 
   async function handleSelection (evt: Event, selection: number): Promise<void> {
     const item = items[selection]
-    if (item == null) {
+    if (item == null || item.actionCategory == undefined) {
       return
     }
     if (item.item !== undefined) {
@@ -376,9 +376,9 @@
               </div>
             {/if}
             {#if item.action !== undefined}
-              {@const action = item.action}
-              <div class="flex-row-center flex-between flex-grow ml-2 text-base cursor-pointer actionsitem">
-                <div class="mr-4 {selection === num ? 'caption-color' : 'content-dark-color'}">
+            {@const action = item.action}
+            <div class="flex-row-center flex-between flex-grow ml-2 text-base cursor-pointer actionsitem">
+              <div class="mr-4 {selection === num ? 'caption-color' : 'content-dark-color'}">
                   <Icon icon={action.icon ?? IconArrowLeft} size={'small'} />
                 </div>
                 <div class="flex-grow {selection === num ? 'caption-color' : 'content-color'}">


### PR DESCRIPTION
Fixed:

When a user tries to search something, and click on back arrow button. the application crashes with error `undefined length`

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBiZDUzNGU1MGZjYjI5NThiMDVhMjciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.NcvZma32ES3jGYTJBkcp2FvwBMjizq-JzoA-ovXaBm0">Huly&reg;: <b>UBERF-6272</b></a></sub>