### PR TITLE
Inbox duplication of the same DocNotifyContext

### DIFF
--- a/packages/ui/src/components/ListView.svelte
+++ b/packages/ui/src/components/ListView.svelte
@@ -27,7 +27,7 @@
   export let updateOnMouse = true
   export let lazy = false
   export let highlightIndex: number | undefined = undefined
-  export let getKey: (index: number) => string = (index) => index.toString()
+  const getKey: (index: number) => string = (index) => index.toString()
 
   const refs: HTMLElement[] = []
 

--- a/plugins/notification-resources/src/components/inbox/InboxGroupedListView.svelte
+++ b/plugins/notification-resources/src/components/inbox/InboxGroupedListView.svelte
@@ -98,12 +98,6 @@
   $: if (element != null) {
     element.focus()
   }
-
-  function getContextKey (index: number): string {
-    const contextId = displayData[index][0]
-
-    return contextId ?? index.toString()
-  }
 </script>
 
 <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
@@ -118,7 +112,6 @@
     kind="full-size"
     colorsSchema="lumia"
     lazy={true}
-    getKey={getContextKey}
   >
     <svelte:fragment slot="item" let:item={itemIndex}>
       {@const contextId = displayData[itemIndex][0]}


### PR DESCRIPTION
Changed logic for getting the key for `each` loop.

<sub>View in Huly <a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBjMGM3NmU1MGZjYjI5NThiMDVjZTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.sVbsi9ZeYlmNNCnLqrX45dSRBWwtxi8Gn-Rkak2nWBM">UBERF-6284</a></sub>