### PR TITLE
Fix tab navigation order in issue creation popup

### DIFF
--- a/packages/ui/src/components/calendar/DatePresenter.svelte
+++ b/packages/ui/src/components/calendar/DatePresenter.svelte
@@ -32,7 +32,6 @@
   export let mode: DateRangeMode = DateRangeMode.DATE
   export let mondayStart: boolean = true
   export let editable: boolean = false
-  export let input: HTMLButtonElement | undefined = undefined
   export let icon: Asset | AnySvelteComponent | ComponentType | undefined = undefined
   export let iconModifier: 'normal' | 'warning' | 'critical' | 'overdue' = 'normal'
   export let shouldIgnoreOverdue: boolean = false
@@ -51,6 +50,7 @@
   let currentDate: Date | null = null
   if (value != null) currentDate = new Date(value)
   let opened: boolean = false
+  let input: HTMLButtonElement | undefined = undefined
 
   const onChange = (result: Date | null): void => {
     if (result === null) {

--- a/packages/ui/src/components/calendar/DatePresenter.svelte
+++ b/packages/ui/src/components/calendar/DatePresenter.svelte
@@ -26,11 +26,13 @@
   import DPCalendar from './icons/DPCalendar.svelte'
   import DPCalendarOver from './icons/DPCalendarOver.svelte'
   import { getMonthName } from './internal/DateUtils'
+  import { registerFocus } from '../../focus'
 
   export let value: number | null | undefined
   export let mode: DateRangeMode = DateRangeMode.DATE
   export let mondayStart: boolean = true
   export let editable: boolean = false
+  export let input: HTMLButtonElement | undefined = undefined
   export let icon: Asset | AnySvelteComponent | ComponentType | undefined = undefined
   export let iconModifier: 'normal' | 'warning' | 'critical' | 'overdue' = 'normal'
   export let shouldIgnoreOverdue: boolean = false
@@ -64,9 +66,30 @@
   }
 
   $: withTime = mode !== DateRangeMode.DATE
+
+  // Focusable control with index
+  export let focusIndex = -1
+  const { idx, focusManager } = registerFocus(focusIndex, {
+    focus: () => {
+      input?.focus()
+      return input != null
+    },
+    isFocus: () => document.activeElement === input
+  })
+
+  $: if (idx !== -1 && focusManager) {
+    focusManager.updateFocus(idx, focusIndex)
+  }
+
+  $: if (input != null) {
+    input.addEventListener('focus', () => {
+      focusManager?.setFocus(idx)
+    })
+  }
 </script>
 
 <button
+  bind:this={input}
   class="datetime-button {kind} {size}"
   class:editable
   class:dateTimeButtonNoLabel={!shouldShowLabel}

--- a/plugins/tags-resources/src/components/TagsDropdownEditor.svelte
+++ b/plugins/tags-resources/src/components/TagsDropdownEditor.svelte
@@ -34,6 +34,7 @@
   export let justify: 'left' | 'center' = 'center'
   export let width: string | undefined = undefined
   export let labelDirection: TooltipAlignment | undefined = undefined
+  export let focusIndex = -1
 
   export let disabled: boolean = false
 
@@ -90,6 +91,7 @@
   {kind}
   {size}
   {justify}
+  {focusIndex}
   showTooltip={{ label: key.attr.label, direction: labelDirection }}
   on:click={addTag}
 >

--- a/plugins/tracker-resources/src/components/CreateIssue.svelte
+++ b/plugins/tracker-resources/src/components/CreateIssue.svelte
@@ -956,6 +956,7 @@
     </div>
     <div id="duedate-editor" class="new-line">
       <DatePresenter
+        focusIndex={10}
         bind:value={object.dueDate}
         labelNull={tracker.string.DueDate}
         kind={'regular'}
@@ -965,6 +966,7 @@
     </div>
     <div id="parentissue-editor" class="new-line">
       <Button
+        focusIndex={11}
         icon={tracker.icon.Parent}
         label={object.parentIssue != null ? tracker.string.RemoveParent : tracker.string.SetParent}
         kind={'regular'}
@@ -991,7 +993,7 @@
   </svelte:fragment>
   <svelte:fragment slot="footer">
     <Button
-      focusIndex={10}
+      focusIndex={12}
       icon={IconAttachment}
       iconProps={{ fill: 'var(--theme-dark-color)' }}
       size={'large'}

--- a/plugins/tracker-resources/src/components/CreateIssue.svelte
+++ b/plugins/tracker-resources/src/components/CreateIssue.svelte
@@ -932,7 +932,7 @@
       }}
     />
     <ComponentSelector
-      focusIndex={8}
+      focusIndex={7}
       value={object.component}
       space={_space}
       onChange={handleComponentIdChanged}
@@ -941,7 +941,7 @@
       size={'large'}
     />
     <div id="estimation-editor" class="new-line">
-      <EstimationEditor focusIndex={7} kind={'regular'} size={'large'} value={object} />
+      <EstimationEditor focusIndex={8} kind={'regular'} size={'large'} value={object} />
     </div>
     <div id="milestone-editor" class="new-line">
       <MilestoneSelector


### PR DESCRIPTION
Fixes https://github.com/hcengineering/platform/issues/4493. When creating a new issue in the project's issue tracker, the Tab navigation was working out of order and not jumping to the next field. To adress this bug:

* Fixed the focus order of ComponentSelector and EstimationEditor
* TagsDropdownEditor was ignored when using Tab navigation, added the missing focusIndex to TagsDropdownEditor to address the issue

Now the tab button click traverses the components in correct order:

https://github.com/hcengineering/platform/assets/36786266/169d36cc-6ee6-4d11-bcf7-aec3fbcc3f21

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBjMjgwZmU1MGZjYjI5NThiMDVlNmUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.QG29JqxBma2WQVeGp2z3lLo-9BkIgYprJpj0wO4s1kg">Huly&reg;: <b>UBERF-6288</b></a></sub>