### PR TITLE
Assign last name to empty string on github login

### DIFF
--- a/pods/authProviders/src/github.ts
+++ b/pods/authProviders/src/github.ts
@@ -43,7 +43,7 @@ export function registerGithub (
     passport.authenticate('github', { failureRedirect: concatLink(frontUrl, '/login'), session: true }),
     async (ctx, next) => {
       const email = ctx.state.user.emails?.[0]?.value ?? `github:${ctx.state.user.username}`
-      const [first, last] = ctx.state.user.displayName.split(' ')
+      const [first, last = ""] = ctx.state.user.displayName.split(' ')
       if (email !== undefined) {
         if (ctx.query?.state != null) {
           const loginInfo = await joinWithProvider(ctx, db, productId, email, first, last, ctx.query.state, {


### PR DESCRIPTION
This solution will assign an empty string as the last name if the last name is null during GitHub login.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBkMmU4Yzc1NzhmZDkwY2I5ZDBmNDciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.MLVJX6W2BSaShgzvPjIafLIh15uMV6lm6Ubf8Ghwaxg">Huly&reg;: <b>UBERF-6304</b></a></sub>