### PR TITLE
Qfix: Restore ats task types tool

### DIFF
--- a/dev/tool/src/clean.ts
+++ b/dev/tool/src/clean.ts
@@ -653,7 +653,8 @@ export async function restoreRecruitingTaskTypes (
   transactorUrl: string
 ): Promise<void> {
   const connection = (await connect(transactorUrl, workspaceId, undefined, {
-    mode: 'backup'
+    mode: 'backup',
+    model: 'upgrade'
   })) as unknown as CoreClient & BackupClient
   const client = new MongoClient(mongoUrl)
   try {

--- a/dev/tool/src/clean.ts
+++ b/dev/tool/src/clean.ts
@@ -30,13 +30,18 @@ import core, {
   type Domain,
   type Ref,
   type TxCreateDoc,
-  type WorkspaceId
+  type WorkspaceId,
+  type StatusCategory,
+  type TxMixin,
+  type TxCUD
 } from '@hcengineering/core'
 import { getWorkspaceDB } from '@hcengineering/mongo'
 import recruit from '@hcengineering/recruit'
+import recruitModel from '@hcengineering/model-recruit'
 import { type StorageAdapter } from '@hcengineering/server-core'
 import { connect } from '@hcengineering/server-tool'
 import tags, { type TagCategory, type TagElement, type TagReference } from '@hcengineering/tags'
+import task, { type ProjectType, type TaskType } from '@hcengineering/task'
 import tracker from '@hcengineering/tracker'
 import { deepEqual } from 'fast-equals'
 import { MongoClient } from 'mongodb'
@@ -640,4 +645,167 @@ function groupBy<T extends Doc> (docs: T[], key: string): Record<any, T[]> {
 
     return storage
   }, {})
+}
+
+export async function restoreRecruitingTaskTypes (
+  mongoUrl: string,
+  workspaceId: WorkspaceId,
+  transactorUrl: string
+): Promise<void> {
+  const connection = (await connect(transactorUrl, workspaceId, undefined, {
+    mode: 'backup'
+  })) as unknown as CoreClient & BackupClient
+  const client = new MongoClient(mongoUrl)
+  try {
+    await client.connect()
+    const db = getWorkspaceDB(client, workspaceId)
+
+    // Query all vacancy project types creations (in Model)
+    // We only update new project types in model here and not old ones in spaces
+    const vacancyTypes = await connection.findAll<TxCreateDoc<ProjectType>>(core.class.TxCreateDoc, {
+      objectClass: task.class.ProjectType,
+      objectSpace: core.space.Model,
+      'attributes.descriptor': recruit.descriptors.VacancyType
+    })
+
+    console.log('Found ', vacancyTypes.length, ' vacancy types to check')
+
+    if (vacancyTypes.length === 0) {
+      return
+    }
+
+    const descr = connection.getModel().getObject(recruit.descriptors.VacancyType)
+    const knownCategories = [
+      task.statusCategory.UnStarted,
+      task.statusCategory.Active,
+      task.statusCategory.Won,
+      task.statusCategory.Lost
+    ]
+
+    function compareCategories (a: Ref<StatusCategory>, b: Ref<StatusCategory>): number {
+      const indexOfA = knownCategories.indexOf(a)
+      const indexOfB = knownCategories.indexOf(b)
+
+      return indexOfA - indexOfB
+    }
+
+    for (const vacType of vacancyTypes) {
+      for (const taskTypeId of vacType.attributes.tasks) {
+        // Check if task type create TX exists
+        const createTx = (
+          await connection.findAll<TxCreateDoc<TaskType>>(core.class.TxCreateDoc, {
+            objectClass: task.class.TaskType,
+            objectSpace: core.space.Model,
+            objectId: taskTypeId
+          })
+        )[0]
+
+        console.log('####################################')
+        console.log('Checking vacancy type: ', vacType.attributes.name)
+
+        if (createTx !== undefined) {
+          console.log('Task type already exists in model')
+          continue
+        }
+
+        console.log('Restoring task type: ', taskTypeId, ' in vacancy type: ', vacType.attributes.name)
+
+        // Restore create task type tx
+
+        // Get target class mixin
+
+        const typeMixin = (
+          await connection.findAll<TxMixin<any, any>>(core.class.TxMixin, {
+            mixin: task.mixin.TaskTypeClass,
+            'attributes.projectType': vacType.objectId,
+            'attributes.taskType': taskTypeId
+          })
+        )[0]
+
+        if (typeMixin === undefined) {
+          console.error(new Error('No type mixin found for the task type being restored'))
+          continue
+        }
+
+        // Get statuses and categories
+        const statusesIds = vacType.attributes.statuses.filter((s) => s.taskType === taskTypeId).map((s) => s._id)
+        if (statusesIds.length === 0) {
+          console.error(new Error('No statuses defined for the task type being restored'))
+          continue
+        }
+
+        const statuses = await connection.findAll(core.class.Status, {
+          _id: { $in: statusesIds }
+        })
+        const categoriesIds = new Set<Ref<StatusCategory>>()
+
+        statuses.forEach((st) => {
+          if (st.category !== undefined) {
+            categoriesIds.add(st.category)
+          }
+        })
+
+        if (categoriesIds.size === 0) {
+          console.error(new Error('No categories found for the task type being restored'))
+          continue
+        }
+
+        const statusCategories = Array.from(categoriesIds)
+
+        statusCategories.sort(compareCategories)
+
+        const createTxNew: TxCreateDoc<TaskType> = {
+          _id: generateId(),
+          _class: core.class.TxCreateDoc,
+          space: core.space.Tx,
+          objectId: taskTypeId,
+          objectClass: task.class.TaskType,
+          objectSpace: core.space.Model,
+          modifiedBy: core.account.ConfigUser, // So it's not removed during the next migration
+          modifiedOn: vacType.modifiedOn,
+          createdOn: vacType.createdOn,
+          attributes: {
+            name: 'Applicant',
+            descriptor: recruitModel.descriptors.Application,
+            ofClass: recruit.class.Applicant,
+            targetClass: typeMixin.objectId,
+            statusClass: core.class.Status,
+            allowedAsChildOf: [taskTypeId],
+            statuses: statusesIds,
+            statusCategories,
+            parent: vacType.objectId,
+            kind: 'both',
+            icon: descr.icon
+          }
+        }
+
+        await db.collection<Doc>(DOMAIN_TX).insertOne(createTxNew)
+        console.log('Successfully created new task type: ')
+        console.log(createTxNew)
+
+        // If there were updates to the task type - move them to the model
+        const updateTxes = (
+          await connection.findAll(core.class.TxCUD, {
+            objectClass: task.class.TaskType,
+            objectSpace: vacType.objectId as any,
+            objectId: taskTypeId
+          })
+        ).filter((tx) => [core.class.TxUpdateDoc, core.class.TxRemoveDoc].includes(tx._class))
+
+        for (const updTx of updateTxes) {
+          await db.collection<TxCUD<Doc>>(DOMAIN_TX).insertOne({
+            ...updTx,
+            _id: generateId(),
+            objectSpace: core.space.Model
+          })
+        }
+        console.log('Successfully restored ', updateTxes.length, ' CUD transactions')
+      }
+    }
+  } catch (err: any) {
+    console.trace(err)
+  } finally {
+    await client.close()
+    await connection.close()
+  }
 }

--- a/dev/tool/src/index.ts
+++ b/dev/tool/src/index.ts
@@ -75,6 +75,7 @@ import {
   fixCommentDoubleIdCreate,
   fixMinioBW,
   fixSkills,
+  restoreRecruitingTaskTypes,
   optimizeModel
 } from './clean'
 import { checkOrphanWorkspaces } from './cleanOrphan'
@@ -795,6 +796,15 @@ export function devTool (
     .action(async (workspace: string, step: string) => {
       const { mongodbUri } = prepareTools()
       await fixSkills(mongodbUri, getWorkspaceId(workspace, productId), transactorUrl, step)
+    })
+
+  program
+    .command('restore-ats-types <workspace>')
+    .description('Restore recruiting task types for workspace')
+    .action(async (workspace: string, step: string) => {
+      const { mongodbUri } = prepareTools()
+      console.log('Restoring recruiting task types in workspace ', workspace, '...')
+      await restoreRecruitingTaskTypes(mongodbUri, getWorkspaceId(workspace, productId), transactorUrl)
     })
 
   program


### PR DESCRIPTION
* Adds a new tool command that restores missing recruiting task types' create Txes.

Usage: ... restore-ats-types {workspace}

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBlNjVjOTY4ZWY5NjM0ZDNmMDMyOTAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.UBROfbnOs1HrOsSZL9Cc0Zz0Hqi8nVQVK3_swmA3R1Q">Huly&reg;: <b>UBERF-6345</b></a></sub>