### PR TITLE
Upgrade docker compose version to 3.8

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.8"
 services:
   mongodb:
     image: 'mongo:7-jammy'

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.8"
 services:
   mongodb:
     image: 'mongo:7-jammy'


### PR DESCRIPTION
The pull_policy option in Docker Compose files is supported starting from version 3.7 of the Docker Compose file format.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBlOGRlMDY4ZWY5NjM0ZDNmMDMzZTYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.VnqhUhd941DKc4qzRnNbwHuhj06fHSkZ3jFl3QyC4XY">Huly&reg;: <b>UBERF-6348</b></a></sub>