### PR TITLE
EZQMS-663: Add permissions util

### DIFF
--- a/plugins/view-resources/src/utils.ts
+++ b/plugins/view-resources/src/utils.ts
@@ -1333,10 +1333,14 @@ async function getAttrEditor (key: KeyedAttribute, hierarchy: Hierarchy): Promis
 
 type PermissionsBySpace = Record<Ref<Space>, Set<Ref<Permission>>>
 type AccountsByPermission = Record<Ref<Space>, Record<Ref<Permission>, Set<Ref<Account>>>>
-interface PermissionsStore {
+export interface PermissionsStore {
   ps: PermissionsBySpace
   ap: AccountsByPermission
   whitelist: Set<Ref<Space>>
+}
+
+export function checkMyPermission (_id: Ref<Permission>, space: Ref<Space>, store: PermissionsStore): boolean {
+  return (store.whitelist.has(space) || store.ps[space]?.has(_id)) ?? false
 }
 
 export const permissionsStore = writable<PermissionsStore>({

--- a/plugins/view-resources/src/utils.ts
+++ b/plugins/view-resources/src/utils.ts
@@ -1339,7 +1339,7 @@ export interface PermissionsStore {
   whitelist: Set<Ref<Space>>
 }
 
-export function checkMyPermission (_id: Ref<Permission>, space: Ref<Space>, store: PermissionsStore): boolean {
+export function checkMyPermission (_id: Ref<Permission>, space: Ref<TypedSpace>, store: PermissionsStore): boolean {
   return (store.whitelist.has(space) || store.ps[space]?.has(_id)) ?? false
 }
 


### PR DESCRIPTION
Adds a new utility to check permissions reactively.

https://front.hc.engineering/workbench/platform/tracker/EZQMS-663

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBlOWM5NzY4ZWY5NjM0ZDNmMDM0NGQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.TDJM4OalgLL8tNt9xkCSccTlPzRpVqahKfemYwoOttg">Huly&reg;: <b>UBERF-6349</b></a></sub>