### PR TITLE
fix Some of emojis are not displayed properly as icons

### DIFF
--- a/packages/ui/src/components/EmojiPopup.svelte
+++ b/packages/ui/src/components/EmojiPopup.svelte
@@ -16,7 +16,7 @@
   import { tooltip } from '../tooltips'
   import { AnySvelteComponent, emojiSP } from '../types'
   import plugin from '../plugin'
-  import { fromCodePoint } from '../utils'
+  import { codepointsToEmoji, emojiToCodepoints, fromCodePoint } from '../utils'
 
   export let embedded = false
   export let selected: string | undefined
@@ -52,13 +52,15 @@
         String.fromCodePoint(0x1f44b, 0x1f3fc),
         String.fromCodePoint(0x1f44d, 0x1f3fc),
         String.fromCodePoint(0x1f44c, 0x1f3fc)
-      ],
+      ].map((emoji) => (emoji ? codepointsToEmoji(emojiToCodepoints(emoji)) : undefined)),
       icon: Work
     },
     {
       id: 'smileys',
       label: plugin.string.Smileys,
-      emojis: [...getEmojis(0x1f600, 0x1f64f), ...getEmojis(0x1f90c, 0x1f92f)],
+      emojis: [...getEmojis(0x1f600, 0x1f64f), ...getEmojis(0x1f90c, 0x1f92f)].map((emoji) =>
+        emoji ? codepointsToEmoji(emojiToCodepoints(emoji)) : undefined
+      ),
       icon: Emoji
     },
     {
@@ -71,25 +73,25 @@
         ...getEmojis(0x1f300, 0x1f320),
         ...getEmojis(0x1f324, 0x1f32c, [0xfe0f]),
         ...getEmojis(0x2600, 0x2604, [0xfe0f])
-      ],
+      ].map(emoji => emoji ? codepointsToEmoji(emojiToCodepoints(emoji)) : undefined),
       icon: Nature
     },
     {
       id: 'travels',
       label: plugin.string.TravelAndPlaces,
-      emojis: [...getEmojis(0x1f5fb, 0x1f5ff), ...getEmojis(0x1f3e0, 0x1f3f0), ...getEmojis(0x1f680, 0x1f6a3)],
+      emojis: [...getEmojis(0x1f5fb, 0x1f5ff), ...getEmojis(0x1f3e0, 0x1f3f0), ...getEmojis(0x1f680, 0x1f6a3)].map(emoji => emoji ? codepointsToEmoji(emojiToCodepoints(emoji)) : undefined),
       icon: Places
     },
     {
       id: 'food',
       label: plugin.string.Food,
-      emojis: [...getEmojis(0x1f345, 0x1f37f), ...getEmojis(0x1f32d, 0x1f32f)],
+      emojis: [...getEmojis(0x1f345, 0x1f37f), ...getEmojis(0x1f32d, 0x1f32f)].map(emoji => emoji ? codepointsToEmoji(emojiToCodepoints(emoji)) : undefined),
       icon: Food
     },
     {
       id: 'objects',
       label: plugin.string.Objects,
-      emojis: [...getEmojis(0x1f4b6, 0x1f4fc)],
+      emojis: [...getEmojis(0x1f4b6, 0x1f4fc)].map(emoji => emoji ? codepointsToEmoji(emojiToCodepoints(emoji)) : undefined),
       icon: Objects
     },
     {
@@ -100,14 +102,14 @@
         ...getEmojis(0x2764, 0x2b07, [0xfe0f]),
         ...getEmojis(0x0023, 0x0039, [0xfe0f, 0x20e3]),
         ...getEmojis(0x1f532, 0x1f53d)
-      ],
+      ].map(emoji => emoji ? codepointsToEmoji(emojiToCodepoints(emoji)) : undefined),
       icon: Symbols
     }
   ]
 
   let currentCategory = categories[0]
 
-  function getEmojis (startCode: number, endCode: number, postfix?: number[]): Array<string | undefined> {
+  function getEmojis(startCode: number, endCode: number, postfix?: number[]): Array<string | undefined> {
     return [...Array(endCode - startCode + 1).keys()].map((v) => {
       const str = postfix ? fromCodePoint(v + startCode, ...postfix) : fromCodePoint(v + startCode)
       if ([...str.matchAll(regex)].length > 0) return str
@@ -115,7 +117,7 @@
     })
   }
 
-  function handleScrollToCategory (categoryId: string) {
+  function handleScrollToCategory(categoryId: string) {
     const labelElement = document.getElementById(categoryId)
 
     if (labelElement) {
@@ -124,7 +126,7 @@
     }
   }
 
-  function handleCategoryScrolled () {
+  function handleCategoryScrolled() {
     const selectedCategory = categories.find((category) => {
       const labelElement = document.getElementById(category.id)
 

--- a/packages/ui/src/utils.ts
+++ b/packages/ui/src/utils.ts
@@ -24,7 +24,7 @@ import { deviceSizes, type AnyComponent, type AnySvelteComponent, type WidthType
 /**
  * @public
  */
-export function setMetadataLocalStorage<T> (id: Metadata<T>, value: T | null): void {
+export function setMetadataLocalStorage<T>(id: Metadata<T>, value: T | null): void {
   if (value != null) {
     localStorage.setItem(id, typeof value === 'string' ? value : JSON.stringify(value))
   } else {
@@ -36,7 +36,7 @@ export function setMetadataLocalStorage<T> (id: Metadata<T>, value: T | null): v
 /**
  * @public
  */
-export function fetchMetadataLocalStorage<T> (id: Metadata<T>): T | null {
+export function fetchMetadataLocalStorage<T>(id: Metadata<T>): T | null {
   const data = localStorage.getItem(id)
   if (data === null) {
     return null
@@ -54,34 +54,34 @@ export function fetchMetadataLocalStorage<T> (id: Metadata<T>): T | null {
 /**
  * @public
  */
-export function checkMobile (): boolean {
+export function checkMobile(): boolean {
   return /Android|webOS|iPhone|iPad|iPod|BlackBerry|Mobile|Opera Mini/i.test(navigator.userAgent)
 }
 
 /**
  * @public
  */
-export function isSafari (): boolean {
+export function isSafari(): boolean {
   return navigator.userAgent.toLowerCase().includes('safari/')
 }
 
 /**
  * @public
  */
-export function checkAdaptiveMatching (size: WidthType | null, limit: WidthType): boolean {
+export function checkAdaptiveMatching(size: WidthType | null, limit: WidthType): boolean {
   const range = new Set(deviceSizes.slice(0, deviceSizes.findIndex((ds) => ds === limit) + 1))
   return size !== null ? range.has(size) : false
 }
 
 // TODO: Fix naming, since it doesn't floor (floorFractionDigits(2.5) === 3.0)
-export function floorFractionDigits (n: number | string, amount: number): number {
+export function floorFractionDigits(n: number | string, amount: number): number {
   return Number(Number(n).toFixed(amount))
 }
 
 /**
  * @public
  */
-export function addNotification (
+export function addNotification(
   title: string,
   subTitle: string,
   component: AnyComponent | AnySvelteComponent,
@@ -103,11 +103,10 @@ export function addNotification (
     notificationsStore.addNotification(notification)
   }
 }
-
 /**
  * @public
  */
-export function handler<T, EVT = MouseEvent> (target: T, op: (value: T, evt: EVT) => void): (evt: EVT) => void {
+export function handler<T, EVT = MouseEvent>(target: T, op: (value: T, evt: EVT) => void): (evt: EVT) => void {
   return (evt: EVT) => {
     op(target, evt)
   }
@@ -116,7 +115,7 @@ export function handler<T, EVT = MouseEvent> (target: T, op: (value: T, evt: EVT
 /**
  * @public
  */
-export function tableToCSV (tableId: string, separator = ','): string {
+export function tableToCSV(tableId: string, separator = ','): string {
   const rows = document.querySelectorAll('table#' + tableId + ' tr')
   // Construct csv
   const csv: string[] = []
@@ -144,7 +143,7 @@ let attractorMy: number | undefined
 /**
  * perform mouse movement checks and call method if they was
  */
-export function mouseAttractor (op: () => void, diff = 2): (evt: MouseEvent) => void {
+export function mouseAttractor(op: () => void, diff = 2): (evt: MouseEvent) => void {
   return (evt: MouseEvent) => {
     if (attractorMy !== undefined && attractorMx !== undefined) {
       const dx = evt.screenX - attractorMx
@@ -172,7 +171,7 @@ export function mouseAttractor (op: () => void, diff = 2): (evt: MouseEvent) => 
  * @param {string} text
  * @returns {string} string with replaced URLs
  */
-export function replaceURLs (text: string): string {
+export function replaceURLs(text: string): string {
   try {
     return autolinker.link(text, {
       urls: true,
@@ -198,7 +197,7 @@ export function replaceURLs (text: string): string {
  * @param {string} text
  * @returns {string} string with parsed URL
  */
-export function parseURL (text: string): string {
+export function parseURL(text: string): string {
   const matches = autolinker.parse(text, { urls: true })
   return matches.length > 0 ? matches[0].getAnchorHref() : ''
 }
@@ -215,7 +214,7 @@ export interface IModeSelector<Mode extends string = string> {
 /**
  * @public
  */
-export function capitalizeFirstLetter (str: string): string {
+export function capitalizeFirstLetter(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
@@ -224,7 +223,7 @@ const isMac = /Macintosh/i.test(navigator.userAgent)
 /**
  * @public
  */
-export function formatKey (key: string): string[][] {
+export function formatKey(key: string): string[][] {
   const thens = key.split('->')
   const result: string[][] = []
   for (const r of thens) {
@@ -245,17 +244,33 @@ export function formatKey (key: string): string[][] {
   return result
 }
 
-export function fromCodePoint (...vals: number[]): string {
+export function fromCodePoint(...vals: number[]): string {
   return String.fromCodePoint(...vals.map((p) => Math.abs(p) % 0x10ffff))
 }
 
+export function emojiToCodepoints(emoji: string): number[] {
+  const codepoints: number[] = []
+  let i = 0
+  while (i < emoji.length) {
+    const value = emoji.codePointAt(i)
+    if (value !== undefined) {
+      codepoints.push(value)
+      i += value > 0xffff ? 2 : 1
+    }
+  }
+  return codepoints
+}
+
+export function codepointsToEmoji(codepoints: number[]): string {
+  return String.fromCodePoint(...codepoints)
+}
 /**
  * @public
  */
 export class DelayedCaller {
   op?: () => void
-  constructor (readonly delay: number = 10) {}
-  call (op: () => void): void {
+  constructor(readonly delay: number = 10) {}
+  call(op: () => void): void {
     const needTimer = this.op === undefined
     this.op = op
     if (needTimer) {


### PR DESCRIPTION
* fix #4942
* The `emojiToCodepoints` function converts an emoji to its Unicode codepoints. The `codepointsToEmoji` function does the reverse, converting Unicode codepoints back into an emoji string, and thus giving it in proper format.

  ![Screenshot 2024-04-04 184747](https://github.com/hcengineering/platform/assets/79590183/cebbbe0d-e15e-4bc4-b895-207c4a74d073)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBlYWZkMDY4ZWY5NjM0ZDNmMDM0ODYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.lFYAMxELfWBCZCsZy9UjCp2FU4nqh1jTpWtwuDZq3go">Huly&reg;: <b>UBERF-6350</b></a></sub>