### PR TITLE
Prevent empty label

### DIFF
--- a/plugins/tags-resources/src/components/CreateTagElement.svelte
+++ b/plugins/tags-resources/src/components/CreateTagElement.svelte
@@ -48,6 +48,10 @@
 
   let colorSet = false
 
+  function getTitle (value: string): string {
+    return value.trim()
+  }
+
   $: if (!colorSet) {
     color = getColorNumberByText(title)
   }
@@ -55,7 +59,8 @@
   $: if (!categoryWasSet && categories.length > 0) {
     category = findTagCategory(title, categories)
   }
-
+  $: canSave = getTitle(title).length > 0
+ 
   export function canClose (): boolean {
     return title === ''
   }
@@ -100,7 +105,7 @@
   label={tags.string.AddTag}
   labelProps={{ word: keyTitle }}
   okAction={createTagElementFnc}
-  canSave={title.length > 0}
+  {canSave}
   on:close={() => {
     dispatch('close')
   }}


### PR DESCRIPTION
# Change Summary

When creating a label, if you type a space, an empty label will be created. I trim the result in the validation to prevent this. I replicated the pattern I found in `plugins/tracker-resources/src/components/CreateIssue.svelte`

This is related to my investigation on [UBERF-6322](https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBkOTNmODg1M2Y5NTk2N2JhOTU4OWYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.e_bh4R0iV1GQV49MQUzJTNDuhf8JoZaLOLVo5zEc-kI), but I think this task may be referring to something else.

# Screenshots

## Bug (reproduced from main)

https://github.com/hcengineering/platform/assets/44687983/535e103f-6bb7-4112-ad7c-65ea50124ec9

## Fix

https://github.com/hcengineering/platform/assets/44687983/f3108535-2f14-4441-bf1e-1e989226d7aa

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBlYzA2YTY4ZWY5NjM0ZDNmMDM1ZmEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.Io7aCHl-tS_eqkMT1G7CLdAF3rS6Pnr7TwKSzwxtvGU">Huly&reg;: <b>UBERF-6354</b></a></sub>