### PR TITLE
Single z-index for tooltips and popups

### DIFF
--- a/packages/ui/src/components/Popup.svelte
+++ b/packages/ui/src/components/Popup.svelte
@@ -38,7 +38,7 @@
     element={popup.element}
     onClose={popup.onClose}
     onUpdate={popup.onUpdate}
-    zIndex={(i + 1) * 500}
+    zIndex={popup.options.zIndexOverride ?? (i + 1) * 500}
     top={$modal.length - 1 === i}
     close={popup.close}
     {contentPanel}

--- a/packages/ui/src/components/Popup.svelte
+++ b/packages/ui/src/components/Popup.svelte
@@ -13,7 +13,7 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  import { popupstore as modal } from '../popups'
+  import { popupstore as modal, zIndexPopupTooltip } from '../popups'
   import PopupInstance from './PopupInstance.svelte'
 
   export let contentPanel: HTMLElement | undefined = undefined
@@ -38,7 +38,7 @@
     element={popup.element}
     onClose={popup.onClose}
     onUpdate={popup.onUpdate}
-    zIndex={popup.options.zIndexOverride ?? (i + 1) * 500}
+    zIndex={zIndexPopupTooltip.findIndex((id) => id === popup.id) + 10000 ?? (i + 1) * 500}
     top={$modal.length - 1 === i}
     close={popup.close}
     {contentPanel}

--- a/packages/ui/src/components/TooltipInstance.svelte
+++ b/packages/ui/src/components/TooltipInstance.svelte
@@ -300,7 +300,7 @@
     style:width={options.width}
     style:height={options.height}
     style:transform={options.transform}
-    style:z-index={($tooltip.zIndex ?? 0) + 10000}
+    style:z-index={($tooltip.zIndex ?? 1) + 10000}
     bind:this={tooltipHTML}
   >
     {#if $tooltip.label}

--- a/packages/ui/src/components/TooltipInstance.svelte
+++ b/packages/ui/src/components/TooltipInstance.svelte
@@ -300,6 +300,7 @@
     style:width={options.width}
     style:height={options.height}
     style:transform={options.transform}
+    style:z-index={($tooltip.zIndex ?? 0) + 10000}
     bind:this={tooltipHTML}
   >
     {#if $tooltip.label}

--- a/packages/ui/src/popups.ts
+++ b/packages/ui/src/popups.ts
@@ -24,6 +24,7 @@ export interface CompAndProps {
     category: string
     overlay: boolean
     fixed?: boolean
+    zIndexOverride?: number
   }
 }
 
@@ -61,6 +62,7 @@ export function showPopup (
     category: string
     overlay: boolean
     fixed?: boolean
+    zIndexOverride?: number
   } = { category: 'popup', overlay: true }
 ): PopupResult {
   const id = `${popupId++}`

--- a/packages/ui/src/popups.ts
+++ b/packages/ui/src/popups.ts
@@ -24,9 +24,7 @@ export interface CompAndProps {
     category: string
     overlay: boolean
     fixed?: boolean
-    zIndexOverride?: number
   }
-  zIndex?: number
 }
 
 export interface PopupResult {
@@ -63,7 +61,6 @@ export function showPopup (
     category: string
     overlay: boolean
     fixed?: boolean
-    zIndexOverride?: number
   } = { category: 'popup', overlay: true }
 ): PopupResult {
   const id = `${popupId++}`

--- a/packages/ui/src/popups.ts
+++ b/packages/ui/src/popups.ts
@@ -26,6 +26,7 @@ export interface CompAndProps {
     fixed?: boolean
     zIndexOverride?: number
   }
+  zIndex?: number
 }
 
 export interface PopupResult {
@@ -44,7 +45,7 @@ export function updatePopup (id: string, props: Partial<CompAndProps>): void {
     return popups
   })
 }
-
+export const zIndexPopupTooltip: string[] = []
 function addPopup (props: CompAndProps): void {
   popupstore.update((popups) => {
     popups.push(props)
@@ -72,6 +73,7 @@ export function showPopup (
       if (pos !== -1) {
         popups.splice(pos, 1)
       }
+      zIndexPopupTooltip.pop()
       return popups
     })
   }
@@ -79,12 +81,14 @@ export function showPopup (
   if (typeof component === 'string') {
     getResource(component)
       .then((resolved) => {
+        zIndexPopupTooltip.push(id)
         addPopup({ id, is: resolved, props, element: _element, onClose, onUpdate, close: closePopupOp, options })
       })
       .catch((err) => {
         console.log(err)
       })
   } else {
+    zIndexPopupTooltip.push(id)
     addPopup({ id, is: component, props, element: _element, onClose, onUpdate, close: closePopupOp, options })
   }
   return {

--- a/packages/ui/src/tooltips.ts
+++ b/packages/ui/src/tooltips.ts
@@ -1,6 +1,7 @@
 import { type IntlString } from '@hcengineering/platform'
 import { writable } from 'svelte/store'
 import type { AnyComponent, AnySvelteComponent, LabelAndProps, TooltipAlignment } from './types'
+import { zIndexPopupTooltip } from './popups'
 
 const emptyTooltip: LabelAndProps = {
   label: undefined,
@@ -107,7 +108,8 @@ export function showTooltip (
     anchor,
     onUpdate,
     kind,
-    keys
+    keys,
+    zIndex: zIndexPopupTooltip.push(label as string)
   }
   tooltipstore.update((old) => {
     if (old.component === storedValue.component) {
@@ -126,4 +128,5 @@ export function closeTooltip (): void {
   clearTimeout(toHandler)
   storedValue = emptyTooltip
   tooltipstore.set(emptyTooltip)
+  zIndexPopupTooltip.pop()
 }

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -289,6 +289,7 @@ export interface LabelAndProps {
   onUpdate?: (result: any) => void
   kind?: 'tooltip' | 'submenu' | 'popup'
   keys?: string[]
+  zIndex?: number
 }
 
 export interface ListItem {

--- a/plugins/activity-resources/src/components/reactions/AddReactionAction.svelte
+++ b/plugins/activity-resources/src/components/reactions/AddReactionAction.svelte
@@ -39,11 +39,18 @@
 
   function openEmojiPalette (ev: Event) {
     dispatch('open')
-    showPopup(EmojiPopup, {}, ev.target as HTMLElement, (emoji: string) => {
-      updateDocReactions(client, reactions, object, emoji)
-      isOpened = false
-      dispatch('close')
-    })
+    showPopup(
+      EmojiPopup,
+      {},
+      ev.target as HTMLElement,
+      (emoji: string) => {
+        updateDocReactions(client, reactions, object, emoji)
+        isOpened = false
+        dispatch('close')
+      },
+      undefined,
+      { category: 'popup', overlay: true, zIndexOverride: 10002 }
+    )
 
     isOpened = true
   }

--- a/plugins/activity-resources/src/components/reactions/AddReactionAction.svelte
+++ b/plugins/activity-resources/src/components/reactions/AddReactionAction.svelte
@@ -48,8 +48,7 @@
         isOpened = false
         dispatch('close')
       },
-      undefined,
-      { category: 'popup', overlay: true, zIndexOverride: 10002 }
+      undefined
     )
 
     isOpened = true


### PR DESCRIPTION
Override zIndex for cases the popup opens from tooltip (ex.: comments)

![image](https://github.com/hcengineering/platform/assets/37306501/4bf30c57-1d97-4ff6-84eb-88fa37fa508c)