### PR TITLE
Chore: Disable dragging on Planner

### DIFF
--- a/plugins/time-resources/src/components/ToDoDraggable.svelte
+++ b/plugins/time-resources/src/components/ToDoDraggable.svelte
@@ -103,7 +103,7 @@
 <div
   class="hulyToDoLine-draggable {draggingOverClass} step-tb125"
   class:dragging={isDragging}
-  draggable={true}
+  draggable={isDraggable}
   on:dragstart={handleDragStart}
   on:dragend={handleDragEnd}
   on:dragover|preventDefault={handleDragOver}

--- a/plugins/time-resources/src/components/ToDoElement.svelte
+++ b/plugins/time-resources/src/components/ToDoElement.svelte
@@ -78,9 +78,11 @@
 >
   <div class="flex-row-top flex-grow flex-gap-2">
     <div class="flex-row-center flex-no-shrink">
-      <button class="hulyToDoLine-dragbox" class:isNew on:contextmenu={onMenuClick}>
-        <Icon icon={IconMoreV2} size={'small'} />
-      </button>
+      {#if !isDone}
+        <button class="hulyToDoLine-dragbox" class:isNew on:contextmenu={onMenuClick}>
+          <Icon icon={IconMoreV2} size={'small'} />
+        </button>
+      {/if}
       <div class="hulyToDoLine-statusPriority">
         <div class="hulyToDoLine-checkbox" class:updating>
           {#if updating !== undefined}


### PR DESCRIPTION
* Description

a. The planned TODOs in Planner app are still draggable, but it does not re-order finally. I think the dragging should be disabled on planned TODOs list.

b. The drag indicator at the start of TODO item for planned TODOs can be hidden.

* Changeset

a. The ToDoDraggable component's `draggable` prop is set to `isDraggable`

b. The drag indicator is only shown when `isDone` is false.

## Before

https://www.loom.com/share/8532c680f08641b48da095b53927272c?sid=a1b91b64-16eb-4144-8b55-afd5f6f533ba

## After

https://www.loom.com/share/25ae41ee2a2e4cdea6af3fa6b1e4ac2d?sid=86ef5efe-cb63-4b12-944b-ffb04449d2cb

* Include a screenshots if applicable
* Ensure that the changeset adheres to the [DCO guidelines](https://github.com/apps/dco).

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBmMDIxMjY4ZWY5NjM0ZDNmMDM3YjkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.-Up1PaBY-BwM4LJ3Vu0Iyjnjqu0py6E2qxmuEiR6vKI">Huly&reg;: <b>UBERF-6359</b></a></sub>