### PR TITLE
Test: Extend login tests for user enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,24 @@ This project offers a convenient method to host Huly using `docker`, designed fo
 
 ## Table of Content
 
-- [Pre-requisites](#pre-requisites)
-- [Fast start](#fast-start)
-- [Installation](#installation)
-- [Build and run](#build-and-run)
-- Development mode
+- [Huly Platform](#huly-platform)
+  - [About](#about)
+  - [Activity](#activity)
+  - [Self-Hosting](#self-hosting)
+  - [Table of Content](#table-of-content)
+  - [Pre-requisites](#pre-requisites)
+  - [Fast start](#fast-start)
+  - [Installation](#installation)
+  - [Build and run](#build-and-run)
   - [Run in development mode](#run-in-development-mode)
   - [Update project structure and database](#update-project-structure-and-database)
-  - Tests
-    - [Tests](#tests)
+  - [Troubleshooting](#troubleshooting)
+  - [Build \& Watch](#build--watch)
+  - [Tests](#tests)
     - [Unit tests](#unit-tests)
     - [UI tests](#ui-tests)
   - [Package publishing](#package-publishing)
+  - [Additional testing](#additional-testing)
 
 ## Pre-requisites
 
@@ -70,6 +76,7 @@ Support is available for both amd64 and arm64 containers on Linux and macOS.
 
 ```bash
 cd ./dev/
+rush install  # Will install package dependencies.
 rush build    # Will build all the required packages. 
 # rush rebuild  # could be used to omit build cache.
 rush bundle   # Will prepare bundles.
@@ -187,6 +194,7 @@ rush docker:build
 ## creates test Docker containers and sets up test database
 ./prepare.sh
 ## runs UI tests
+cd ./sanity
 rushx uitest
 ```
 

--- a/tests/sanity/tests/login.spec.ts
+++ b/tests/sanity/tests/login.spec.ts
@@ -1,10 +1,10 @@
-import { test } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import { PlatformUser } from './utils'
 import { LoginPage } from './model/login-page'
 import { SelectWorkspacePage } from './model/select-workspace-page'
 
 test.describe('login test', () => {
-  test('check login', async ({ page }) => {
+  test('check login with valid credentials', async ({ page }) => {
     page.on('pageerror', (exception) => {
       console.log('Uncaught exception:')
       console.log(exception.message)
@@ -15,5 +15,29 @@ test.describe('login test', () => {
 
     const selectWorkspacePage = new SelectWorkspacePage(page)
     await selectWorkspacePage.selectWorkspace('SanityTest')
+  })
+
+  test('check login with valid username and wrong password', async ({ page }) => {
+    page.on('pageerror', (exception) => {
+      console.log('Uncaught exception:')
+      console.log(exception.message)
+    })
+    const loginPage = new LoginPage(page)
+    await loginPage.goto()
+    await loginPage.login(PlatformUser, 'wrong_password')
+    const errDiv = page.locator('div.ERROR')
+    await expect(errDiv).toHaveText('Invalid username or password')
+  })
+
+  test('check login with invalid username', async ({ page }) => {
+    page.on('pageerror', (exception) => {
+      console.log('Uncaught exception:')
+      console.log(exception.message)
+    })
+    const loginPage = new LoginPage(page)
+    await loginPage.goto()
+    await loginPage.login('wrong_username', 'wrong_password')
+    const errDiv = page.locator('div.ERROR')
+    await expect(errDiv).toHaveText('Invalid username or password')
   })
 })


### PR DESCRIPTION
## Changes made

* Added test cases for invalid credentials to test **user enumeration** issue. Should return a generic error message
  * Tests login with a valid username and wrong password
  * Tests login with a invalid username and wrong password

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBmN2U0MjY4ZWY5NjM0ZDNmMDM4NGEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.uwg4G7Hkf_YDOH5rpx_Vu46eUuXy3yAoToF0ujfnjrg">Huly&reg;: <b>UBERF-6362</b></a></sub>