### PR TITLE
Improve 'Add Issue' Button Visibility

### DIFF
--- a/plugins/tracker-resources/src/components/issues/KanbanView.svelte
+++ b/plugins/tracker-resources/src/components/issues/KanbanView.svelte
@@ -498,12 +498,6 @@
     .counter {
       color: var(--theme-dark-color);
     }
-    .tools {
-      opacity: 0;
-    }
-    &:hover .tools {
-      opacity: 1;
-    }
   }
   .tracker-card {
     position: relative;


### PR DESCRIPTION
This Pull Request introduces a UI improvement to the issue tracking component. It keeps the plus icon (+) always visible to users, addressing the concern raised in issue [#4759](https://github.com/hcengineering/platform/issues/4759) about the "Add new issue" button's visibility. The text label 'Add issue...' will still appear on hover to provide clear context while preserving the clean aesthetics of the interface.

* Ensures the plus icon (+) for adding new issues is visible at all times.
* Retains on-hover text appearance for 'Add issue...' to maintain interface cleanliness.

Closes [#4759](https://github.com/hcengineering/platform/issues/4759)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBmY2MzMjY4ZWY5NjM0ZDNmMDNhOTgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.8s58c6fCLzHPcSFOWTtFdECFkipILvtK2SzQvCzzS84">Huly&reg;: <b>UBERF-6371</b></a></sub>