### PR TITLE
Add password validation on signup

### DIFF
--- a/plugins/login-assets/lang/en.json
+++ b/plugins/login-assets/lang/en.json
@@ -3,8 +3,12 @@
     "RequiredField": "Required field {field}",
     "FieldsDoNotMatch": "{field} don't match {field2}",
     "ConnectingToServer": "Connecting to server....",
-    "IncorrectValue": "Incorrect value {field}"
-  },
+    "IncorrectValue": "Incorrect value {field}",
+    "PasswordLength": "Password must be at least 8 characters long",
+    "PasswordNumber": "Password must contain at least one number",
+    "PasswordLowercase": "Password must contain at least one lowercase letter",
+    "PasswordUppercase": "Password must contain at least one uppercase letter"
+  },  
   "string": {
     "LogIn": "Log In",
     "SignUp": "Sign Up",

--- a/plugins/login-assets/lang/es.json
+++ b/plugins/login-assets/lang/es.json
@@ -3,7 +3,11 @@
     "RequiredField": "Campo obligatorio: {field}",
     "FieldsDoNotMatch": "{field} no coincide con {field2}",
     "ConnectingToServer": "Conectando al servidor...",
-    "IncorrectValue": "Valor incorrecto para {field}"
+    "IncorrectValue": "Valor incorrecto para {field}",
+    "PasswordLength": "La contraseña debe tener al menos 8 caracteres",
+    "PasswordNumber": "La contraseña debe contener al menos un número",
+    "PasswordLowercase": "La contraseña debe contener al menos una letra minúscula",
+    "PasswordUppercase": "La contraseña debe contener al menos una letra mayúscula"
   },
   "string": {
     "LogIn": "Iniciar sesión",

--- a/plugins/login-assets/lang/pt.json
+++ b/plugins/login-assets/lang/pt.json
@@ -3,7 +3,11 @@
     "RequiredField": "Campo obrigatório {field}",
     "FieldsDoNotMatch": "{field} não coincidem com {field2}",
     "ConnectingToServer": "A ligar ao servidor....",
-    "IncorrectValue": "Valor incorreto {field}"
+    "IncorrectValue": "Valor incorreto {field}",
+    "PasswordLength": "A senha deve ter pelo menos 8 caracteres",
+    "PasswordNumber": "A senha deve conter pelo menos um número",
+    "PasswordLowercase": "A senha deve conter pelo menos uma letra minúscula",
+    "PasswordUppercase": "A senha deve conter pelo menos uma letra maiúscula"
   },
   "string": {
     "LogIn": "Iniciar Sessão",

--- a/plugins/login-assets/lang/ru.json
+++ b/plugins/login-assets/lang/ru.json
@@ -3,7 +3,11 @@
     "RequiredField": "Требуется заполнить {field}",
     "FieldsDoNotMatch": "{field} не совпадает {field2}",
     "ConnectingToServer": "Подключение к серверу....",
-    "IncorrectValue": "Неправильное значение {field}"
+    "IncorrectValue": "Неправильное значение {field}",
+    "PasswordLength": "Пароль должен быть длиной не менее 8 символов",
+    "PasswordNumber": "Пароль должен содержать хотя бы одну цифру",
+    "PasswordLowercase": "Пароль должен содержать хотя бы одну строчную букву",
+    "PasswordUppercase": "Пароль должен содержать хотя бы одну заглавную букву"
   },
   "string": {
     "LogIn": "Вход",

--- a/plugins/login-resources/src/components/SignupForm.svelte
+++ b/plugins/login-resources/src/components/SignupForm.svelte
@@ -21,11 +21,35 @@
   import { goTo, signUp } from '../utils'
   import Form from './Form.svelte'
 
+  const passwordValidationRules = [
+    {
+      rule: /.{8,}/,
+      notMatch: false,
+      ruleDescr: login.status.PasswordLength
+    },
+    {
+      rule: /[0-9]/,
+      notMatch: false,
+      ruleDescr: login.status.PasswordNumber
+    },
+    {
+      rule: /[a-z]/,
+      notMatch: false,
+      ruleDescr: login.status.PasswordLowercase
+    },
+    {
+      rule: /[A-Z]/,
+      notMatch: false,
+      ruleDescr: login.status.PasswordUppercase
+    }
+    // Add more rules as needed
+  ]
+
   const fields = [
     { id: 'given-name', name: 'first', i18n: login.string.FirstName, short: true },
     { id: 'family-name', name: 'last', i18n: login.string.LastName, short: true },
     { id: 'email', name: 'username', i18n: login.string.Email },
-    { id: 'new-password', name: 'password', i18n: login.string.Password, password: true },
+    { id: 'new-password', name: 'password', i18n: login.string.Password, password: true, rules: passwordValidationRules },
     { id: 'new-password', name: 'password2', i18n: login.string.PasswordRepeat, password: true }
   ]
 

--- a/plugins/login-resources/src/plugin.ts
+++ b/plugins/login-resources/src/plugin.ts
@@ -24,7 +24,11 @@ export default mergeIds(loginId, login, {
     RequiredField: '' as StatusCode<{ field: string }>,
     FieldsDoNotMatch: '' as StatusCode<{ field: string, field2: string }>,
     ConnectingToServer: '' as StatusCode,
-    IncorrectValue: '' as StatusCode<{ field: string }>
+    IncorrectValue: '' as StatusCode<{ field: string }>,
+    PasswordLength: '' as StatusCode,
+    PasswordNumber: '' as StatusCode,
+    PasswordLowercase: '' as StatusCode,
+    PasswordUppercase: '' as StatusCode
   },
   string: {
     CreateWorkspace: '' as IntlString,


### PR DESCRIPTION
Added validation rules to the password field in the form component. The new validation checks include ensuring the password is at least 8 characters long, contains at least one number, one lowercase letter, and one uppercase letter. Updated the status object to include descriptive messages for the new validation rules.

Closes #4638

<img width="1043" src="https://github.com/hcengineering/platform/assets/62548048/e2cfd47d-bb21-4ed4-9bce-c8e71e9578f8" alt="Screenshot 2024-04-06 at 7 38 10 PM">