### PR TITLE
Fix alignment of `AssigneeBox` button

### DIFF
--- a/plugins/contact-resources/src/components/AssigneeBox.svelte
+++ b/plugins/contact-resources/src/components/AssigneeBox.svelte
@@ -76,7 +76,7 @@
 
   const client = getClient()
 
-  async function updateSelected (value: Ref<Person> | null | undefined) {
+  async function updateSelected(value: Ref<Person> | null | undefined) {
     selected = value
       ? $personByIdStore.get(value) ?? (await client.findOne(contact.class.Person, { _id: value }))
       : undefined
@@ -86,7 +86,7 @@
 
   const mgr = getFocusManager()
 
-  function _click (ev: MouseEvent): void {
+  function _click(ev: MouseEvent): void {
     if (!readonly) {
       ev.preventDefault()
       ev.stopPropagation()
@@ -128,7 +128,13 @@
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
-<div {id} bind:this={container} class="min-w-0 h-full flex items-center" class:w-full={width === '100%'} style:flex-shrink={shrink}>
+<div
+  {id}
+  bind:this={container}
+  class="min-w-0 h-full flex items-center"
+  class:w-full={width === '100%'}
+  style:flex-shrink={shrink}
+>
   {#if $$slots.content}
     <div
       class="w-full h-full flex-streatch"

--- a/plugins/contact-resources/src/components/AssigneeBox.svelte
+++ b/plugins/contact-resources/src/components/AssigneeBox.svelte
@@ -128,7 +128,7 @@
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
-<div {id} bind:this={container} class="min-w-0 h-full" class:w-full={width === '100%'} style:flex-shrink={shrink}>
+<div {id} bind:this={container} class="min-w-0 h-full flex items-center" class:w-full={width === '100%'} style:flex-shrink={shrink}>
   {#if $$slots.content}
     <div
       class="w-full h-full flex-streatch"

--- a/plugins/contact-resources/src/components/EmployeeAttributePresenter.svelte
+++ b/plugins/contact-resources/src/components/EmployeeAttributePresenter.svelte
@@ -35,7 +35,7 @@
   <AssigneeBox
     label={contact.string.Employee}
     {value}
-    size={'medium'}
+    size={'large'}
     kind={'link'}
     showNavigate={false}
     justify={'left'}


### PR DESCRIPTION
After I got the Huly platform up and running locally, I quickly noticed an alignment bug on the `AssigneeBox` component on the "All Projects" in the "Tracker" section.

![image](https://github.com/hcengineering/platform/assets/70126993/d720a5a2-e884-4f9a-b0a2-fa35de0bde1d)

After doing a little digging, it looks like this bug was introduced in [PR #5013](https://github.com/hcengineering/platform/pull/5013) with the addition of the `h-full` class. This bug goes away if I remove that class, but--assuming that new class is necessary--it can be fixed in this instance by adding `flex items-center`. The size of the button was also inconsistent compared to others in the table, so I bumped it up to `large`.

![image](https://github.com/hcengineering/platform/assets/70126993/acc3d56d-d90c-4def-a97b-bd8808ff2c7e)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjExZjYzOTY4ZWY5NjM0ZDNmMDQyMjUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.IY54VwCs1Ga4Ix5s8EgAZ7vlwsHCX1IsjD5HiKhgjps">Huly&reg;: <b>UBERF-6396</b></a></sub>