### PR TITLE
fix-5221:prevent default to handle form submission

### DIFF
--- a/plugins/login-resources/src/components/Form.svelte
+++ b/plugins/login-resources/src/components/Form.svelte
@@ -136,6 +136,7 @@
   style:min-height={$deviceInfo.docHeight > 720 ? '42rem' : '0'}
   on:keydown={(evt) => {
     if (evt.key === 'Enter' && !inAction) {
+      evt.preventDefault();
       validate($themeStore.language).then((res) => {
         if (res) {
           performAction(action)


### PR DESCRIPTION
**Pull Request Requirements:**

* Added evt.preventDefault() to ensure the "Enter" key code is used to submit the form rather default form submission.
* This Pull request fixed issue 5221

Link to the original issue: https://github.com/hcengineering/platform/issues/5221

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjEyNTM3YTY4ZWY5NjM0ZDNmMDQyOWYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.AB6dRJdU8zaidRBwD9nSBjwhzieptcpOKRMs9y2vdgk">Huly&reg;: <b>UBERF-6398</b></a></sub>