### PR TITLE
UBERF-6068 Show collaborators in collaborative documents

### DIFF
--- a/packages/text-editor/src/components/CollaborationUsers.svelte
+++ b/packages/text-editor/src/components/CollaborationUsers.svelte
@@ -1,0 +1,102 @@
+<!--
+//
+// Copyright © 2022-2024 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+-->
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { TiptapCollabProvider } from '../provider/tiptap'
+  import { CollaborationUserState } from '../types'
+  import contact from '@hcengineering/contact'
+  import { Button, Component } from '@hcengineering/ui'
+  import view from '@hcengineering/view'
+  import { Editor } from '@tiptap/core'
+  import { createRelativePositionFromJSON } from 'yjs'
+  import { relativePositionToAbsolutePosition, ySyncPluginKey } from 'y-prosemirror'
+
+  export let provider: TiptapCollabProvider
+  export let editor: Editor
+
+  let states: CollaborationUserState[] = []
+
+  function onAwarenessUpdate (data: { states: CollaborationUserState[] }): void {
+    states = data.states.filter((x) => x.clientId !== provider.awareness?.clientID).filter((x) => x.cursor !== null)
+  }
+
+  onMount(() => {
+    provider.on('awarenessUpdate', onAwarenessUpdate)
+    return () => provider.off('awarenessUpdate', onAwarenessUpdate)
+  })
+
+  function goToCursor (cursor: CollaborationUserState['cursor']): void {
+    if (cursor == null) return
+    const yState = ySyncPluginKey.getState(editor.state)
+    // Calculate cursor position same as in https://github.com/yjs/y-prosemirror/blob/master/src/plugins/cursor-plugin.js
+    const abs = relativePositionToAbsolutePosition(
+      provider.document,
+      yState.type,
+      createRelativePositionFromJSON(cursor.head),
+      yState.binding.mapping
+    )
+    if (abs == null) return
+    editor.commands.focus(abs, { scrollIntoView: true })
+  }
+</script>
+
+<div class="collaboration-users">
+  {#each states as state}
+    <Button
+      kind="icon"
+      shape="round-small"
+      padding="0"
+      size="x-small"
+      on:click={() => {
+        goToCursor(state.cursor)
+      }}
+    >
+      <svelte:fragment slot="icon">
+        <div class="collaboration-user">
+          <Component
+            is={view.component.ObjectPresenter}
+            props={{
+              objectId: state.user.id,
+              _class: contact.class.PersonAccount,
+              shouldShowAvatar: true,
+              shouldShowName: false
+            }}
+          />
+        </div>
+      </svelte:fragment>
+    </Button>
+  {/each}
+</div>
+
+<style lang="scss">
+  .collaboration-users {
+    z-index: 1000;
+    position: fixed;
+    display: flex;
+    flex-direction: column;
+    margin-left: -2.75rem;
+    width: 2rem;
+    gap: 1rem;
+  }
+  .collaboration-user {
+    pointer-events: none;
+    width: 1.5rem;
+    * {
+      pointer-events: none;
+    }
+  }
+</style>

--- a/packages/text-editor/src/components/CollaborativeTextEditor.svelte
+++ b/packages/text-editor/src/components/CollaborativeTextEditor.svelte
@@ -53,6 +53,7 @@
   import { InlinePopupExtension } from './extension/inlinePopup'
   import { InlineStyleToolbarExtension } from './extension/inlineStyleToolbar'
   import { completionConfig } from './extensions'
+  import CollaborationUsers from './CollaborationUsers.svelte'
 
   export let documentId: DocumentId
   export let field: string | undefined = undefined
@@ -330,6 +331,8 @@
   class:h-full={full}
   on:click|preventDefault|stopPropagation={() => (needFocus = true)}
 >
+  <CollaborationUsers provider={remoteProvider} {editor} />
+
   {#if loading}
     <div class="flex p-3">
       <Loading />

--- a/packages/text-editor/src/types.ts
+++ b/packages/text-editor/src/types.ts
@@ -2,6 +2,7 @@ import { type Asset, type IntlString, type Resource } from '@hcengineering/platf
 import { type Account, type Doc, type Ref } from '@hcengineering/core'
 import type { AnySvelteComponent } from '@hcengineering/ui'
 import { type Editor, type SingleCommands } from '@tiptap/core'
+import type { RelativePosition } from 'yjs'
 
 /**
  * @public
@@ -104,4 +105,16 @@ export interface CollaborationUser {
   name: string
   email: string
   color: string
+}
+
+/**
+ * @public
+ */
+export interface CollaborationUserState {
+  clientId: number
+  user: CollaborationUser
+  cursor: {
+    anchor: RelativePosition
+    head: RelativePosition
+  } | null
 }


### PR DESCRIPTION
## Brief Description:

* Implemented simple panel with active collaborators list for document
* Click on collaborator moves focus on their cursor position with scoll

  ![image](https://github.com/hcengineering/platform/assets/3264482/23fec93b-63b9-432a-a68f-56df60fb61b2)

## How to test:

* Open one document in two tabs
* Focus editor in one tab will show user icon in other tab
* Click on icon shoud move cursor to same position
* Long documents should be scrolled to cursor position
* Unfocus editor should hide user icon in other tab

## Related Issue:

#5004

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjEyYjA4NDY4ZWY5NjM0ZDNmMDQzODQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.c2G5fiTnrweB1WmY6WLpQ_904mCosbKWZov1YTRcsQg">Huly&reg;: <b>UBERF-6402</b></a></sub>