### PR TITLE
Add new copy link message action

### DIFF
--- a/plugins/activity-resources/src/components/ActivityMessageActions.svelte
+++ b/plugins/activity-resources/src/components/ActivityMessageActions.svelte
@@ -23,6 +23,7 @@
   import SaveMessageAction from './SaveMessageAction.svelte'
   import ActivityMessageExtensionComponent from './activity-message/ActivityMessageExtension.svelte'
   import AddReactionAction from './reactions/AddReactionAction.svelte'
+  import CopyLinkMessageAction from './CopyLinkMessageAction.svelte'
 
   export let message: ActivityMessage | undefined
   export let extensions: ActivityMessageExtension[] = []
@@ -64,6 +65,7 @@
     <ActivityMessageExtensionComponent kind="action" {extensions} props={{ object: message }} on:close on:open />
     <PinMessageAction object={message} />
     <SaveMessageAction object={message} />
+    <CopyLinkMessageAction object={message} />
 
     {#if withActionMenu}
       <ActivityMessageAction size="small" icon={IconMoreV} opened={isActionMenuOpened} action={showMenu} />

--- a/plugins/activity-resources/src/components/CopyLinkMessageAction.svelte
+++ b/plugins/activity-resources/src/components/CopyLinkMessageAction.svelte
@@ -1,0 +1,34 @@
+<!--
+// Copyright © 2023 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+-->
+<script lang="ts">
+  import view from '@hcengineering/view'
+  import { ActivityMessage } from '@hcengineering/activity'
+  import ActivityMessageAction from './ActivityMessageAction.svelte'
+  import { copyTextToClipboard } from '@hcengineering/presentation'
+  import { getCurrentLocation, locationToUrl } from '@hcengineering/ui'
+
+  export let object: ActivityMessage
+
+  async function copyMessageLinkToClipbard(): Promise<void> {
+    const { protocol, hostname, port } = window.location
+    const baseUrl = `${protocol}//${hostname}${port ? `:${port}` : ''}`
+    const location = getCurrentLocation()
+    location.query = { message: object._id }
+    const targetUrl = locationToUrl(location)
+    copyTextToClipboard(baseUrl + targetUrl)
+  }
+</script>
+
+<ActivityMessageAction icon={view.icon.CopyLink} action={copyMessageLinkToClipbard} />


### PR DESCRIPTION
I added a button for copying links to individual messages within channels or in direct chats. The button is located next to the other message actions like "pin", "bookmark", etc.

[copy_message_link_demo.webm](https://github.com/hcengineering/platform/assets/89492199/caab0a2d-74d9-48c4-a25f-d83af3a5bab9)

Edit: I'm not sure if this issue is related: #4785. I also found this possibly related PR from 2022: #2078. Was this functionality added and then removed in the course of a re-write?

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjEzMmE2ZDY4ZWY5NjM0ZDNmMDQ0ODAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.j4oSAadvnrLdsnNFjvjNR4WG-S-O9ZDFJD5lXE0UhjU">Huly&reg;: <b>UBERF-6405</b></a></sub>