### PR TITLE
Fixed bug related to Invalid Image retrievals on multiple tabs.

### DIFF
--- a/packages/text-editor/src/provider/minio.ts
+++ b/packages/text-editor/src/provider/minio.ts
@@ -26,9 +26,10 @@ async function fetchContent (doc: YDoc, name: string): Promise<void> {
   for (let i = 0; i < 2; i++) {
     try {
       const frontUrl = getMetadata(presentation.metadata.FrontUrl) ?? window.location.origin
+      const token = getCookieToken(); 
 
       try {
-        const res = await fetch(concatLink(frontUrl, `/files?file=${name}`))
+        const res = await fetch(concatLink(frontUrl, `/files?file=${name}&token=${token}`))
 
         if (res.ok) {
           const blob = await res.blob()
@@ -40,10 +41,22 @@ async function fetchContent (doc: YDoc, name: string): Promise<void> {
     } catch (err: any) {
       console.error(err)
     }
-    // White a while
+    // Wait for a while
     await new Promise((resolve) => setTimeout(resolve, 10))
   }
 }
+
+function getCookieToken(): string | null {
+  const cookies = document.cookie.split(';');
+  for (let i = 0; i < cookies.length; i++) {
+    const cookie = cookies[i].trim();
+    if (cookie.startsWith('presentation-metadata-Token=')) {
+      return cookie.substring('presentation-metadata-Token='.length, cookie.length);
+    }
+  }
+  return null; 
+}
+
 
 export class MinioProvider extends Observable<EVENTS> {
   loaded: Promise<void>


### PR DESCRIPTION
Bug: When opening multiple workspace tabs in the browser and trying to view an issue with an attached image in one of the tabs, the images are not displayed. This occurs because the Image API requires a token stored in the presentation-metadata-Token cookie, but when opening another workspace tab, the cookie gets overridden with the token associated with the new workspace. As a result, the first tab starts using the wrong token, leading to image retrieval failures.

Solution: To address the issue, I implemented a solution that ensures the correct token is used when fetching images. This involved modifying the fetchContent function to retrieve the token from the presentation-metadata-Token cookie and passing it along with the image request to the Image API. This solution ensures that images are displayed correctly, even when multiple workspace tabs are open simultaneously.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjEzZWIwMzc5NmRkMzAxMWUwZTQ0NzUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.rvAHCx4fXUGBOExCnOhXPsw2XPEZRqU0ZQfoU2bPy0c">Huly&reg;: <b>UBERF-6418</b></a></sub>