### PR TITLE
UBERF-NA-App: Add number increment buttons & ADA aria-labels on Button comp

### DIFF
--- a/packages/ui/src/components/Button.svelte
+++ b/packages/ui/src/components/Button.svelte
@@ -65,6 +65,7 @@
   export let adaptiveShrink: WidthType | null = null
   export let gap: 'medium' | 'large' = 'medium'
   export let stopPropagation: boolean = true
+  export let aria: string | undefined = label || undefined
 
   $: iconSize = iconProps?.size !== undefined ? iconProps.size : size && size === 'inline' ? 'inline' : 'small'
   $: iconRightSize = iconRightProps?.size !== undefined ? iconRightProps.size : 'x-small'
@@ -141,6 +142,7 @@
   style:height
   style:flex-shrink={shrink}
   style:padding
+  aria-label={aria}
   {title}
   type={kind === 'primary' ? 'submit' : 'button'}
   on:click={preventHandler}

--- a/packages/ui/src/components/EditBox.svelte
+++ b/packages/ui/src/components/EditBox.svelte
@@ -22,6 +22,9 @@
   import Label from './Label.svelte'
   import { floorFractionDigits } from '../utils'
   import { themeStore } from '@hcengineering/theme'
+  import Button from './Button.svelte'
+  import IconDown from './icons/Down.svelte'
+  import IconUp from './icons/Up.svelte'
 
   export let label: IntlString | undefined = undefined
   export let maxWidth: string = '100%'
@@ -55,7 +58,7 @@
       value = floorFractionDigits(Number(value), maxDigitsAfterPoint)
     }
   }
-  $: void translate(placeholder, placeholderParam ?? {}, $themeStore.language).then((res) => {
+  $: void translate(placeholder, placeholderParam ?? {}, $themeStore.language).then((res: string) => {
     phTraslate = res
   })
 
@@ -101,6 +104,14 @@
   export function focus (): void {
     input.focus()
   }
+
+  function handleArrowIncrement (direction: 'up' | 'down'): void {
+    if (typeof value === 'number') {
+      if (direction === 'up') value++
+      else if (direction === 'down') value--
+      handleInput()
+    }
+  }
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -135,6 +146,7 @@
   >
     {#if format === 'password'}
       <input
+        aria-label="Password Input"
         {disabled}
         style:width={maxWidth}
         id="userPassword"
@@ -151,7 +163,9 @@
         }}
       />
     {:else if format === 'number'}
+    <div class="flex-row-center justify-stretch p-1">
       <input
+        aria-label="Number Input"
         {disabled}
         style:width={maxWidth}
         bind:this={input}
@@ -167,8 +181,16 @@
           dispatch('blur', value)
         }}
       />
+      <div class="ml-2">
+        <Button icon={IconDown} size={'small'} on:click={() => handleArrowIncrement('down')} aria="Decrease" />
+      </div>
+      <div class="ml-2">
+        <Button icon={IconUp} size={'small'} on:click={() => handleArrowIncrement('up')} aria="Increase" />
+      </div>
+    </div>
     {:else}
       <input
+        aria-label="Text Input"
         {disabled}
         style:width={maxWidth}
         bind:this={input}


### PR DESCRIPTION
* Added up / down buttons on `EditBox` component for `type="number"` fields, increments value by 1.
* Added `aria-label` to the `Button` component as prop `aria` for ADA compliance on buttons. Only added `aria` prop to the above mentioned buttons currently, as well as raw aria-labels to `type="password"` and text input fields in `EditBox`.

![Screenshot from 2024-04-08 15-09-41](https://github.com/hcengineering/platform/assets/97066574/7b6bc13e-29fd-41f1-ad49-cd65577f4d71)