### PR TITLE
Tooltip added to chat text editor

### DIFF
--- a/packages/ui/src/components/ButtonBase.svelte
+++ b/packages/ui/src/components/ButtonBase.svelte
@@ -37,9 +37,9 @@
   export let type: ButtonBaseType
   export let inheritColor: boolean = false
   export let inheritFont: boolean = false
-  export let tooltip: LabelAndProps | undefined = undefined
   export let element: HTMLButtonElement | undefined = undefined
   export let id: string | undefined = undefined
+  export let showTooltip: LabelAndProps | undefined = undefined
 
   let actualIconSize: IconSize = 'small'
 
@@ -87,7 +87,7 @@
   class:inheritFont
   class:menu={hasMenu}
   disabled={loading || disabled}
-  use:tp={tooltip}
+  use:tp={showTooltip}
   on:click|stopPropagation
   on:keydown
 >

--- a/packages/ui/src/components/ButtonIcon.svelte
+++ b/packages/ui/src/components/ButtonIcon.svelte
@@ -28,8 +28,8 @@
   export let hasMenu: boolean = false
   export let loading: boolean = false
   export let inheritColor: boolean = false
-  export let tooltip: LabelAndProps | undefined = undefined
   export let focusIndex = -1
+  export let showTooltip: LabelAndProps | undefined = undefined
 
   let element: ButtonBase | undefined
 
@@ -51,8 +51,8 @@
   {inheritColor}
   {pressed}
   {hasMenu}
-  {tooltip}
   {focusIndex}
+  {showTooltip}
   on:click
   on:keydown
 />

--- a/plugins/activity-assets/lang/en.json
+++ b/plugins/activity-assets/lang/en.json
@@ -40,6 +40,11 @@
     "Mentions": "Mentions",
     "MentionedYouIn": "Mentioned you in",
     "Messages": "Messages",
-    "Thread": "Thread"
+    "Thread": "Thread",
+    "ReactWithEmoji": "React With Emoji",
+    "ReplyInThread": "Reply In Thread",
+    "SaveForLater": "Save For Later",
+    "MoreActions": "More Actions",
+    "PinMessage": "Pin Message"
   }
 }

--- a/plugins/activity-assets/lang/es.json
+++ b/plugins/activity-assets/lang/es.json
@@ -37,6 +37,11 @@
     "Mentioned": "Mencionado",
     "You": "Tú",
     "Mentions": "Menciones",
-    "MentionedYouIn": "Has sido Mencionado en"
+    "MentionedYouIn": "Has sido Mencionado en",
+    "ReactWithEmoji": "Reaccionar con emojis",
+    "ReplyInThread": "Responder en el hilo",
+    "SaveForLater": "Guardar para más adelante",
+    "MoreActions": "Mas acciones",
+    "PinMessage": "Fijar mensaje"
   }
 }

--- a/plugins/activity-assets/lang/pt.json
+++ b/plugins/activity-assets/lang/pt.json
@@ -37,6 +37,11 @@
     "Mentioned": "Mencionado",
     "You": "Tu",
     "Mentions": "Menções",
-    "MentionedYouIn": "Foste Mencionado em"
+    "MentionedYouIn": "Foste Mencionado em",
+    "ReactWithEmoji": "Reaja com Emoji",
+    "ReplyInThread": "Responder no tópico",
+    "SaveForLater": "Save For Later",
+    "MoreActions": "Guardar para depois",
+    "PinMessage": "Fixar mensagem"
   }
 }

--- a/plugins/activity-assets/lang/ru.json
+++ b/plugins/activity-assets/lang/ru.json
@@ -40,6 +40,11 @@
     "Mentions": "Упоминания",
     "MentionedYouIn": "Упомянул(а) вас в",
     "Messages": "Cообщения",
-    "Thread": "Обсуждение"
+    "Thread": "Обсуждение",
+    "ReactWithEmoji": "Реагируйте с помощью эмодзи",
+    "ReplyInThread": "Ответить в теме",
+    "SaveForLater": "Сохранить на потом",
+    "MoreActions": "Больше действий",
+    "PinMessage": "Пин-сообщение"
   }
 }

--- a/plugins/activity-resources/src/components/ActivityMessageAction.svelte
+++ b/plugins/activity-resources/src/components/ActivityMessageAction.svelte
@@ -13,7 +13,7 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  import { type AnySvelteComponent, ButtonIcon } from '@hcengineering/ui'
+  import { type AnySvelteComponent, ButtonIcon, LabelAndProps } from '@hcengineering/ui'
   import { Asset } from '@hcengineering/platform'
   import { ComponentType } from 'svelte'
 
@@ -22,6 +22,7 @@
   export let size: 'x-small' | 'small' = 'small'
   export let action: (ev: MouseEvent) => Promise<void> | void = async () => {}
   export let opened = false
+  export let showTooltip: LabelAndProps | undefined = undefined
 
   function onClick (ev: MouseEvent): void {
     ev.stopPropagation()
@@ -30,4 +31,4 @@
   }
 </script>
 
-<ButtonIcon {icon} {iconProps} iconSize={size} size="small" kind="tertiary" pressed={opened} on:click={onClick} />
+<ButtonIcon {icon} {iconProps} iconSize={size} size="small" kind="tertiary" pressed={opened} on:click={onClick} {showTooltip}/>

--- a/plugins/activity-resources/src/components/ActivityMessageActions.svelte
+++ b/plugins/activity-resources/src/components/ActivityMessageActions.svelte
@@ -17,6 +17,8 @@
   import { Action, IconMoreV, showPopup } from '@hcengineering/ui'
   import { Menu } from '@hcengineering/view-resources'
   import { createEventDispatcher } from 'svelte'
+  import ActivityPlugin from '../plugin'
+  import { tooltip } from '@hcengineering/ui'
 
   import ActivityMessageAction from './ActivityMessageAction.svelte'
   import PinMessageAction from './PinMessageAction.svelte'
@@ -59,14 +61,14 @@
 </script>
 
 {#if message}
-  <div class="root">
-    <AddReactionAction object={message} on:open on:close />
-    <ActivityMessageExtensionComponent kind="action" {extensions} props={{ object: message }} on:close on:open />
-    <PinMessageAction object={message} />
-    <SaveMessageAction object={message} />
+  <div class="root"> 
+    <AddReactionAction object={message} on:open on:close showTooltip={{ label: ActivityPlugin.string.ReactWithEmoji }}/>
+    <span use:tooltip={{ label: ActivityPlugin.string.ReplyInThread }}><ActivityMessageExtensionComponent kind="action" {extensions} props={{ object: message }} on:close on:open /> </span>
+    <PinMessageAction object={message} showTooltip={{ label: ActivityPlugin.string.PinMessage }}/>
+    <SaveMessageAction object={message} showTooltip={{ label: ActivityPlugin.string.SaveForLater }}/>
 
     {#if withActionMenu}
-      <ActivityMessageAction size="small" icon={IconMoreV} opened={isActionMenuOpened} action={showMenu} />
+      <ActivityMessageAction size="small" icon={IconMoreV} opened={isActionMenuOpened} action={showMenu} showTooltip={{ label: ActivityPlugin.string.MoreActions }} />
     {/if}
   </div>
 {/if}

--- a/plugins/activity-resources/src/components/PinMessageAction.svelte
+++ b/plugins/activity-resources/src/components/PinMessageAction.svelte
@@ -17,8 +17,10 @@
   import view from '@hcengineering/view'
   import { ActivityMessage } from '@hcengineering/activity'
   import ActivityMessageAction from './ActivityMessageAction.svelte'
+  import { LabelAndProps } from '@hcengineering/ui'
 
   export let object: ActivityMessage
+  export let showTooltip: LabelAndProps | undefined = undefined
 
   const client = getClient()
 
@@ -31,4 +33,5 @@
   icon={view.icon.Pin}
   iconProps={{ fill: object.isPinned ? '#3265cb' : 'currentColor' }}
   action={toggleMessagePinning}
+  {showTooltip}
 />

--- a/plugins/activity-resources/src/components/SaveMessageAction.svelte
+++ b/plugins/activity-resources/src/components/SaveMessageAction.svelte
@@ -21,12 +21,14 @@
   import ActivityMessageAction from './ActivityMessageAction.svelte'
   import Bookmark from './icons/Bookmark.svelte'
   import { savedMessagesStore } from '../activity'
+  import { LabelAndProps } from '@hcengineering/ui'
 
   export let object: ActivityMessage
 
   const client = getClient()
 
   let savedMessage: SavedMessage | undefined = undefined
+  export let showTooltip: LabelAndProps | undefined = undefined
 
   savedMessagesStore.subscribe((saved) => {
     savedMessage = saved.find(({ attachedTo }) => attachedTo === object._id)
@@ -49,4 +51,5 @@
   size={savedMessage ? 'small' : 'x-small'}
   iconProps={{ fill: savedMessage ? 'var(--global-accent-TextColor)' : 'currentColor' }}
   action={toggleSaveMessage}
+  {showTooltip}
 />

--- a/plugins/activity-resources/src/components/reactions/AddReactionAction.svelte
+++ b/plugins/activity-resources/src/components/reactions/AddReactionAction.svelte
@@ -14,7 +14,7 @@
 -->
 <script lang="ts">
   import { createEventDispatcher } from 'svelte'
-  import { EmojiPopup, IconEmoji, showPopup } from '@hcengineering/ui'
+  import { EmojiPopup, IconEmoji, LabelAndProps, showPopup } from '@hcengineering/ui'
   import { createQuery, getClient } from '@hcengineering/presentation'
   import activity, { ActivityMessage, Reaction } from '@hcengineering/activity'
 
@@ -30,6 +30,7 @@
 
   let reactions: Reaction[] = []
   let isOpened = false
+  export let showTooltip: LabelAndProps | undefined = undefined
 
   $: if (object?.reactions && object.reactions > 0) {
     reactionsQuery.query(activity.class.Reaction, { attachedTo: object._id }, (res?: Reaction[]) => {
@@ -49,4 +50,4 @@
   }
 </script>
 
-<ActivityMessageAction icon={IconEmoji} action={openEmojiPalette} opened={isOpened} />
+<ActivityMessageAction icon={IconEmoji} action={openEmojiPalette} opened={isOpened} {showTooltip}/>

--- a/plugins/activity-resources/src/plugin.ts
+++ b/plugins/activity-resources/src/plugin.ts
@@ -23,6 +23,11 @@ export default mergeIds(activityId, activity, {
     CollectionUpdated: '' as IntlString,
     DocAdded: '' as IntlString,
     DocCreated: '' as IntlString,
-    DocDeleted: '' as IntlString
+    DocDeleted: '' as IntlString,
+    ReactWithEmoji: '' as IntlString,
+    ReplyInThread: '' as IntlString,
+    PinMessage: '' as IntlString,
+    SaveForLater: '' as IntlString,
+    MoreActions: '' as IntlString
   }
 })


### PR DESCRIPTION
### **Buttons Without Tooltips in Text Editor (Chat)**

* Bold button
* Italic button
* Strike Through
* Attach File button
* Mention button
* Text template button
* React using emoji button
* Reply in thread button
* Pin message button
* Save message button
* More action icon

**### Expected Behavior** When hovering over these buttons, a tooltip should appear to provide a brief description or hint about the button's function.

**### Steps to Reproduce**

1. Navigate to Chat Page.
2. Hover over the mentioned buttons.
3. Note the absence of tooltips.

**### Updated Status** The tooltips for the mentioned buttons have been implemented and added to the code.

**###Sample Screenshot [of changes applied]**

![Screenshot from 2024-04-09 18-06-28 (1)](https://github.com/hcengineering/platform/assets/26093681/d5eb93ea-a7aa-47b7-8e65-91a87f6e2abc)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjE1MjQyMjI0N2IzZDJhZDI5MjJhZjIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.Gox-vCFvYaGhP93pvZDbxDln3hIvhaLuLOeOIBh9VEY">Huly&reg;: <b>UBERF-6446</b></a></sub>