### PR TITLE
Fixed Color Picker Modal

### DIFF
--- a/plugins/view-resources/src/components/IconPicker.svelte
+++ b/plugins/view-resources/src/components/IconPicker.svelte
@@ -72,8 +72,8 @@
                 embedded
                 on:close={(evt) => {
                   _color = evt.detail
-                  dispatch(icons.length === 0 ? 'close' : 'update', {
-                    icon: icons.length === 0 ? null : _icon,
+                  dispatch('close', {
+                    icon: icons.length === 0 ? icons[0] : _icon,
                     color: _color
                   })
                 }}


### PR DESCRIPTION
**Modal is not closing when picking a color**

### Expected Behavior

Modal should close when selecting a color in Create Project Modal in the same way as it is closing when selecting an emoji.

### Steps to Reproduce

1. Go to Tracker from left bar
2. From new issue drop down select Create Project
3. When you click on Choose Icon option a Modal will open
4. From here when you pick a particular color the Modal is not closing in this way user will be unaware what is happeing.

### Updated Status

I've changed the functionality, now when the user pick a color the modal will be close in the same way as choosing an emoji.