### PR TITLE
Allow child classes in navigator model

### DIFF
--- a/plugins/document/src/plugin.ts
+++ b/plugins/document/src/plugin.ts
@@ -18,7 +18,7 @@ import { NotificationGroup, NotificationType } from '@hcengineering/notification
 import type { Asset, Plugin, Resource } from '@hcengineering/platform'
 import { IntlString, plugin } from '@hcengineering/platform'
 import type { AnyComponent, Location, ResolvedLocation } from '@hcengineering/ui'
-import { Action, Viewlet } from '@hcengineering/view'
+import { Action } from '@hcengineering/view'
 import { Document, DocumentEmbedding, DocumentSnapshot, SavedDocument, Teamspace } from './types'
 
 /**
@@ -74,9 +74,6 @@ export const documentPlugin = plugin(documentId, {
     NoParent: '' as Ref<Document>,
     DocumentNotificationGroup: '' as Ref<NotificationGroup>,
     ContentNotification: '' as Ref<NotificationType>
-  },
-  viewlet: {
-    TableBranches: '' as Ref<Viewlet>
   },
   descriptor: {
     TeamspaceType: '' as Ref<SpaceTypeDescriptor>

--- a/plugins/workbench-resources/src/components/Navigator.svelte
+++ b/plugins/workbench-resources/src/components/Navigator.svelte
@@ -42,10 +42,11 @@
   let shownSpaces: Space[] = []
 
   $: if (model) {
+    const classes = getSpecialSpaceClass(model).flatMap((c) => hierarchy.getDescendants(c))
     query.query(
       core.class.Space,
       {
-        _class: { $in: getSpecialSpaceClass(model) }
+        _class: { $in: classes }
         // temp disabled, need way for default spaces
         // members: getCurrentAccount()._id
       },

--- a/plugins/workbench-resources/src/components/navigator/StarredNav.svelte
+++ b/plugins/workbench-resources/src/components/navigator/StarredNav.svelte
@@ -88,7 +88,7 @@
 
   function getSpaceModel (space: Ref<Class<Space>>): SpacesNavModel | undefined {
     const hierarchy = client.getHierarchy()
-    const ancestors = [space, ...hierarchy.getAncestors(space).reverse()]
+    const ancestors = [space, ...[...hierarchy.getAncestors(space)].reverse()]
     for (const clazz of ancestors) {
       const model = models.find((p) => p.spaceClass === clazz)
       if (model !== undefined) return model

--- a/plugins/workbench-resources/src/components/navigator/StarredNav.svelte
+++ b/plugins/workbench-resources/src/components/navigator/StarredNav.svelte
@@ -13,7 +13,7 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  import type { Doc, Ref, Space } from '@hcengineering/core'
+  import type { Class, Doc, Ref, Space } from '@hcengineering/core'
   import core from '@hcengineering/core'
   import { DocNotifyContext, InboxNotification } from '@hcengineering/notification'
   import { InboxNotificationsClientImpl } from '@hcengineering/notification-resources'
@@ -86,6 +86,16 @@
     return result
   }
 
+  function getSpaceModel (space: Ref<Class<Space>>): SpacesNavModel | undefined {
+    const hierarchy = client.getHierarchy()
+    const ancestors = [space, ...hierarchy.getAncestors(space).reverse()]
+    for (const clazz of ancestors) {
+      const model = models.find((p) => p.spaceClass === clazz)
+      if (model !== undefined) return model
+    }
+    return undefined
+  }
+
   const inboxClient = InboxNotificationsClientImpl.getClient()
   const notifyContextByDocStore = inboxClient.contextByDoc
   const inboxNotificationsByContextStore = inboxClient.inboxNotificationsByContext
@@ -103,7 +113,7 @@
 
 <TreeNode _id={'tree-stared'} {label} node actions={async () => [unStarAll]}>
   {#each spaces as space (space._id)}
-    {@const model = models.find((p) => p.spaceClass === space._class)}
+    {@const model = getSpaceModel(space._class)}
     {#await getSpacePresenter(client, space._class) then presenter}
       {#if presenter && model}
         <svelte:component


### PR DESCRIPTION
This pull request enables child spaces to be displayed in navigator.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjE1NjQxNzI0N2IzZDJhZDI5MjJmMGQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.IqEI-Sjs6f0tOHLPgh9Fzfqtjz3IeiGE4s-jhc3uVqM">Huly&reg;: <b>UBERF-6457</b></a></sub>