### PR TITLE
Added documents page tests

### DIFF
--- a/tests/sanity/tests/documents.spec.ts
+++ b/tests/sanity/tests/documents.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from '@playwright/test'
+import { generateId, PlatformSetting, PlatformURI } from './utils'
+import { LeftSideMenuPage } from './model/left-side-menu-page'
+import { DocumentsPage } from './model/documents/documents-page'
+import { NewDocument } from './model/documents/types'
+
+test.use({
+  storageState: PlatformSetting
+})
+
+test.describe('documents tests', () => {
+  test.beforeEach(async ({ page }) => {
+    await (await page.goto(`${PlatformURI}/workbench/sanity-ws`))?.finished()
+  })
+
+  test('documents-new-document', async ({ page }) => {
+    const leftSideMenuPage = new LeftSideMenuPage(page)
+    await leftSideMenuPage.buttonDocuments.click()
+
+    const documentsPage = new DocumentsPage(page)
+    await documentsPage.buttonCreateDocument.click()
+
+    const documentTest: NewDocument = {
+      title: 'document-' + generateId(),
+      space: 'default'
+    }
+    // Creates test document
+    await documentsPage.createDocument(documentTest)
+    // Confirms new test document by opening it
+    await documentsPage.openDocument(documentTest.title)
+  })
+
+  test('documents-delete-document', async ({ page }) => {
+    const leftSideMenuPage = new LeftSideMenuPage(page)
+    await leftSideMenuPage.buttonDocuments.click()
+
+    const documentsPage = new DocumentsPage(page)
+    await documentsPage.buttonCreateDocument.click()
+
+    const documentTest: NewDocument = {
+      title: 'document-' + generateId(),
+      space: 'default'
+    }
+    // Creates test document and opens it
+    await documentsPage.createDocument(documentTest)
+    await documentsPage.openDocument(documentTest.title)
+    // Deletes test document
+    await documentsPage.moreActionsOnDocument(documentTest.title, 'Delete')
+    await page.locator('form[id="view:string:DeleteObject"] button.primary').click()
+    await page.waitForTimeout(1000)
+    // Confirms test document is not present in document list
+    await expect(documentsPage).not.toContain(documentTest.title)
+  })
+
+  test('documents-enable-disable-star', async ({ page }) => {
+    const leftSideMenuPage = new LeftSideMenuPage(page)
+    await leftSideMenuPage.buttonDocuments.click()
+
+    const documentsPage = new DocumentsPage(page)
+    await documentsPage.buttonCreateDocument.click()
+
+    const documentTest: NewDocument = {
+      title: 'document-' + generateId(),
+      space: 'default'
+    }
+    // Creates test document and opens it
+    await documentsPage.createDocument(documentTest)
+    await documentsPage.openDocument(documentTest.title)
+    // Confirms document is not starred
+    await page.locator('use[href="/img/aFUUrxVo.svg#star"]').isVisible()
+    await page.locator('use[href="/img/aFUUrxVo.svg#starred"]').isHidden()
+    // Stars document
+    await documentsPage.buttonStarDocument.click()
+    // Confirms document is starred, and remains starred after a page refresh
+    await page.locator('use[href="/img/aFUUrxVo.svg#starred"]').isVisible()
+    await page.reload()
+    await page.locator('use[href="/img/aFUUrxVo.svg#starred"]').isVisible()
+    await page.locator('use[href="/img/aFUUrxVo.svg#star"]').isHidden()
+    // Unstars document
+    await documentsPage.buttonStarDocument.click()
+    // Confirms document is unstarred, and remains unstarred after a page refresh
+    await page.locator('use[href="/img/aFUUrxVo.svg#starred"]').isHidden()
+    await page.reload()
+    await page.locator('use[href="/img/aFUUrxVo.svg#starred"]').isHidden()
+    await page.locator('use[href="/img/aFUUrxVo.svg#star"]').isVisible()
+  })
+
+  test('documents-add-snapshot', async ({ page }) => {
+    const leftSideMenuPage = new LeftSideMenuPage(page)
+    await leftSideMenuPage.buttonDocuments.click()
+
+    const documentsPage = new DocumentsPage(page)
+    await documentsPage.buttonCreateDocument.click()
+
+    const documentTest: NewDocument = {
+      title: 'document-' + generateId(),
+      space: 'default'
+    }
+    // Creates test document and opens it
+    await documentsPage.createDocument(documentTest)
+    await documentsPage.openDocument(documentTest.title)
+    // Opens document history and creates snapshot
+    await documentsPage.buttonViewHistory.click()
+    await documentsPage.buttonModalNewSnapshot.click()
+    await documentsPage.createSnapshot('TestSnap')
+    // Verifies snapshot was created
+    await expect(page.getByText('TestSnap')).toBeVisible()
+  })
+})

--- a/tests/sanity/tests/model/documents-page.ts
+++ b/tests/sanity/tests/model/documents-page.ts
@@ -1,0 +1,153 @@
+import { type Locator, type Page, expect } from '@playwright/test'
+import { NewDocument, NewTeamspace } from './types'
+import { CommonPage } from '../common-page'
+import { DocumentCreatePopup } from './document-create-popup'
+import { DocumentMovePopup } from './document-move-popup'
+import { DocumentCreateSnapshot } from './document-create-snapshot'
+
+export class DocumentsPage extends CommonPage {
+  readonly page: Page
+  readonly buttonCreateDocument: Locator
+  readonly buttonStarDocument: Locator
+  readonly buttonViewHistory: Locator
+  readonly divTeamspacesParent: Locator
+  readonly buttonCreateTeamspace: Locator
+  readonly inputModalNewDocumentTitle: Locator
+  readonly inputModalNewTeamspaceTitle: Locator
+  readonly inputModalNewTeamspaceDescription: Locator
+  readonly inputModalNewTeamspacePrivate: Locator
+  readonly buttonModalNewTeamspaceCreate: Locator
+  readonly buttonModalEditTeamspaceTitle: Locator
+  readonly buttonModalEditTeamspaceDescription: Locator
+  readonly buttonModalEditTeamspacePrivate: Locator
+  readonly buttonModalEditTeamspaceSave: Locator
+  readonly buttonModalEditTeamspaceClose: Locator
+  readonly buttonModalNewSnapshot: Locator
+  readonly popupCreateDocument: DocumentCreatePopup
+  readonly popupMoveDocument: DocumentMovePopup
+  readonly popupCreateSnapshot: DocumentCreateSnapshot
+
+  constructor(page: Page) {
+    super()
+    this.page = page
+    this.popupCreateDocument = new DocumentCreatePopup(page)
+    this.popupMoveDocument = new DocumentMovePopup(page)
+    this.popupCreateSnapshot = new DocumentCreateSnapshot(page)
+    this.buttonStarDocument = page.locator('button[id="btnGID-references"]')
+    this.buttonCreateDocument = page.locator('div[data-float="navigator"] button[id="new-document"]')
+    this.buttonViewHistory = page.locator('button[id="btnGID-history"]')
+    this.divTeamspacesParent = page.locator('div#tree-teamspaces').locator('xpath=..')
+    this.buttonCreateTeamspace = page.locator('div#tree-teamspaces > button')
+    this.inputModalNewDocumentTitle = page.locator(
+      'form[id="document:string:CreateDocument"] input[placeholder="Untitled"]'
+    )
+    this.inputModalNewTeamspaceTitle = page.locator(
+      'form[id="document:string:NewTeamspace"] input[placeholder="New teamspace"]'
+    )
+    this.inputModalNewTeamspaceDescription = page.locator('form[id="document:string:NewTeamspace"] div.tiptap')
+    this.inputModalNewTeamspacePrivate = page.locator(
+      'form[id="document:string:NewTeamspace"] div.antiGrid label.toggle'
+    )
+    this.buttonModalNewTeamspaceCreate = page.locator('form[id="document:string:NewTeamspace"] button[type="submit"]')
+    this.buttonModalEditTeamspaceTitle = page.locator('form[id="document:string:EditTeamspace"] input[type="text"]')
+    this.buttonModalEditTeamspaceDescription = page.locator('form[id="document:string:EditTeamspace"] div.tiptap')
+    this.buttonModalEditTeamspacePrivate = page.locator(
+      'form[id="document:string:EditTeamspace"] div.antiGrid label.toggle'
+    )
+    this.buttonModalEditTeamspaceSave = page.locator('form[id="document:string:EditTeamspace"] button[type="submit"]')
+    this.buttonModalEditTeamspaceClose = page.locator('form[id="document:string:EditTeamspace"] button#card-close')
+    this.buttonModalNewSnapshot = page.locator('.header > .antiButton')
+  }
+
+  async createNewTeamspace(data: NewTeamspace): Promise<void> {
+    await this.divTeamspacesParent.hover()
+    await this.buttonCreateTeamspace.click()
+
+    await this.inputModalNewTeamspaceTitle.fill(data.title)
+    if (data.description != null) {
+      await this.inputModalNewTeamspaceDescription.fill(data.description)
+    }
+    if (data.private != null) {
+      await this.inputModalNewTeamspacePrivate.click()
+    }
+
+    await this.buttonModalNewTeamspaceCreate.click()
+  }
+
+  async openTeamspace(name: string): Promise<void> {
+    const classes = await this.page
+      .locator('div.antiNav-element span[class*="label"]', { hasText: name })
+      .locator('xpath=..')
+      .getAttribute('class')
+    if (classes != null && classes.includes('collapsed')) {
+      await this.page.locator('div.antiNav-element span[class*="label"]', { hasText: name }).click()
+    }
+  }
+
+  async checkTeamspaceExist(name: string): Promise<void> {
+    await expect(this.page.locator('div[class*="dropbox"] span[class*="label"]', { hasText: name })).toHaveCount(1)
+  }
+
+  async checkTeamspaceNotExist(name: string): Promise<void> {
+    await expect(this.page.locator('div[class*="dropbox"] span[class*="label"]', { hasText: name })).toHaveCount(0)
+  }
+
+  async moreActionTeamspace(name: string, action: string): Promise<void> {
+    await this.page.locator('div[class*="dropbox"] > div > span[class*="label"]', { hasText: name }).hover()
+    await this.page.locator(`xpath=//span[text()="${name}"]/../div[last()]`).click()
+    await this.selectFromDropdown(this.page, action)
+  }
+
+  async createDocument(data: NewDocument): Promise<void> {
+    await this.popupCreateDocument.createDocument(data)
+  }
+
+  async openDocument(name: string): Promise<void> {
+    await this.page.locator('div.tree > span[class*="label"]', { hasText: name }).click()
+  }
+
+  async openDocumentForTeamspace(spaceName: string, documentName: string): Promise<void> {
+    await this.page
+      .locator('div.parent > span[class*="label"]', { hasText: spaceName })
+      .locator('xpath=../following-sibling::div[1]')
+      .locator('div.tree > span[class*="label"]', { hasText: documentName })
+      .click()
+  }
+
+  async editTeamspace(data: NewTeamspace): Promise<void> {
+    await this.buttonModalEditTeamspaceTitle.fill(data.title)
+    if (data.description != null) {
+      await this.buttonModalEditTeamspaceDescription.fill(data.description)
+    }
+    if (data.private != null) {
+      await this.buttonModalEditTeamspacePrivate.click()
+    }
+
+    await this.buttonModalEditTeamspaceSave.click()
+  }
+
+  async checkTeamspace(data: NewTeamspace): Promise<void> {
+    await expect(this.buttonModalEditTeamspaceTitle).toHaveValue(data.title)
+    if (data.description != null) {
+      await expect(this.buttonModalEditTeamspaceDescription).toHaveText(data.description)
+    }
+    await this.buttonModalEditTeamspaceClose.click()
+  }
+
+  async moreActionsOnDocument(documentName: string, action: string): Promise<void> {
+    await this.page
+      .locator('div.tree > span[class*="label"]', { hasText: documentName })
+      .locator('xpath=..')
+      .locator('div[class*="tool"]:nth-child(6)')
+      .click()
+    await this.selectFromDropdown(this.page, action)
+  }
+
+  async fillMoveDocumentForm(newSpace: string): Promise<void> {
+    await this.popupMoveDocument.moveToSpace(newSpace)
+  }
+
+  async createSnapshot(name: string): Promise<void> {
+    await this.popupCreateSnapshot.createDocument(name)
+  }
+}

--- a/tests/sanity/tests/model/documents/document-create-snapshot.ts
+++ b/tests/sanity/tests/model/documents/document-create-snapshot.ts
@@ -1,0 +1,24 @@
+import { type Locator, type Page } from '@playwright/test'
+import { CommonPage } from '../common-page'
+
+export class DocumentCreateSnapshot extends CommonPage {
+  readonly page: Page
+  readonly popup: Locator
+  readonly form: Locator
+  readonly inputName: Locator
+  readonly buttonCreate: Locator
+
+  constructor(page: Page) {
+    super()
+    this.page = page
+    this.popup = page.locator('div.popup')
+    this.form = this.popup.locator('form[id="document:string:Snapshot"]')
+    this.inputName = this.form.locator('input')
+    this.buttonCreate = this.form.locator('button[type="submit"]')
+  }
+
+  async createDocument(name: string): Promise<void> {
+    await this.inputName.fill(name)
+    await this.buttonCreate.click()
+  }
+}


### PR DESCRIPTION
Added 4 Playwright tests for the /workbench/ws1/document/ page, covering:

* Creating a new document
* Deleting a document
* Enabling/Disabling star on a document
* Adding a snapshot of a document

Signed-off-by: Dustin Sison [dustinsison@github.com](mailto:dustinsison@github.com)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjE2MTZlYzI0N2IzZDJhZDI5MjMxYmIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.k2PKOLT6osJltGgA0dV3lCIIfEXR_Wq8F5SQuEndAek">Huly&reg;: <b>UBERF-6462</b></a></sub>