### PR TITLE
Fix: sub-tab is selected initally clicking on settings #4758

### DIFF
--- a/plugins/workbench-resources/src/components/AccountPopup.svelte
+++ b/plugins/workbench-resources/src/components/AccountPopup.svelte
@@ -61,20 +61,22 @@
     { limit: 1 }
   )
 
-  function selectCategory (sp?: SettingsCategory): void {
-    closePopup()
-    const loc = getCurrentResolvedLocation()
-    loc.fragment = undefined
-    loc.query = undefined
-    loc.path[2] = settingId
-    if (sp) {
-      loc.path[3] = sp.name
-      loc.path.length = 4
-    } else {
-      loc.path.length = 3
-    }
-    navigate(loc)
+  function selectCategory(sp?: SettingsCategory): void {
+  closePopup();
+  const loc = getCurrentResolvedLocation();
+  loc.fragment = undefined;
+  loc.query = undefined;
+  loc.path[2] = settingId;
+
+  if (sp) {
+    loc.path[3] = sp.name;
+    loc.path.length = 4;
+  } else {
+    loc.path.length = 3;
+    loc.path.push('profile');
   }
+  navigate(loc);
+}
 
   function inviteWorkspace (): void {
     showPopup(login.component.InviteLink, {})


### PR DESCRIPTION
The issue addressed in this pull request was related to the handling of sub-tabs within the settings menu. Initially, upon clicking on settings, no tab was selected, I have explicitly pushed the '/profile' tab when no specific sub-tab is selected, ensuring proper functionality. After this adjustment, the sub-tab behavior operates as intended without any issues.

[Screencast from 10-04-24 10:42:41 PM IST.webm](https://github.com/hcengineering/platform/assets/92533674/0a688026-396f-4bee-bdea-c49df46c4d11)