### PR TITLE
Added colors for an Active Call

### DIFF
--- a/packages/theme/styles/_lumia-colors.scss
+++ b/packages/theme/styles/_lumia-colors.scss
@@ -104,6 +104,9 @@
   --input-HelperColor: #8b97ad;
   --input-error-BorderColor: #fb6863;
   --input-search-IconColor: #ffffff;
+
+  --love-active-call-color-1: #5190EC;
+  --love-active-call-color-2: #F47758;
 }
 
 /* Light Theme */
@@ -181,4 +184,7 @@
   --input-HelperColor: #556178;
   --input-error-BorderColor: #e34748;
   --input-search-IconColor: #0f121a;
+
+  --love-active-call-color-1: #205DC2;
+  --love-active-call-color-2: #e34748;
 }


### PR DESCRIPTION
<img width="393" src="https://github.com/hcengineering/platform/assets/75478678/58b0b1c8-8aef-4f11-bd9e-cb506e1361c5" alt="screen-1">

<img width="393" src="https://github.com/hcengineering/platform/assets/75478678/c13587ba-9257-42e0-97c1-ca694ded935a" alt="screen-1-hover">

<img width="393" src="https://github.com/hcengineering/platform/assets/75478678/b118f8f9-efe8-495b-90f2-660ece8a7bdf" alt="screen-2">

<img width="393" src="https://github.com/hcengineering/platform/assets/75478678/7a03791b-6e58-4904-acbf-97dd177f46b2" alt="screen-2-hover">

**Pull Request Requirements:**

* Provide a brief description of the changeset.
* Include a screenshots if applicable
* Ensure that the changeset adheres to the [DCO guidelines](https://github.com/apps/dco).

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjE3MmUxOGZiMTljMDhlYWJhZDZmNjQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.cYQwGEaS3MSEThg_Ra-kdhaI2jYcxTV6z6iKSuGzllo">Huly&reg;: <b>UBERF-6499</b></a></sub>