### PR TITLE
UBERF-6509: fix reading mention notifications

### DIFF
--- a/plugins/activity-resources/src/activityMessagesUtils.ts
+++ b/plugins/activity-resources/src/activityMessagesUtils.ts
@@ -594,3 +594,11 @@ export function isReactionMessage (message?: ActivityMessage): boolean {
 
   return message.objectClass === activity.class.Reaction
 }
+
+export function isActivityMessageClass (_class?: Ref<Class<Doc>>): boolean {
+  if (_class === undefined) {
+    return false
+  }
+
+  return getClient().getHierarchy().isDerived(_class, activity.class.ActivityMessage)
+}

--- a/plugins/chunter-resources/src/components/chat/navigator/ChatNavItem.svelte
+++ b/plugins/chunter-resources/src/components/chat/navigator/ChatNavItem.svelte
@@ -18,7 +18,12 @@
   import { getClient } from '@hcengineering/presentation'
   import { Action, IconEdit } from '@hcengineering/ui'
   import { getActions } from '@hcengineering/view-resources'
-  import { getNotificationsCount, InboxNotificationsClientImpl } from '@hcengineering/notification-resources'
+  import {
+    getNotificationsCount,
+    InboxNotificationsClientImpl,
+    isActivityNotification,
+    isMentionNotification
+  } from '@hcengineering/notification-resources'
   import { createEventDispatcher } from 'svelte'
 
   import NavItem from './NavItem.svelte'
@@ -38,9 +43,7 @@
   let actions: Action[] = []
 
   notificationClient.inboxNotificationsByContext.subscribe((res) => {
-    notifications = (res.get(context._id) ?? []).filter(
-      ({ _class }) => _class === notification.class.ActivityInboxNotification
-    )
+    notifications = (res.get(context._id) ?? []).filter((n) => isMentionNotification(n) || isActivityNotification(n))
   })
 
   $: void getNotificationsCount(context, notifications).then((res) => {

--- a/plugins/notification-resources/src/components/inbox/Inbox.svelte
+++ b/plugins/notification-resources/src/components/inbox/Inbox.svelte
@@ -13,7 +13,11 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  import notification, { DocNotifyContext, InboxNotification } from '@hcengineering/notification'
+  import notification, {
+    ActivityInboxNotification,
+    DocNotifyContext,
+    InboxNotification
+  } from '@hcengineering/notification'
   import { ActionContext, getClient } from '@hcengineering/presentation'
   import view from '@hcengineering/view'
   import {
@@ -31,15 +35,23 @@
     TabList
   } from '@hcengineering/ui'
   import chunter, { ThreadMessage } from '@hcengineering/chunter'
-  import { Account, getCurrentAccount, IdMap, Ref } from '@hcengineering/core'
+  import { IdMap, Ref } from '@hcengineering/core'
   import activity, { ActivityMessage } from '@hcengineering/activity'
-  import { isReactionMessage } from '@hcengineering/activity-resources'
+  import { isActivityMessageClass, isReactionMessage } from '@hcengineering/activity-resources'
   import { get } from 'svelte/store'
   import { translate } from '@hcengineering/platform'
 
   import { InboxNotificationsClientImpl } from '../../inboxNotificationsClient'
   import Filter from '../Filter.svelte'
-  import { archiveAll, getDisplayInboxData, openInboxDoc, readAll, resolveLocation, unreadAll } from '../../utils'
+  import {
+    archiveAll,
+    getDisplayInboxData,
+    isMentionNotification,
+    openInboxDoc,
+    readAll,
+    resolveLocation,
+    unreadAll
+  } from '../../utils'
   import { InboxData, InboxNotificationsFilter } from '../../types'
   import InboxGroupedListView from './InboxGroupedListView.svelte'
 
@@ -161,7 +173,19 @@
       return
     }
 
-    if (hierarchy.isDerived(selectedContext.attachedToClass, activity.class.ActivityMessage)) {
+    const selectedNotification: InboxNotification | undefined = event?.detail?.notification
+
+    if (isMentionNotification(selectedNotification) && isActivityMessageClass(selectedNotification.mentionedInClass)) {
+      const selectedMsg = selectedNotification.mentionedIn as Ref<ActivityMessage>
+
+      openInboxDoc(
+        selectedContext._id,
+        isActivityMessageClass(selectedContext.attachedToClass)
+          ? (selectedContext.attachedTo as Ref<ActivityMessage>)
+          : undefined,
+        selectedMsg
+      )
+    } else if (hierarchy.isDerived(selectedContext.attachedToClass, activity.class.ActivityMessage)) {
       const message = event?.detail?.notification?.$lookup?.attachedTo
 
       if (selectedContext.attachedToClass === chunter.class.ThreadMessage) {
@@ -172,7 +196,7 @@
       } else if (isReactionMessage(message)) {
         openInboxDoc(selectedContext._id, undefined, selectedContext.attachedTo as Ref<ActivityMessage>)
       } else {
-        const selectedMsg = event?.detail?.notification?.attachedTo
+        const selectedMsg = (selectedNotification as ActivityInboxNotification)?.attachedTo
 
         openInboxDoc(
           selectedContext._id,
@@ -181,7 +205,7 @@
         )
       }
     } else {
-      openInboxDoc(selectedContext._id, undefined, event?.detail?.notification?.attachedTo)
+      openInboxDoc(selectedContext._id, undefined, (selectedNotification as ActivityInboxNotification)?.attachedTo)
     }
   }
 

--- a/plugins/notification-resources/src/utils.ts
+++ b/plugins/notification-resources/src/utils.ts
@@ -35,7 +35,8 @@ import notification, {
   type Collaborators,
   type DisplayInboxNotification,
   type DocNotifyContext,
-  type InboxNotification
+  type InboxNotification,
+  type MentionInboxNotification
 } from '@hcengineering/notification'
 import { MessageBox, getClient } from '@hcengineering/presentation'
 import { getLocation, navigate, showPopup, type Location, type ResolvedLocation } from '@hcengineering/ui'
@@ -274,8 +275,14 @@ export async function unreadAll (): Promise<void> {
   await client.unreadAllNotifications()
 }
 
-export function isActivityNotification (doc: InboxNotification): doc is ActivityInboxNotification {
+export function isActivityNotification (doc?: InboxNotification): doc is ActivityInboxNotification {
+  if (doc === undefined) return false
   return doc._class === notification.class.ActivityInboxNotification
+}
+
+export function isMentionNotification (doc?: InboxNotification): doc is MentionInboxNotification {
+  if (doc === undefined) return false
+  return doc._class === notification.class.MentionInboxNotification
 }
 
 export async function getDisplayInboxNotifications (


### PR DESCRIPTION
Notification about mention was not read for channels

What was done:

1. When user click on a notification about a mention, the corresponding message in the chat is highlighted
2. Read related mention notification on message read
3. Show red circle in chat on mention

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjE3YzcxNmZiMTljMDhlYWJhZDcyYWEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.aQrj99wAlnPxKKIen4TrGdKLVoBYsJKEaCZqomgio2E">Huly&reg;: <b>UBERF-6512</b></a></sub>