### PR TITLE
Fix for null lastName during signup with google

### DIFF
--- a/server/account/src/index.ts
+++ b/server/account/src/index.ts
@@ -1746,6 +1746,9 @@ export async function joinWithProvider (
   const email = cleanEmail(_email)
   const invite = await getInvite(db, inviteId)
   const workspace = await checkInvite(invite, email)
+  if (last == null) {
+    last = ''
+  }
   let account = await getAccount(db, email)
   if (account == null && extra !== undefined) {
     account = await getAccountByQuery(db, extra)
@@ -1795,6 +1798,9 @@ export async function loginWithProvider (
   extra?: Record<string, string>
 ): Promise<LoginInfo> {
   const email = cleanEmail(_email)
+  if (last == null) {
+    last = ''
+  }
   let account = await getAccount(db, email)
   if (account == null && extra !== undefined) {
     account = await getAccountByQuery(db, extra)
@@ -1811,7 +1817,6 @@ export async function loginWithProvider (
     }
     return result
   }
-
   const newAccount = await createAcc(ctx, db, productId, email, null, first, last, true, extra)
 
   const result = {


### PR DESCRIPTION
**Pull Request Requirements:**

* Provide a brief description of the changeset Last Name (Family Name) is not mandatory in google accounts. When signing up with Google, null is being received under last Name parameter and this appears in the UI causing bad user experience. However, already created accounts will still see null in their last Name and this requires data migration to fix.
* Include a screenshots if applicable

  ![image](https://github.com/hcengineering/platform/assets/89013637/002a656f-1c49-4909-9325-8b12f7145a9a)

  ![image](https://github.com/hcengineering/platform/assets/89013637/57975f09-f837-494c-8b08-3c0183c373f7)

  ![image](https://github.com/hcengineering/platform/assets/89013637/3e3ab306-42a6-44cf-a55f-192b403a5465)
* Ensure that the changeset adheres to the [DCO guidelines](https://github.com/apps/dco).

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjE4NmM0NGZiMTljMDhlYWJhZDc2NGYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.lVHidqSAIFtCq1W3bnmsqlJEyFZCKj6cZWBA7Nae4C4">Huly&reg;: <b>UBERF-6518</b></a></sub>