### PR TITLE
UBERF-6523: Allow to use zstd compression for mongo access.

### DIFF
--- a/plugins/workbench-resources/src/components/ServerManager.svelte
+++ b/plugins/workbench-resources/src/components/ServerManager.svelte
@@ -30,27 +30,34 @@
     endpoint = endpoint.substring(0, endpoint.length - 1)
   }
 
+  async function fetchStats (): Promise<void> {
+    await fetch(endpoint + `/api/v1/statistics?token=${token}`, {})
+      .then(async (json) => {
+        data = await json.json()
+        admin = data?.admin ?? false
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }
+  async function fetchUIStats (): Promise<void> {
+    await fetch(`/api/v1/statistics?token=${token}`, {})
+      .then(async (json) => {
+        dataFront = await json.json()
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }
+
   let data: any
   let dataFront: any
   let admin = false
   onDestroy(
     ticker.subscribe(() => {
-      void fetch(endpoint + `/api/v1/statistics?token=${token}`, {})
-        .then(async (json) => {
-          data = await json.json()
-          admin = data?.admin ?? false
-        })
-        .catch((err) => {
-          console.error(err)
-        })
+      void fetchStats()
 
-      void fetch(`/api/v1/statistics?token=${token}`, {})
-        .then(async (json) => {
-          dataFront = await json.json()
-        })
-        .catch((err) => {
-          console.error(err)
-        })
+      void fetchUIStats()
     })
   )
   const tabs: TabItem[] = [
@@ -264,6 +271,24 @@
         {/each}
       </div>
     {:else if selectedTab === 'statistics'}
+      {#if admin}
+        <div class="flex flex-col">
+          <div class="flex-row-center p-1">
+            <div class="p-3">1.</div>
+            <Button
+              icon={IconArrowRight}
+              label={getEmbeddedLabel('Wipe statistics')}
+              on:click={() => {
+                void fetch(endpoint + `/api/v1/manage?token=${token}&operation=wipe-statistics`, {
+                  method: 'PUT'
+                }).then(async () => {
+                  await fetchStats()
+                })
+              }}
+            />
+          </div>
+        </div>
+      {/if}
       <div class="flex-column p-3 h-full" style:overflow="auto">
         {#if metricsData !== undefined}
           <MetricsInfo metrics={metricsData} />

--- a/pods/account/Dockerfile
+++ b/pods/account/Dockerfile
@@ -1,8 +1,9 @@
-FROM node:20-alpine
+FROM node:20
 
 WORKDIR /usr/src/app
 
 COPY bundle/bundle.js ./
+RUN npm install --ignore-scripts=false --verbose bufferutil utf-8-validate @mongodb-js/zstd --unsafe-perm
 
 EXPOSE 3000
 CMD [ "node", "bundle.js" ]

--- a/pods/backup/Dockerfile
+++ b/pods/backup/Dockerfile
@@ -1,8 +1,9 @@
 
-FROM node:20-alpine
+FROM node:20
 
 WORKDIR /usr/src/app
 
+RUN npm install --ignore-scripts=false --verbose bufferutil utf-8-validate @mongodb-js/zstd --unsafe-perm
 COPY bundle/bundle.js ./
 
 EXPOSE 3000

--- a/pods/collaborator/Dockerfile
+++ b/pods/collaborator/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:20
 
 WORKDIR /usr/src/app
-RUN npm install --ignore-scripts=false --verbose bufferutil --unsafe-perm
+RUN npm install --ignore-scripts=false --verbose bufferutil utf-8-validate @mongodb-js/zstd --unsafe-perm
 
 COPY bundle/bundle.js ./
 

--- a/pods/front/Dockerfile
+++ b/pods/front/Dockerfile
@@ -1,13 +1,11 @@
-FROM node:20-alpine
+FROM node:20
 
-RUN apk add dumb-init
 ENV NODE_ENV production
 
 WORKDIR /app
-RUN npm install --ignore-scripts=false --verbose sharp@v0.32.6 --unsafe-perm
-
+RUN npm install --ignore-scripts=false --verbose sharp@v0.32.6 bufferutil utf-8-validate @mongodb-js/zstd --unsafe-perm
 COPY bundle/bundle.js ./
 COPY dist/ ./dist/
 
 EXPOSE 8080
-CMD [ "dumb-init", "node", "./bundle.js" ]
+CMD [ "node", "./bundle.js" ]

--- a/pods/server/Dockerfile
+++ b/pods/server/Dockerfile
@@ -3,10 +3,9 @@ FROM node:20
 ENV NODE_ENV production
 
 WORKDIR /app
-RUN npm install --ignore-scripts=false --verbose bufferutil --unsafe-perm
+RUN npm install --ignore-scripts=false --verbose bufferutil utf-8-validate @mongodb-js/zstd --unsafe-perm
 
 COPY bundle/bundle.js ./
-# COPY ./dist/*.node ./
 
 EXPOSE 8080
 CMD [ "node", "./bundle.js" ]

--- a/server/mongo/src/rawAdapter.ts
+++ b/server/mongo/src/rawAdapter.ts
@@ -45,8 +45,7 @@ export function createRawMongoDBAdapter (url: string): RawDBAdapter {
       const db = getWorkspaceDB(await client.getClient(), workspace)
       const coll = db.collection(domain)
       let cursor = coll.find<T>(query as Filter<Document>, {
-        checkKeys: false,
-        enableUtf8Validation: false
+        checkKeys: false
       })
 
       let total: number = -1

--- a/server/ws/src/server_http.ts
+++ b/server/ws/src/server_http.ts
@@ -22,7 +22,7 @@ import cors from 'cors'
 import express from 'express'
 import http, { type IncomingMessage } from 'http'
 import { WebSocketServer, type RawData, type WebSocket } from 'ws'
-import { getStatistics } from './stats'
+import { getStatistics, wipeStatistics } from './stats'
 import {
   LOGGING_ENABLED,
   type ConnectionSocket,
@@ -118,7 +118,14 @@ export function startHttpServer (
 
           res.writeHead(200)
           res.end()
-          break
+          return
+        }
+        case 'wipe-statistics': {
+          wipeStatistics(ctx)
+
+          res.writeHead(200)
+          res.end()
+          return
         }
         case 'reboot': {
           process.exit(0)


### PR DESCRIPTION
Allow to pass compressors=zstd as part of mongo url to enable compression between transactor and mongodb

* allow to wipe statistics for admin users.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjE4Y2RiNmZiMTljMDhlYWJhZDc4ODciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.uL6zGDitkA_Ue5ibQ5arHVZX9y5b96TRgQhOIdoDf14">Huly&reg;: <b>UBERF-6524</b></a></sub>