### PR TITLE
UBERF-6537: Fix teamspace creation

### DIFF
--- a/models/document/src/migration.ts
+++ b/models/document/src/migration.ts
@@ -314,15 +314,18 @@ export const documentOperation: MigrateOperation = {
   },
 
   async upgrade (client: MigrationUpgradeClient): Promise<void> {
+    const tx = new TxOperations(client, core.account.System)
     await tryUpgrade(client, documentId, [
       {
         state: 'u-default-project',
         func: async (client) => {
-          const tx = new TxOperations(client, core.account.System)
           await createSpace(tx)
-          await createDefaultTeamspaceType(tx)
         }
       }
     ])
+
+    // Currently space type has to be recreated every time as it's in the model
+    // created by the system user
+    await createDefaultTeamspaceType(tx)
   }
 }


### PR DESCRIPTION
* Fixes new teamspace (and vacancies) creation by re-creating default project types for these modules all the time as they are removed on every upgrade

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-6537

Closes: https://github.com/hcengineering/platform/issues/5353

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjFiYzg3MmZiMTljMDhlYWJhZDgwYWYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.9-3SJ7wp2Xq6KB1CAw_vc_hY0h8aEgeJ7fLKQel2IfU">Huly&reg;: <b>UBERF-6550</b></a></sub>