### PR TITLE
UBERF-6585 Show hr event description as text

### DIFF
--- a/plugins/hr-resources/package.json
+++ b/plugins/hr-resources/package.json
@@ -51,6 +51,7 @@
     "@hcengineering/contact-resources": "^0.6.0",
     "@hcengineering/attachment-resources": "^0.6.0",
     "@hcengineering/workbench-resources": "^0.6.1",
+    "@hcengineering/text": "^0.6.1",
     "@hcengineering/text-editor": "^0.6.0",
     "@hcengineering/setting": "^0.6.11",
     "@hcengineering/attachment": "^0.6.9",

--- a/plugins/hr-resources/src/components/schedule/ScheduleRequest.svelte
+++ b/plugins/hr-resources/src/components/schedule/ScheduleRequest.svelte
@@ -15,6 +15,7 @@
 <script lang="ts">
   import hr, { Request, RequestType } from '@hcengineering/hr'
   import { getClient } from '@hcengineering/presentation'
+  import { jsonToText, markupToJSON } from '@hcengineering/text'
   import { Icon, Label, closeTooltip } from '@hcengineering/ui'
   import { showMenu } from '@hcengineering/view-resources'
 
@@ -40,7 +41,7 @@
     showMenu(e, { object: request })
   }
 
-  $: description = shouldShowDescription ? request.description.replace(/<[^>]*>/g, '').trim() : ''
+  $: description = shouldShowDescription ? jsonToText(markupToJSON(request.description)) : ''
 </script>
 
 {#await getType(request) then type}


### PR DESCRIPTION
Fixed descriptions display. Probably should remove markup from these descriptions and use plain text.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjFmNjVjZWFmNmZhZmI3OWM0YTQyODUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.HWDlt4vP0p1YfbkOkQwLTlgaTIJRFrniBjmcMjKcZVM">Huly&reg;: <b>UBERF-6588</b></a></sub>