### PR TITLE
UBERF-6633: Fix model enabled tracking

### DIFF
--- a/models/all/src/index.ts
+++ b/models/all/src/index.ts
@@ -341,7 +341,7 @@ export default function buildModel (enabled: string[] = ['*'], disabled: string[
         ...config,
         enabled:
           config?.label === undefined ||
-          ((config?.enabled ?? true) && (enabled.includes(id) || enabled.includes('*')) && !disabled.includes(id)),
+          (((config?.enabled ?? true) || enabled.includes(id) || enabled.includes('*')) && !disabled.includes(id)),
         beta: config?.beta ?? false
       },
       ('plugin-configuration-' + id) as Ref<PluginConfiguration>


### PR DESCRIPTION
UBERF-6633: Fix model enabled tracking

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjIxZmVlNjEyMTRhOWI4YTEyZTRhYjkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.kvFj8S6d9DeozXcMWvSv2wEjeJ18QeMkiw6br184qyM">Huly&reg;: <b>UBERF-6634</b></a></sub>