### PR TITLE
TSK-1692 Use code tag for inline code block

### DIFF
--- a/packages/presentation/src/components/markup/Mark.svelte
+++ b/packages/presentation/src/components/markup/Mark.svelte
@@ -45,7 +45,7 @@
   {#if mark.type === MarkupMarkType.bold}
     <strong><slot /></strong>
   {:else if mark.type === MarkupMarkType.code}
-    <pre class="proseCode"><slot /></pre>
+    <code class="proseCode"><slot /></code>
   {:else if mark.type === MarkupMarkType.em}
     <em><slot /></em>
   {:else if mark.type === MarkupMarkType.link}


### PR DESCRIPTION
Use `code` instead of `pre` for inline code.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjIzN2IwNmY1ODA2NzU5MzdjY2E1YzgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.qGN2j1QNxsDiAh--LU77t1nnLFzY7ln2NEa3nG-s5c0">Huly&reg;: <b>UBERF-6648</b></a></sub>