### PR TITLE
fix-#5319 (opening contact us page in a new tab)

### DIFF
--- a/plugins/workbench-resources/src/components/Workbench.svelte
+++ b/plugins/workbench-resources/src/components/Workbench.svelte
@@ -701,7 +701,7 @@
           size={appsMini ? 'small' : 'large'}
           on:click={() => showPopup(AppSwitcher, { apps }, popupPosition)}
         />
-        <a href={supportLink}>
+        <a href={supportLink} target="_blank" rel="noopener noreferrer">
           <AppItem
             icon={support.icon.Support}
             label={support.string.ContactUs}


### PR DESCRIPTION
**Pull Request Requirements:**

* Fix the #5319 issue that opens Contact Us page in a new tab. Also, added a security layer that a new tab does not have access back to the originating page.
* Ensure that the changeset adheres to the [DCO guidelines](https://github.com/apps/dco).

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjIzY2EyMmY1ODA2NzU5MzdjY2E2Y2IiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.F1pCLW3pKR_eDsUxa1YwnKvKVvhfb3wAX8laoMCgPpo">Huly&reg;: <b>UBERF-6649</b></a></sub>