### PR TITLE
Fix incorecct message rendering in inbox

### DIFF
--- a/plugins/notification-resources/src/utils.ts
+++ b/plugins/notification-resources/src/utils.ts
@@ -375,10 +375,12 @@ export async function getDisplayInboxNotifications (
         continue
       }
 
+      const combined = activityNotifications.filter(({ attachedTo }) => ids.includes(attachedTo))
+
       const displayNotification = {
         ...activityNotification,
-        combinedIds: activityNotifications.filter(({ attachedTo }) => ids.includes(attachedTo)).map(({ _id }) => _id),
-        combinedMessages: activityNotifications
+        combinedIds: combined.map(({ _id }) => _id),
+        combinedMessages: combined
           .map((a) => a.$lookup?.attachedTo)
           .filter((m): m is ActivityMessage => m !== undefined)
       }


### PR DESCRIPTION
Fixed a bug due to which the same messages could be displayed in the inbox

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjI2MjZhMTViMGU1MzQ2OTA5MmM0ZGYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.xOIqbVC38oq9u9AirDMg8KbmBpx-bawK1NTXrpCu2Jc">Huly&reg;: <b>UBERF-6662</b></a></sub>