### PR TITLE
Fix double notifications contexts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,7 +51,8 @@
         // "SERVER_PROVIDER":"uweb"
         "SERVER_PROVIDER":"ws",
         "MODEL_VERSION": "",
-        "ELASTIC_INDEX_NAME": "local_storage_index"
+        "ELASTIC_INDEX_NAME": "local_storage_index",
+        "UPLOAD_URL": "/files",
         
         // "RETRANSLATE_URL": "http://127.0.0.1:4500",
         //"RETRANSLATE_URL": "https://208.167.249.201",

--- a/server-plugins/chunter-resources/src/index.ts
+++ b/server-plugins/chunter-resources/src/index.ts
@@ -464,22 +464,22 @@ async function OnChannelMembersChanged (tx: TxUpdateDoc<Channel>, control: Trigg
     const context = allContexts.find(({ user }) => user === addedMember)
 
     if (context === undefined) {
-      res.push(
-        control.txFactory.createTxCreateDoc(notification.class.DocNotifyContext, tx.objectSpace, {
-          attachedTo: tx.objectId,
-          attachedToClass: tx.objectClass,
-          user: addedMember,
-          hidden: false,
-          lastViewedTimestamp: tx.modifiedOn
-        })
-      )
+      const createTx = control.txFactory.createTxCreateDoc(notification.class.DocNotifyContext, tx.objectSpace, {
+        attachedTo: tx.objectId,
+        attachedToClass: tx.objectClass,
+        user: addedMember,
+        hidden: false,
+        lastViewedTimestamp: tx.modifiedOn
+      })
+
+      await control.apply([createTx], true)
     } else {
-      res.push(
-        control.txFactory.createTxUpdateDoc(context._class, context.space, context._id, {
-          hidden: false,
-          lastViewedTimestamp: tx.modifiedOn
-        })
-      )
+      const updateTx = control.txFactory.createTxUpdateDoc(context._class, context.space, context._id, {
+        hidden: false,
+        lastViewedTimestamp: tx.modifiedOn
+      })
+
+      await control.apply([updateTx], true)
     }
   }
 

--- a/server-plugins/notification-resources/src/index.ts
+++ b/server-plugins/notification-resources/src/index.ts
@@ -403,15 +403,14 @@ export async function pushInboxNotifications (
       hidden: false,
       lastUpdateTimestamp: shouldUpdateTimestamp ? modifiedOn : undefined
     })
-    res.push(createContextTx)
+    await control.apply([createContextTx], true)
     docNotifyContextId = createContextTx.objectId
   } else {
     if (shouldUpdateTimestamp) {
-      res.push(
-        control.txFactory.createTxUpdateDoc(context._class, context.space, context._id, {
-          lastUpdateTimestamp: modifiedOn
-        })
-      )
+      const updateTx = control.txFactory.createTxUpdateDoc(context._class, context.space, context._id, {
+        lastUpdateTimestamp: modifiedOn
+      })
+      await control.apply([updateTx], true)
     }
     docNotifyContextId = context._id
   }


### PR DESCRIPTION
Fixed double notifications contexts when issue created with `Todo` status

Bug:
![Screenshot from 2024-04-22 13-41-21](https://github.com/hcengineering/platform/assets/113431133/224c0e85-a94c-4cf1-b50a-9534a8f7b0cf)

After fix:
![Screenshot from 2024-04-22 13-46-44](https://github.com/hcengineering/platform/assets/113431133/82c3565c-dfc4-4176-adc6-1764a8858223)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjI2MzJhZDViMGU1MzQ2OTA5MmM1NTQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.X_oP-Za_qmDQ2MqAFblZOo4bdfAZSkfSCJEPV61MUr8">Huly&reg;: <b>UBERF-6663</b></a></sub>