### PR TITLE
FIX: Optimize Emoji load and highlight Symbols icon on scroll

### DIFF
--- a/packages/ui/src/components/EmojiPopup.svelte
+++ b/packages/ui/src/components/EmojiPopup.svelte
@@ -105,7 +105,7 @@
 
   let currentCategory = categories[0]
 
-  function getEmojis(startCode: number, endCode: number, postfix?: number[]): Array<string | undefined> {
+  function getEmojis(startCode: number, endCode: number, postfix?: number[]): Array<string> {
     const result = []
     for (let i = startCode; i <= endCode; i++) {
       const codePoints = [i, ...(postfix || [])]

--- a/packages/ui/src/components/EmojiPopup.svelte
+++ b/packages/ui/src/components/EmojiPopup.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import emojiRegex from 'emoji-regex'
-  import { createEventDispatcher, getContext } from 'svelte'
+  import { createEventDispatcher, getContext, onMount } from 'svelte'
   import { IntlString } from '@hcengineering/platform'
 
   import Label from './Label.svelte'
@@ -16,8 +16,6 @@
   import { tooltip } from '../tooltips'
   import { AnySvelteComponent, emojiSP } from '../types'
   import plugin from '../plugin'
-  import { fromCodePoint } from '../utils'
-
   export let embedded = false
   export let selected: string | undefined
 
@@ -107,12 +105,16 @@
 
   let currentCategory = categories[0]
 
-  function getEmojis (startCode: number, endCode: number, postfix?: number[]): Array<string | undefined> {
-    return [...Array(endCode - startCode + 1).keys()].map((v) => {
-      const str = postfix ? fromCodePoint(v + startCode, ...postfix) : fromCodePoint(v + startCode)
-      if ([...str.matchAll(regex)].length > 0) return str
-      return undefined
-    })
+  function getEmojis(startCode: number, endCode: number, postfix?: number[]): Array<string | undefined> {
+    const result = []
+    for (let i = startCode; i <= endCode; i++) {
+      const codePoints = [i, ...(postfix || [])]
+      const str = String.fromCodePoint(...codePoints)
+      if (regex.test(str)) {
+        result.push(str)
+      }
+    }
+    return result
   }
 
   function handleScrollToCategory (categoryId: string) {
@@ -134,7 +136,7 @@
 
       const emojisElement = labelElement.nextElementSibling as HTMLElement
 
-      return emojisElement.offsetTop + emojisElement.offsetHeight - emojiRowHeightPx > scrollElement.scrollTop
+      return (emojisElement.offsetTop + emojisElement.offsetHeight) * 0.9 - emojiRowHeightPx > scrollElement.scrollTop
     })
 
     if (selectedCategory) {


### PR DESCRIPTION
* Change the way that we generate emojis (loop function)
* When we scroll the emojis, Symbols icon category was not highlighted, Now we move to next category when we are at 90% scroll of the precedent category div size