### PR TITLE
UBERF-6411 Fix documents max width

### DIFF
--- a/plugins/document-resources/src/components/EditDoc.svelte
+++ b/plugins/document-resources/src/components/EditDoc.svelte
@@ -66,8 +66,6 @@
 
   $: readonly = $restrictionStore.readonly
 
-  let useMaxWidth = true
-
   export function canClose (): boolean {
     return false
   }
@@ -241,7 +239,6 @@
     {kind}
     bind:content
     bind:innerWidth
-    bind:useMaxWidth
     floatAside={false}
     on:open
     on:close={() => dispatch('close')}
@@ -272,7 +269,7 @@
       {/if}
     </svelte:fragment>
 
-    <div class="container" class:container-max-width={useMaxWidth}>
+    <div class="container">
       <div class="title flex-row-center">
         <div class="icon">
           <Button
@@ -389,10 +386,6 @@
     flex-direction: column;
     width: 100%;
     margin: auto;
-  }
-
-  .container-max-width {
-    max-width: 700px;
   }
 
   .toc-container {


### PR DESCRIPTION
Use default platform max width control.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjI5MjQzY2Y2ZjRiZWI4MjliNTlmMWEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.nrmgaaX1YU52hB9CVf4ws1oAG3Lu4RmXOeGMU-us1hk">Huly&reg;: <b>UBERF-6716</b></a></sub>