### PR TITLE
fix: show max width button in documents

### DIFF
--- a/plugins/document-resources/src/components/EditDoc.svelte
+++ b/plugins/document-resources/src/components/EditDoc.svelte
@@ -235,6 +235,7 @@
     isHeader={false}
     isCustomAttr={false}
     isSub={false}
+    useMaxWidth={false}
     {embedded}
     {kind}
     bind:content


### PR DESCRIPTION
accidentally removed useMaxwidth parameter that changed behavior, by default the button is hidden

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjJiNjAxZTg4M2UwMDk0ZTNhOTRhMjgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.ZChbWX_QmCy0IRLg_mnxTw2-crCW8efeMP5aCnui1rs">Huly&reg;: <b>UBERF-6735</b></a></sub>