### PR TITLE
QFix: Connection should restore boolean query fields

### DIFF
--- a/plugins/client-resources/src/connection.ts
+++ b/plugins/client-resources/src/connection.ts
@@ -586,7 +586,7 @@ class Connection implements ClientConnection {
         doc._class = _class
       }
       for (const [k, v] of Object.entries(query)) {
-        if (typeof v === 'string' || typeof v === 'number') {
+        if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
           if (doc[k] == null) {
             doc[k] = v
           }


### PR DESCRIPTION
QFix: Connection should restore boolean query fields

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjM3YTBlMWM2MTdkNTcxZjcwZTMzOTEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.k7YDcm876h-_QluDtJJEGO-u8wxLuj6nVgJXOdXZimY">Huly&reg;: <b>UBERF-6789</b></a></sub>