### PR TITLE
EZQMS-798: Fix role name update

### DIFF
--- a/models/server-setting/src/index.ts
+++ b/models/server-setting/src/index.ts
@@ -15,7 +15,7 @@
 //
 
 import { type Builder } from '@hcengineering/model'
-
+import serverCore from '@hcengineering/server-core'
 import core from '@hcengineering/core'
 import serverNotification from '@hcengineering/server-notification'
 import serverSetting from '@hcengineering/server-setting'
@@ -64,4 +64,15 @@ export function createModel (builder: Builder): void {
       serverFunc: serverSetting.function.GetOwnerPosition
     }
   )
+
+  builder.createDoc(serverCore.class.Trigger, core.space.Model, {
+    trigger: serverSetting.trigger.OnRoleNameUpdate,
+    txMatch: {
+      _class: core.class.TxCollectionCUD,
+      objectSpace: core.space.Model,
+      collection: 'roles',
+      'tx._class': core.class.TxUpdateDoc,
+      'tx.objectClass': core.class.Role
+    }
+  })
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -619,9 +619,16 @@ export interface RoleAttributeBaseProps {
 export function getRoleAttributeBaseProps (data: AttachedData<Role>, roleId: Ref<Role>): RoleAttributeBaseProps {
   const name = data.name.trim()
   const label = getEmbeddedLabel(`Role: ${name}`)
-  const id = `role-${roleId}` as Ref<Attribute<PropertyType>>
+  const id = getRoleAttributeId(roleId)
 
   return { label, id }
+}
+
+/**
+ * @public
+ */
+export function getRoleAttributeId (roleId: Ref<Role>): Ref<Attribute<PropertyType>> {
+  return `role-${roleId}` as Ref<Attribute<PropertyType>>
 }
 
 /**

--- a/server-plugins/setting/src/index.ts
+++ b/server-plugins/setting/src/index.ts
@@ -16,6 +16,7 @@
 import type { Plugin, Resource } from '@hcengineering/platform'
 import { plugin } from '@hcengineering/platform'
 import { Presenter } from '@hcengineering/server-notification'
+import { TriggerFunc } from '@hcengineering/server-core'
 import { TemplateFieldServerFunc } from '@hcengineering/server-templates'
 
 /**
@@ -34,5 +35,8 @@ export default plugin(serverSettingId, {
     GetFirstName: '' as Resource<TemplateFieldServerFunc>,
     GetLastName: '' as Resource<TemplateFieldServerFunc>,
     GetOwnerPosition: '' as Resource<TemplateFieldServerFunc>
+  },
+  trigger: {
+    OnRoleNameUpdate: '' as Resource<TriggerFunc>
   }
 })


### PR DESCRIPTION
* Updates the corresponding role's mixin attribute when the role name is updated

Related to: https://front.hc.engineering/workbench/platform/tracker/EZQMS-798

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjM3ZGRmZGM2MTdkNTcxZjcwZTM0ZjUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.Croq3nkauFKOYmEujeBh4YFC_-vNbsguY7H5wJ7Eyrg">Huly&reg;: <b>UBERF-6799</b></a></sub>