### PR TITLE
Add group analytics to track workspace activity

### DIFF
--- a/plugins/guest-resources/src/connect.ts
+++ b/plugins/guest-resources/src/connect.ts
@@ -113,11 +113,11 @@ export async function connect (title: string): Promise<Client | undefined> {
   )
   console.log('logging in as guest')
   Analytics.handleEvent('GUEST LOGIN')
-  Analytics.setTag('workspace', ws)
+  Analytics.setWorkspace(ws)
   const me = await _client?.getAccount()
   if (me !== undefined) {
     Analytics.setUser(me.email)
-    Analytics.setTag('workspace', ws)
+    Analytics.setWorkspace(ws)
     console.log('login: employee account', me)
     setCurrentAccount(me)
   }

--- a/plugins/login-resources/src/utils.ts
+++ b/plugins/login-resources/src/utils.ts
@@ -179,7 +179,7 @@ export async function createWorkspace (
     const result = await response.json()
     if (result.error == null) {
       Analytics.handleEvent('create workspace')
-      Analytics.setTag('workspace', workspaceName)
+      Analytics.setWorkspace(workspaceName)
     } else {
       await handleStatusError('Create workspace error', result.error)
     }
@@ -337,7 +337,7 @@ export async function selectWorkspace (workspace: string): Promise<[Status, Work
     const result = await response.json()
     if (result.error == null) {
       Analytics.handleEvent('Select workspace')
-      Analytics.setTag('workspace', workspace)
+      Analytics.setWorkspace(workspace)
     } else {
       await handleStatusError('Select workspace error', result.error)
     }
@@ -386,7 +386,7 @@ export async function fetchWorkspace (workspace: string): Promise<[Status, Works
     const result = await response.json()
     if (result.error == null) {
       Analytics.handleEvent('Fetch workspace')
-      Analytics.setTag('workspace', workspace)
+      Analytics.setWorkspace(workspace)
     } else {
       await handleStatusError('Fetch workspace error', result.error)
     }
@@ -433,7 +433,7 @@ export async function createMissingEmployee (workspace: string): Promise<[Status
     const result = await response.json()
     if (result.error == null) {
       Analytics.handleEvent('Create missing employee')
-      Analytics.setTag('workspace', workspace)
+      Analytics.setWorkspace(workspace)
     } else {
       await handleStatusError('Fetch workspace error', result.error)
     }


### PR DESCRIPTION
* Adds `posthog.group()` call to `setWorkspace()` in `PosthogAnalyticProvider` to create user groups based on workspaces ([see PR in uberflow](https://github.com/hcengineering/uberflow/pull/1163))
* Replaces `setTag()` call with `setWorkspace()` in places where this is used to add a workspace tag to the user
* This in combination with the [analytics PR in uberflow](https://github.com/hcengineering/uberflow/pull/1163) will be used to track workspace activity in PostHog

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjM4Yjg1ZmM2MTdkNTcxZjcwZTM2ZjAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.2M_31C0y5Gh0IGylOIsnYKUkBSZ1zCZauCFkmO0VA8A">Huly&reg;: <b>UBERF-6804</b></a></sub>