### PR TITLE
fix: add missing productId to getAccountInfo

### DIFF
--- a/server/account/src/operations.ts
+++ b/server/account/src/operations.ts
@@ -226,7 +226,13 @@ function toAccountInfo (account: Account): AccountInfo {
   return result
 }
 
-async function getAccountInfo (ctx: MeasureContext, db: Db, email: string, password: string): Promise<AccountInfo> {
+async function getAccountInfo (
+  ctx: MeasureContext,
+  db: Db,
+  productId: string,
+  email: string,
+  password: string
+): Promise<AccountInfo> {
   const account = await getAccount(db, email)
   if (account === null) {
     throw new PlatformError(new Status(Severity.ERROR, platform.status.AccountNotFound, { account: email }))
@@ -285,7 +291,7 @@ export async function login (
 ): Promise<LoginInfo> {
   const email = cleanEmail(_email)
   try {
-    const info = await getAccountInfo(ctx, db, email, password)
+    const info = await getAccountInfo(ctx, db, productId, email, password)
     const result = {
       endpoint: getEndpoint(),
       email,
@@ -1496,7 +1502,7 @@ export async function changePassword (
   password: string
 ): Promise<void> {
   const { email } = decodeToken(token)
-  const account = await getAccountInfo(ctx, db, email, oldPassword)
+  const account = await getAccountInfo(ctx, db, productId, email, oldPassword)
 
   const salt = randomBytes(32)
   const hash = hashWithSalt(password, salt)


### PR DESCRIPTION
getAccountInfo is exposed via account REST API, but does not satisfy the contract. `productId` should be specified in the method signature even though it is not used.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjNiMTE2M2M2MTdkNTcxZjcwZTQzNDMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.WRMQJjgQ2jKO99w57ZqSUgKn1AhfkFCx-Ps4IFvpisk">Huly&reg;: <b>UBERF-6846</b></a></sub>