### PR TITLE
disable cache to get uWebsockets

### DIFF
--- a/server/ws/package.json
+++ b/server/ws/package.json
@@ -12,7 +12,7 @@
     "build:watch": "./uws.sh && compile && cp ./src/uws/*.node ./lib/uws",
     "test": "jest --passWithNoTests --silent --forceExit",
     "format": "format src",
-    "_phase:build": "./uws.sh && compile transpile src && cp ./src/uws/*.node ./lib/uws",
+    "_phase:build": "RUSH_BUILD_CACHE_ENABLED=0 ./uws.sh && compile transpile src && cp ./src/uws/*.node ./lib/uws",
     "_phase:test": "jest --passWithNoTests --silent --forceExit",
     "_phase:format": "format src",
     "_phase:validate": "./uws.sh && compile validate"


### PR DESCRIPTION
Fix for lost uwebsockets file if build is restored from cache

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjNiOTUxOWQwNjNiZTNlZGIxMWRmNDkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.x_9_8_vQBBMNbeuUi3XlQwL1PYwWOeY87xdUlBj5exg">Huly&reg;: <b>UBERF-6865</b></a></sub>