### PR TITLE
Fix extra inbox notifications

### DIFF
--- a/plugins/activity-resources/src/components/doc-update-message/DocUpdateMessageObjectValue.svelte
+++ b/plugins/activity-resources/src/components/doc-update-message/DocUpdateMessageObjectValue.svelte
@@ -91,6 +91,9 @@
         {/if}
       </span>
     {/await}
+    {#if hasSeparator}
+      <span class="ml-1" />
+    {/if}
   {/if}
 {/if}
 


### PR DESCRIPTION
Fixed a bug due to which a `user` could receive extra `notifications` if multiple fields were changed in a `tx`

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjNiYWI3MGQwNjNiZTNlZGIxMWUwMDYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0._LqvLVCJ_rcyNR0S1LqbokN8bI03iEWFE-X17gH2SUs">Huly&reg;: <b>UBERF-6867</b></a></sub>