### PR TITLE
Improve directs sort order

### DIFF
--- a/plugins/chunter-resources/src/components/chat/navigator/ChatNavSection.svelte
+++ b/plugins/chunter-resources/src/components/chat/navigator/ChatNavSection.svelte
@@ -21,10 +21,11 @@
   import contact from '@hcengineering/contact'
   import { getResource, translate } from '@hcengineering/platform'
   import view from '@hcengineering/view'
+  import { personAccountByIdStore, statusByUserStore } from '@hcengineering/contact-resources'
 
   import ChatNavItem from './ChatNavItem.svelte'
   import chunter from '../../../plugin'
-  import { ChatNavItemModel } from '../types'
+  import { ChatNavItemModel, SortFnOptions } from '../types'
   import { getObjectIcon, getChannelName } from '../../../utils'
   import { navigatorStateStore, toggleSections } from '../utils'
 
@@ -35,11 +36,12 @@
   export let actions: Action[] = []
   export let maxItems: number | undefined = undefined
   export let objectId: Ref<Doc> | undefined
-  export let sortFn: (items: ChatNavItemModel[], contexts: DocNotifyContext[]) => ChatNavItemModel[]
+  export let sortFn: (items: ChatNavItemModel[], options: SortFnOptions) => ChatNavItemModel[]
 
   const client = getClient()
   const hierarchy = client.getHierarchy()
 
+  let sortedItems: ChatNavItemModel[] = []
   let items: ChatNavItemModel[] = []
   let visibleItems: ChatNavItemModel[] = []
 
@@ -50,12 +52,17 @@
   $: isCollapsed = $navigatorStateStore.collapsedSections.includes(id)
 
   $: void getChatNavItems(objects).then((res) => {
-    items = sortFn(res, contexts)
+    items = res
   })
 
+  $: sortedItems = sortFn(items, {
+    contexts,
+    userStatusByAccount: $statusByUserStore,
+    personAccountById: $personAccountByIdStore
+  })
   $: canShowMore = !!maxItems && items.length > maxItems
 
-  $: visibleItems = getVisibleItems(canShowMore, isShownMore, maxItems, items, objectId)
+  $: visibleItems = getVisibleItems(canShowMore, isShownMore, maxItems, sortedItems, objectId)
 
   async function getChatNavItems (objects: Doc[]): Promise<ChatNavItemModel[]> {
     const items: ChatNavItemModel[] = []
@@ -132,7 +139,7 @@
   }
 </script>
 
-{#if items.length > 0 && contexts.length > 0}
+{#if visibleItems.length > 0 && contexts.length > 0}
   <NavGroup
     title={header}
     categoryName={id}
@@ -161,7 +168,7 @@
         </div>
       {/if}
     {:else if objectId}
-      {@const item = items.find(({ id }) => id === objectId)}
+      {@const item = visibleItems.find(({ id }) => id === objectId)}
       {#if item}
         {@const context = contexts.find(({ attachedTo }) => attachedTo === item.id)}
         <ChatNavItem {context} isSelected {item} on:select />

--- a/plugins/chunter-resources/src/components/chat/types.ts
+++ b/plugins/chunter-resources/src/components/chat/types.ts
@@ -13,17 +13,24 @@
 // limitations under the License.
 //
 import { type Asset, type IntlString } from '@hcengineering/platform'
-import { type Doc, type DocumentQuery, type Ref } from '@hcengineering/core'
+import { type Account, type Doc, type DocumentQuery, type IdMap, type Ref, type UserStatus } from '@hcengineering/core'
 import { type DocNotifyContext } from '@hcengineering/notification'
 import { type AnySvelteComponent, type IconSize, type Action } from '@hcengineering/ui'
+import { type PersonAccount } from '@hcengineering/contact'
 
 export type ChatGroup = 'activity' | 'direct' | 'channels' | 'starred'
+
+export interface SortFnOptions {
+  contexts: DocNotifyContext[]
+  userStatusByAccount: Map<Ref<Account>, UserStatus>
+  personAccountById: IdMap<PersonAccount>
+}
 
 export interface ChatNavGroupModel {
   id: ChatGroup
   label?: IntlString
   query: DocumentQuery<DocNotifyContext>
-  sortFn: (items: ChatNavItemModel[], contexts: DocNotifyContext[]) => ChatNavItemModel[]
+  sortFn: (items: ChatNavItemModel[], options: SortFnOptions) => ChatNavItemModel[]
   wrap: boolean
   getActionsFn?: (contexts: DocNotifyContext[]) => Action[]
   maxSectionItems?: number


### PR DESCRIPTION
Directs order:

1. online users
2. group chats
3. offline users
4. own direct

![Screenshot from 2024-05-10 19-07-30](https://github.com/hcengineering/platform/assets/113431133/92bcafa4-293b-4031-93e7-6829824716fe)
![Screenshot from 2024-05-10 18-54-19](https://github.com/hcengineering/platform/assets/113431133/611163f4-6f94-4041-b308-1d90a16514bf)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjQyMTE0NTI1NjAzZjg0ZDA0ZWNmMGMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.rIlF-t-mppG56kaZbATvHe5kzNrieWUuvEobDdkcAco">Huly&reg;: <b>UBERF-6940</b></a></sub>