### PR TITLE
Fix messages and reactions spaces

### DIFF
--- a/models/activity/src/index.ts
+++ b/models/activity/src/index.ts
@@ -76,7 +76,7 @@ import { type AnyComponent } from '@hcengineering/ui/src/types'
 import activity from './plugin'
 
 export { activityId } from '@hcengineering/activity'
-export { activityOperation } from './migration'
+export { activityOperation, migrateMessagesSpace } from './migration'
 
 export const DOMAIN_ACTIVITY = 'activity' as Domain
 

--- a/models/chunter/src/migration.ts
+++ b/models/chunter/src/migration.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-import { chunterId } from '@hcengineering/chunter'
+import { chunterId, type ThreadMessage } from '@hcengineering/chunter'
 import core, {
   type Account,
   TxOperations,
@@ -30,10 +30,10 @@ import {
   type MigrationClient,
   type MigrationUpgradeClient
 } from '@hcengineering/model'
-import activity, { DOMAIN_ACTIVITY } from '@hcengineering/model-activity'
+import activity, { migrateMessagesSpace, DOMAIN_ACTIVITY } from '@hcengineering/model-activity'
 import notification from '@hcengineering/notification'
-
 import contactPlugin, { type PersonAccount } from '@hcengineering/contact'
+
 import chunter from './plugin'
 
 export const DOMAIN_COMMENT = 'comment' as Domain
@@ -185,6 +185,28 @@ export const chunterOperation: MigrateOperation = {
       {
         state: 'remove-backlinks',
         func: removeBacklinks
+      },
+      {
+        state: 'migrate-chat-messages-space',
+        func: async (client) => {
+          await migrateMessagesSpace(
+            client,
+            chunter.class.ChatMessage,
+            ({ attachedTo }) => attachedTo,
+            ({ attachedToClass }) => attachedToClass
+          )
+        }
+      },
+      {
+        state: 'migrate-thread-messages-space',
+        func: async (client) => {
+          await migrateMessagesSpace(
+            client,
+            chunter.class.ThreadMessage,
+            (msg) => (msg as ThreadMessage).objectId,
+            (msg) => (msg as ThreadMessage).objectClass
+          )
+        }
       }
     ])
   },

--- a/packages/presentation/src/utils.ts
+++ b/packages/presentation/src/utils.ts
@@ -42,7 +42,8 @@ import core, {
   type Tx,
   type TxResult,
   type TypeAny,
-  type WithLookup
+  type WithLookup,
+  type Space
 } from '@hcengineering/core'
 import { getMetadata, getResource } from '@hcengineering/platform'
 import { LiveQuery as LQ } from '@hcengineering/query'
@@ -565,4 +566,8 @@ export function decodeTokenPayload (token: string): any {
 
 export function isAdminUser (): boolean {
   return decodeTokenPayload(getMetadata(plugin.metadata.Token) ?? '').admin === 'true'
+}
+
+export function isSpace (space: Doc): space is Space {
+  return getClient().getHierarchy().isDerived(space._class, core.class.Space)
 }

--- a/plugins/chunter-resources/src/components/chat-message/ChatMessageInput.svelte
+++ b/plugins/chunter-resources/src/components/chat-message/ChatMessageInput.svelte
@@ -17,7 +17,7 @@
   import { createEventDispatcher } from 'svelte'
   import { AttachmentRefInput } from '@hcengineering/attachment-resources'
   import { Class, Doc, generateId, getCurrentAccount, Ref } from '@hcengineering/core'
-  import { createQuery, DraftController, draftsStore, getClient } from '@hcengineering/presentation'
+  import { createQuery, DraftController, draftsStore, getClient, isSpace } from '@hcengineering/presentation'
   import chunter, { ChatMessage, ThreadMessage } from '@hcengineering/chunter'
   import { PersonAccount } from '@hcengineering/contact'
   import activity, { ActivityMessage } from '@hcengineering/activity'
@@ -162,7 +162,7 @@
     } else {
       await operations.addCollection<Doc, ChatMessage>(
         _class,
-        object.space,
+        isSpace(object) ? object._id : object.space,
         object._id,
         object._class,
         collection,

--- a/server-plugins/activity-resources/src/index.ts
+++ b/server-plugins/activity-resources/src/index.ts
@@ -28,7 +28,8 @@ import core, {
   TxCreateDoc,
   TxProcessor,
   matchQuery,
-  Hierarchy
+  Hierarchy,
+  Space
 } from '@hcengineering/core'
 import { ActivityControl, DocObjectCache } from '@hcengineering/server-activity'
 import type { TriggerControl } from '@hcengineering/server-core'
@@ -146,6 +147,10 @@ function isActivityDoc (_class: Ref<Class<Doc>>, hierarchy: Hierarchy): boolean 
   return mixin !== undefined
 }
 
+function isSpace (space: Doc, hierarchy: Hierarchy): space is Space {
+  return hierarchy.isDerived(space._class, core.class.Space)
+}
+
 function getDocUpdateMessageTx (
   control: ActivityControl,
   originTx: TxCUD<Doc>,
@@ -153,9 +158,11 @@ function getDocUpdateMessageTx (
   rawMessage: Data<DocUpdateMessage>,
   modifiedBy?: Ref<Account>
 ): TxCollectionCUD<Doc, DocUpdateMessage> {
+  const { hierarchy } = control
+  const space = isSpace(object, hierarchy) ? object._id : object.space
   const innerTx = control.txFactory.createTxCreateDoc(
     activity.class.DocUpdateMessage,
-    object.space,
+    space,
     rawMessage,
     undefined,
     originTx.modifiedOn,
@@ -165,7 +172,7 @@ function getDocUpdateMessageTx (
   return control.txFactory.createTxCollectionCUD(
     rawMessage.attachedToClass,
     rawMessage.attachedTo,
-    object.space,
+    space,
     rawMessage.collection,
     innerTx,
     originTx.modifiedOn,


### PR DESCRIPTION
Avoid using `core.space.Space` in `ActivityMessages `and `Reactions`

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjQyMzM1YzI1NjAzZjg0ZDA0ZWQwNzgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.5_6rRmH2ZUgzch64ILtWzHqmM59QZmWzla07RBxHsdw">Huly&reg;: <b>UBERF-6944</b></a></sub>