### PR TITLE
UBERF-6949: fix kanban options

### DIFF
--- a/plugins/task-resources/src/index.ts
+++ b/plugins/task-resources/src/index.ts
@@ -251,7 +251,7 @@ async function statusSort (
     for (const state of value) {
       if (res.has(state)) continue
       const index = types.findIndex((p) => p.tasks.some((q) => taskTypes.get(q)?.statuses.includes(state)))
-      if (index === -1) break
+      if (index === -1) continue
       const type = types.splice(index, 1)[0]
       const statuses =
         type.tasks.map((it) => taskTypes.get(it)).find((it) => it?.statuses.includes(state))?.statuses ?? []


### PR DESCRIPTION
Fix for `Show empty` option

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjQzMGQ2MzI1NjAzZjg0ZDA0ZWQyMDEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.Gtq7IC7dMCjcBbB3aenGlFMPjJmfVGdrAM3zurZAxXg">Huly&reg;: <b>UBERF-6950</b></a></sub>