### PR TITLE
fix: download drive files via temporary link

### DIFF
--- a/plugins/drive-resources/src/index.ts
+++ b/plugins/drive-resources/src/index.ts
@@ -50,8 +50,13 @@ async function EditDrive (drive: Drive): Promise<void> {
 async function DownloadFile (doc: File | File[]): Promise<void> {
   const files = Array.isArray(doc) ? doc : [doc]
   for (const file of files) {
-    const url = getFileUrl(file.file, 'full', file.name)
-    window.open(url, '_blank')
+    const href = getFileUrl(file.file, 'full', file.name)
+    const link = document.createElement('a')
+    link.style.display = 'none'
+    link.target = '_blank'
+    link.href = href
+    link.download = file.name
+    link.click()
   }
 }
 


### PR DESCRIPTION
create temporary link to avoid files being open in a separate tab instead of downloading

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjRlMTg4ZWJiNWE5OTcxZjBkZmNjYmQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.BtG-Qy3GzXGloIV44ljnId9_a-_nvbt79U5uHJ0xzwE">Huly&reg;: <b>UBERF-7030</b></a></sub>