### PR TITLE
UBERF-6779: Fix get attributes diff

### DIFF
--- a/packages/model/src/utils.ts
+++ b/packages/model/src/utils.ts
@@ -11,6 +11,10 @@ function diffAttributes (doc: Data<Doc>, newDoc: Data<Doc>): DocumentUpdate<Doc>
   const newDocuments = new Map(Object.entries(newDoc))
 
   for (const [key, value] of allDocuments) {
+    if (!newDocuments.has(key)) {
+      continue
+    }
+
     const newValue = toUndef(newDocuments.get(key))
     if (!deepEqual(newValue, toUndef(value))) {
       // update is required, since values are different


### PR DESCRIPTION
Fixed diff of attributes, we shouldn't set `undefined` value for attributes for which no value was specified, we should keep previous value

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjRmN2FkN2QxMmEwOTk1ZmI4MzAzNTUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.IIQqjHEOu_zUV68bVHGA_MpK6XcXTEh_mYUB_Zw7a-E">Huly&reg;: <b>UBERF-7052</b></a></sub>