### PR TITLE
UBERF-7065 Fix file and image upload extensions

### DIFF
--- a/packages/text-editor/src/components/extension/fileUploadExt.ts
+++ b/packages/text-editor/src/components/extension/fileUploadExt.ts
@@ -92,11 +92,14 @@ export const FileUploadExtension = Extension.create<FileUploadOptions>({
             }
           },
           handleDrop (view, event) {
-            event.preventDefault()
-            event.stopPropagation()
             const dataTransfer = event.dataTransfer
             if (dataTransfer !== null) {
-              return handleDrop(view, view.posAtCoords({ left: event.x, top: event.y }), dataTransfer)
+              const res = handleDrop(view, view.posAtCoords({ left: event.x, top: event.y }), dataTransfer)
+              if (res === true) {
+                event.preventDefault()
+                event.stopPropagation()
+              }
+              return res
             }
           }
         }

--- a/packages/text-editor/src/components/extension/imageUploadExt.ts
+++ b/packages/text-editor/src/components/extension/imageUploadExt.ts
@@ -118,11 +118,14 @@ export const ImageUploadExtension = Extension.create<ImageUploadOptions>({
             }
           },
           handleDrop (view, event) {
-            event.preventDefault()
-            event.stopPropagation()
             const dataTransfer = event.dataTransfer
             if (dataTransfer !== null) {
-              return handleDrop(view, view.posAtCoords({ left: event.x, top: event.y }), dataTransfer)
+              const res = handleDrop(view, view.posAtCoords({ left: event.x, top: event.y }), dataTransfer)
+              if (res === true) {
+                event.preventDefault()
+                event.stopPropagation()
+              }
+              return res
             }
           }
         }


### PR DESCRIPTION
Properly handle event when propagation in file and image editor extensions.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjU0MWEyY2QxMmEwOTk1ZmI4MzA5ZTEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.RQmB4KK_pdV9U6XYQXGbIKaG7fD73kTMOD2v4AWojUs">Huly&reg;: <b>UBERF-7066</b></a></sub>