### PR TITLE
UBERF-4647 Use non-empty ydoc field name in wiki documents

### DIFF
--- a/models/document/package.json
+++ b/models/document/package.json
@@ -49,6 +49,7 @@
     "@hcengineering/tags": "^0.6.12",
     "@hcengineering/time": "^0.6.0",
     "@hcengineering/document": "^0.6.0",
-    "@hcengineering/document-resources": "^0.6.0"
+    "@hcengineering/document-resources": "^0.6.0",
+    "@hcengineering/collaboration": "^0.6.0"
   }
 }

--- a/packages/text-editor/src/components/CollaborativeTextEditor.svelte
+++ b/packages/text-editor/src/components/CollaborativeTextEditor.svelte
@@ -75,7 +75,7 @@
 
   export let collaborativeDoc: CollaborativeDoc
   export let initialCollaborativeDoc: CollaborativeDoc | undefined = undefined
-  export let field: string | undefined = undefined
+  export let field: string
 
   export let objectClass: Ref<Class<Doc>> | undefined
   export let objectId: Ref<Doc> | undefined

--- a/packages/text-editor/src/components/CollaboratorEditor.svelte
+++ b/packages/text-editor/src/components/CollaboratorEditor.svelte
@@ -30,7 +30,7 @@
 
   export let collaborativeDoc: CollaborativeDoc
   export let initialCollaborativeDoc: CollaborativeDoc | undefined = undefined
-  export let field: string | undefined = undefined
+  export let field: string
 
   export let objectClass: Ref<Class<Doc>> | undefined = undefined
   export let objectId: Ref<Doc> | undefined = undefined

--- a/plugins/document-resources/src/components/DocumentEditor.svelte
+++ b/plugins/document-resources/src/components/DocumentEditor.svelte
@@ -93,6 +93,7 @@
   objectClass={object._class}
   objectId={object._id}
   objectAttr="content"
+  field="content"
   {user}
   {userComponent}
   {focusIndex}


### PR DESCRIPTION
Fixes intermittent Unexpected Case error in wiki documents

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjU0ODMzNWQxMmEwOTk1ZmI4MzBiZDMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.zp3clYA-tQAGUeiCR9mFeeTCgBGgMdLajFsD6JeZsSk">Huly&reg;: <b>UBERF-7071</b></a></sub>