### PR TITLE
UBERF-7084: fix add new status to task type

### DIFF
--- a/plugins/task-resources/src/components/state/CreateStatePopup.svelte
+++ b/plugins/task-resources/src/components/state/CreateStatePopup.svelte
@@ -286,7 +286,8 @@
               ofAttribute,
               icon,
               color,
-              icons
+              icons,
+              readonly
             }
           }
         }
@@ -329,7 +330,8 @@
         icon,
         color,
         icons,
-        valuePattern: pattern
+        valuePattern: pattern,
+        readonly
       }
     }
   }

--- a/plugins/task-resources/src/components/taskTypes/TaskTypeEditor.svelte
+++ b/plugins/task-resources/src/components/taskTypes/TaskTypeEditor.svelte
@@ -116,7 +116,8 @@
         ofAttribute: attr._id,
         icon: undefined,
         color: 0,
-        icons
+        icons,
+        readonly
       }
     }
   }


### PR DESCRIPTION
* Fixes readonly prop propagation of add status popup and related components

Closes: https://github.com/hcengineering/platform/issues/5683
Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-7084

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjU1ZGZiOGQxMmEwOTk1ZmI4MzExNzkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.WR9PFKFsA9R2TDquyObxUCsNKpI3qk4-EQ4AKg07OXo">Huly&reg;: <b>UBERF-7085</b></a></sub>