### PR TITLE
UBERF-6639: Fix default status when switching task types

### DIFF
--- a/plugins/task/src/utils.ts
+++ b/plugins/task/src/utils.ts
@@ -114,7 +114,7 @@ export async function createState<T extends Status> (
   if (exists !== undefined) {
     return exists._id as Ref<T>
   }
-  const res = await client.createDoc(_class, task.space.Statuses, data)
+  const res = await client.createDoc(_class, core.space.Model, data)
   return res
 }
 

--- a/plugins/tracker-resources/src/components/issues/StatusEditor.svelte
+++ b/plugins/tracker-resources/src/components/issues/StatusEditor.svelte
@@ -96,15 +96,18 @@
         return current
       }
     }
+
     if (defaultIssueStatus !== undefined) {
       const res = statuses?.find((status) => status._id === defaultStatus)
-      void changeStatus(res?._id, false)
-      return res
+      // Might not exist for projects with multiple task types with different statuses
+      if (res != null) {
+        void changeStatus(res?._id, false)
+        return res
+      }
     }
+
     // We need to choose first one, since it should not be case without status.
-    if (value.status === undefined) {
-      void changeStatus(statuses?.[0]?._id, false)
-    }
+    void changeStatus(statuses?.[0]?._id, false)
   }
 
   $: selectedStatus = getSelectedStatus(statuses, value, defaultIssueStatus)


### PR DESCRIPTION
* Shows the first status in task type if the selected status or the default status doesn't exist among the selected task type statuses
* Fixes space in creation of new statuses

Closes: https://github.com/hcengineering/platform/issues/5408
Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-6639

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjU1ZWExZmQxMmEwOTk1ZmI4MzExZmYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.rvcEk3TL0LWAOOYvZ7i9s0xQHLsG8cMhnwba50r8-LA">Huly&reg;: <b>UBERF-7086</b></a></sub>