### PR TITLE
Change button label on Edit Drive dialog from Create to Save

### DIFF
--- a/plugins/drive-resources/src/components/CreateDrive.svelte
+++ b/plugins/drive-resources/src/components/CreateDrive.svelte
@@ -222,7 +222,7 @@
 
 <Card
   label={drive ? driveRes.string.EditDrive : driveRes.string.CreateDrive}
-  okLabel={drive ? presentation.string.Create : presentation.string.Save}
+  okLabel={drive ? presentation.string.Save : presentation.string.Create}
   okAction={handleSave}
   {canSave}
   accentHeader


### PR DESCRIPTION
Changed button label from "Create" to "Save" on Edit Drive dialog. Connected to <https://front.hc.engineering/workbench/platform/tracker/UBERF-7074>

<img width="1447" src="https://github.com/hcengineering/platform/assets/145867967/2722a9cc-f4f5-4382-9f5d-d0458b1f841d" alt="edit-drive-btn">

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjU2MGFmZWQxMmEwOTk1ZmI4MzE0MDQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.Qhu0PEZ7UlZGNeT9gd2dzM-NQujVwtiM7OUxaVp9ps8">Huly&reg;: <b>UBERF-7094</b></a></sub>