### PR TITLE
Qfix: Remove hardcoded platform url from test

### DIFF
--- a/tests/sanity/tests/chat/chat.spec.ts
+++ b/tests/sanity/tests/chat/chat.spec.ts
@@ -301,7 +301,8 @@ test.describe('channel tests', () => {
   })
 
   test('check if user can copy message', async ({ page }) => {
-    const expectedUrl = `http://localhost:8083/workbench/${data.workspaceName}/chunter/chunter:space:Random|chunter:class:Channel?message=`
+    const baseURL = process.env.PLATFORM_URI ?? 'http://localhost:8083'
+    const expectedUrl = `${baseURL}/workbench/${data.workspaceName}/chunter/chunter:space:Random|chunter:class:Channel?message=`
     await leftSideMenuPage.clickChunter()
     await channelPage.clickChannel('random')
     await channelPage.sendMessage('Test message')


### PR DESCRIPTION
* Replaces hardcoded platform URL in a test with reading env var

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjU2ZTAxMWQxMmEwOTk1ZmI4MzE1YjYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.W7HubzAVblu6BcdXXHhFAv0uORTGpcA7t4KV-5vRFIs">Huly&reg;: <b>UBERF-7097</b></a></sub>