### PR TITLE
throw error in case of non-model space for classes in model

### DIFF
--- a/packages/core/src/operations.ts
+++ b/packages/core/src/operations.ts
@@ -1,5 +1,5 @@
 import { deepEqual } from 'fast-equals'
-import { DocumentUpdate, Hierarchy, MixinData, MixinUpdate, ModelDb, toFindResult } from '.'
+import { DocumentUpdate, DOMAIN_MODEL, Hierarchy, MixinData, MixinUpdate, ModelDb, toFindResult } from '.'
 import type {
   Account,
   AnyAttribute,
@@ -92,6 +92,9 @@ export class TxOperations implements Omit<Client, 'notify'> {
     const hierarchy = this.client.getHierarchy()
     if (hierarchy.isDerived(_class, core.class.AttachedDoc)) {
       throw new Error('createDoc cannot be used for objects inherited from AttachedDoc')
+    }
+    if (hierarchy.findDomain(_class) === DOMAIN_MODEL && space !== core.space.Model) {
+      throw new Error('createDoc cannot be called for DOMAIN_MODEL classes with non-model space')
     }
     const tx = this.txFactory.createTxCreateDoc(_class, space, attributes, id, modifiedOn, modifiedBy)
     await this.client.tx(tx)


### PR DESCRIPTION
Throw an error when tried to create Doc with non-model space for DOMAIN_MODEL class

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjU3MjlkNGQxMmEwOTk1ZmI4MzE3NmEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.KiNpMJUTnmjDPNApmiRvWkb21tnkR1NLf9LL5n3OVbo">Huly&reg;: <b>UBERF-7102</b></a></sub>