### PR TITLE
UBERF-7105: Use status colour when projectState is undefined

### DIFF
--- a/plugins/task-resources/src/components/state/StatePresenter.svelte
+++ b/plugins/task-resources/src/components/state/StatePresenter.svelte
@@ -140,7 +140,11 @@
         <Icon
           icon={categoryIcons[category._id]}
           {size}
-          iconProps={{ index, count: sameCategory.length + 1, fill: projectState?.color ?? value?.color ?? category?.color }}
+          iconProps={{
+            index,
+            count: sameCategory.length + 1,
+            fill: projectState?.color ?? value?.color ?? category?.color
+          }}
         />
       {:else}
         <Icon

--- a/plugins/task-resources/src/components/state/StatePresenter.svelte
+++ b/plugins/task-resources/src/components/state/StatePresenter.svelte
@@ -135,18 +135,18 @@
   {#if kind === 'table-attrs'}
     <button class="hulyTableAttr-content__row-icon-wrapper" on:click>
       {#if icon != null}
-        <Icon {icon} {size} iconProps={{ icon: projectState?.color ?? category?.color }} />
+        <Icon {icon} {size} iconProps={{ icon: projectState?.color ?? value?.color ?? category?.color }} />
       {:else if category?._id === task.statusCategory.Active}
         <Icon
           icon={categoryIcons[category._id]}
           {size}
-          iconProps={{ index, count: sameCategory.length + 1, fill: projectState?.color ?? category?.color }}
+          iconProps={{ index, count: sameCategory.length + 1, fill: projectState?.color ?? value?.color ?? category?.color }}
         />
       {:else}
         <Icon
           icon={categoryIcons[category?._id ?? task.statusCategory.UnStarted]}
           {size}
-          iconProps={{ fill: projectState?.color ?? category?.color }}
+          iconProps={{ fill: projectState?.color ?? value?.color ?? category?.color }}
         />
       {/if}
     </button>
@@ -175,18 +175,22 @@
           title={shouldShowTooltip ? value.name : undefined}
         >
           {#if icon != null}
-            <Icon {icon} {size} iconProps={{ icon: projectState?.color ?? category?.color }} />
+            <Icon {icon} {size} iconProps={{ icon: projectState?.color ?? value?.color ?? category?.color }} />
           {:else if category?._id === task.statusCategory.Active}
             <Icon
               icon={categoryIcons[category._id]}
               {size}
-              iconProps={{ index, count: sameCategory.length + 1, fill: projectState?.color ?? category?.color }}
+              iconProps={{
+                index,
+                count: sameCategory.length + 1,
+                fill: projectState?.color ?? value?.color ?? category?.color
+              }}
             />
           {:else}
             <Icon
               icon={categoryIcons[category?._id ?? task.statusCategory.UnStarted]}
               {size}
-              iconProps={{ fill: projectState?.color ?? category?.color }}
+              iconProps={{ fill: projectState?.color ?? value?.color ?? category?.color }}
             />
           {/if}
         </div>


### PR DESCRIPTION
<img width="253" src="https://github.com/hcengineering/platform/assets/37306501/1b53dce2-3d40-463f-9507-a78896c0bc2b" alt="image">

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjU3NmU0YWQxMmEwOTk1ZmI4MzE4N2UiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.zSVJf6NLO7mLnol5NSUOZlnqSsUtPTntiUVrsQ-a7-Y">Huly&reg;: <b>UBERF-7106</b></a></sub>