### PR TITLE
fix: migrate content for documents only

### DIFF
--- a/models/document/src/migration.ts
+++ b/models/document/src/migration.ts
@@ -282,6 +282,7 @@ async function migrateContentField (client: MigrationClient): Promise<void> {
   }
 
   const documents = await client.find<Document>(DOMAIN_DOCUMENT, {
+    _class: document.class.Document,
     content: { $exists: true }
   })
 


### PR DESCRIPTION
<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjU4Mzk3YmQxMmEwOTk1ZmI4MzFhMzQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.bQU6bLpQyo99M88bb7Ej1pEYILrXl9FdVfyJep_GWas">Huly&reg;: <b>UBERF-7109</b></a></sub>