### PR TITLE
UBERF-7118: Fix upgrade/refresh on reconnect

### DIFF
--- a/server/ws/src/server_http.ts
+++ b/server/ws/src/server_http.ts
@@ -276,10 +276,10 @@ export function startHttpServer (
 
     if (webSocketData.session instanceof Promise) {
       void webSocketData.session.then((s) => {
-        if ('upgrade' in s || 'error' in s) {
-          if ('error' in s) {
-            ctx.error('error', { error: s.error?.message, stack: s.error?.stack })
-          }
+        if ('error' in s) {
+          ctx.error('error', { error: s.error?.message, stack: s.error?.stack })
+        }
+        if ('upgrade' in s) {
           void cs
             .send(ctx, { id: -1, result: { state: 'upgrading', stats: (s as any).upgradeInfo } }, false, false)
             .then(() => {


### PR DESCRIPTION
UBERF-7118: Fix upgrade/refresh on reconnect

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjU4YWY5OGEzYWRlNzRlM2ZiNDAzZGYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.7DJXEBwSEvsXmJphHcnVuuZYk2sTpRAboejuc8Dz0mM">Huly&reg;: <b>UBERF-7119</b></a></sub>