### PR TITLE
Add OperationContext to be accessible by triggers

### DIFF
--- a/server/core/src/server/storage.ts
+++ b/server/core/src/server/storage.ts
@@ -702,6 +702,7 @@ export class TServerStorage implements ServerStorage {
     const moves = await ctx.with('process-move', {}, (ctx) => this.processMove(ctx.ctx, txes, findAll))
 
     const triggerControl: Omit<TriggerControl, 'txFactory' | 'ctx' | 'result'> = {
+      operationContext: ctx,
       removedMap,
       workspace: this.workspaceId,
       storageAdapter: this.storageAdapter,

--- a/server/core/src/types.ts
+++ b/server/core/src/types.ts
@@ -139,6 +139,7 @@ export interface Pipeline extends LowLevelStorage {
  * @public
  */
 export interface TriggerControl {
+  operationContext: SessionOperationContext
   ctx: MeasureContext
   workspace: WorkspaceIdWithUrl
   txFactory: TxFactory


### PR DESCRIPTION
Add OperationContext to be accessible by triggers

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjYyZTY5ZWI3NTM3YzAxYTgxNTRmM2MiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.QJyF2ZDfKoj3R04qmjlc8N14vMi8nk7UChatdziXMSI">Huly&reg;: <b>UBERF-7187</b></a></sub>