### PR TITLE
fix: disable guest link action for selection

### DIFF
--- a/models/guest/src/utils.ts
+++ b/models/guest/src/utils.ts
@@ -18,7 +18,7 @@ export function createPublicLinkAction (builder: Builder, _class: Ref<Class<Doc>
       },
       label: guest.string.PublicLink,
       icon: guest.icon.Link,
-      input: 'any',
+      input: 'focus',
       category: guest.category.Guest,
       target: _class,
       context: {


### PR DESCRIPTION
Guest link should be available only  for single selection, not for multiple.

![Screenshot 2024-06-11 at 11 07 30](https://github.com/hcengineering/platform/assets/5876715/0def0ce2-a59d-45e3-b178-688a9ea74882)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjY3Y2EyZjQ1ZjAzNzUxMGNjYzBkMWMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.6h7xe3_NHXZJW2q9BpfgU-wV0JOtQEhVEPxAdO_aDfs">Huly&reg;: <b>UBERF-7220</b></a></sub>