### PR TITLE
fix(ui): allow input month with keystrokes

### DIFF
--- a/packages/ui/src/components/calendar/DateInputBox.svelte
+++ b/packages/ui/src/components/calendar/DateInputBox.svelte
@@ -118,6 +118,7 @@
       if (edit.value === -1 && full && i > 2) result = true
       if (edit.value === -1 && !full && i < 3) result = true
       if (i === 0 && edit.value === 0) result = true
+      if (i === 1 && edit.value === 0) result = true
       if (i === 2 && (edit.value < 1970 || edit.value > 3000)) result = true
     })
     return result


### PR DESCRIPTION
**Pull Request Requirements:**

* Provide a brief description of the changeset.

Fix the calendar month input to allow to type full numerical entries. The current behaviour only allowed to input months from November (10 to 12) due skipping to year once zero was pressed.

Tested in Chrome (Version 125.0.6422.142 (Official Build) (arm64)) and Safari (Version 17.5 (19618.2.12.11.6)).

* Include a screenshots if applicable

Behaviour before >

https://github.com/hcengineering/platform/assets/18152036/95592765-b52a-4296-8c26-95d14431a0a8

Behaviour after fix >

https://github.com/hcengineering/platform/assets/18152036/28966c5b-b7a6-4c41-83bf-739a89cad96d

* Ensure that the changeset adheres to the [DCO guidelines](https://github.com/apps/dco).

Signed-off-by: p-fernandez [pablo.fernandez.otero@gmail.com](mailto:pablo.fernandez.otero@gmail.com)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjY4YjMxMjg3MjUzZDAzOGViYTBkMjEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.X50CL3rNHUvSf3U4i1wFb5ynMH35y2v13KRrGjONam0">Huly&reg;: <b>UBERF-7232</b></a></sub>