### PR TITLE
EZQMS-1008: Disable archived product editing

### DIFF
--- a/plugins/products-resources/src/components/product/EditProduct.svelte
+++ b/plugins/products-resources/src/components/product/EditProduct.svelte
@@ -118,6 +118,7 @@
   $: canEdit =
     !readonly &&
     object !== undefined &&
+    !object.archived &&
     ((object.owners?.includes(me) ?? false) ||
       checkMyPermission(core.permission.UpdateSpace, _id, $permissionsStore) ||
       checkMyPermission(core.permission.UpdateObject, core.space.Space, $permissionsStore))


### PR DESCRIPTION
* Disables editing of an archived product space

Related to: https://front.hc.engineering/workbench/platform/tracker/EZQMS-1008

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjY5YjBhNzJkOTA4MTUzNTY4M2MxZTYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.8ZmGykrR-4E6-sBXYXpQ3u6CMA0XKYQUqf0pISg-21Y">Huly&reg;: <b>UBERF-7245</b></a></sub>