### PR TITLE
EZQMS-976: Exclude other space types' mixins from product space

### DIFF
--- a/plugins/products-resources/src/components/product/EditProduct.svelte
+++ b/plugins/products-resources/src/components/product/EditProduct.svelte
@@ -58,13 +58,6 @@
   const notificationClient = getResource(notification.function.GetInboxNotificationsClient).then((res) => res())
 
   const me = getCurrentAccount()._id
-  // We need to think about this issue and redesign somehow?
-  const ignoredMixins = [
-    core.mixin.SpacesTypeData,
-    documents.mixin.DocumentSpaceTypeData,
-    'training:mixin:TrainingsTypeData' as any
-  ]
-
   let object: Product | undefined
   let title = ''
   let showAllMixins = false
@@ -123,7 +116,24 @@
       checkMyPermission(core.permission.UpdateObject, core.space.Space, $permissionsStore))
 
   $: descriptionKey = client.getHierarchy().getAttribute(products.class.Product, 'fullDescription')
-  $: mixins = object !== undefined ? getDocMixins(object, showAllMixins, new Set(ignoredMixins)) : []
+  $: otherSpaceTypesMixins = new Set(
+    object !== undefined
+      ? client
+        .getModel()
+        .findAllSync(
+          core.class.SpaceType,
+          {
+            _id: { $ne: object.type }
+          },
+          {
+            projection: { targetClass: 1 }
+          }
+        )
+        ?.map((st) => st.targetClass) ?? []
+      : []
+  )
+  $: mixins =
+    object !== undefined ? getDocMixins(object, showAllMixins).filter((m) => !otherSpaceTypesMixins.has(m._id)) : []
 </script>
 
 {#if object !== undefined}


### PR DESCRIPTION
* Excludes all space types mixins except for the mixin of this product space type

Related to: https://front.hc.engineering/workbench/platform/tracker/EZQMS-976

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjY5Yjc4MDJkOTA4MTUzNTY4M2MyMWYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.4RGfnRE4JKDE772-o0Er5_wzc-9l8ALT6XRh2igKbdM">Huly&reg;: <b>UBERF-7246</b></a></sub>