### PR TITLE
Added Pre-requisite Step in Build and Run Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ Development environment setup requires Docker to be installed on system.
 
 Support is available for both amd64 and arm64 containers on Linux and macOS.
 
+### Pre-requisite :
+Ensure wget and unzip are installed on the system and are available in system path, to check open terminal and use commands:
+
+```bash
+wget --version  # To check wget is installed or not
+unzip -v # To check unzip in installed or not
+```
+
+Install wget and unzip if not installed using the below commands:
+
+```bash
+brew install wget  # To install wget on macOS
+brew install unzip # To install unzip on macOS
+```
+
+Now proceed with next steps of Build and Run
+
 ```bash
 cd ./dev/
 rush build    # Will build all the required packages. 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Development environment setup requires Docker to be installed on system.
 Support is available for both amd64 and arm64 containers on Linux and macOS.
 
 ### Pre-requisite :
-Ensure wget and unzip are installed on the system and are available in system path, to check open terminal and use commands:
+Ensure that wget and unzip are installed on the system and are available in system path, to check open terminal and use commands:
 
 ```bash
 wget --version  # To check wget is installed or not


### PR DESCRIPTION
What does this PR do?

This PR updates the Readme. md file and adds a pre-requisite step in the Build and Run section to ensure that required libraries are installed before triggering the `rush build`

It's related to issues raised by users here where they have reported to face ./uws.sh related error: #5707

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjY5YmY3NDJkOTA4MTUzNTY4M2MyN2QiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.C_K0laKDEiE1auzss1f_JGtLNbvL9I_U_ZMhLXBJX0c">Huly&reg;: <b>UBERF-7248</b></a></sub>