### PR TITLE
UBERF-6515 Remove TRANSACTOR_URL from front configuration

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -80,7 +80,6 @@ services:
       - GMAIL_URL=http://localhost:8088
       - TELEGRAM_URL=http://localhost:8086
       - UPLOAD_URL=/files
-      - TRANSACTOR_URL=ws://localhost:3333
       - ELASTIC_URL=http://elastic:9200
       - COLLABORATOR_URL=ws://localhost:3078
       - COLLABORATOR_API_URL=http://localhost:3078

--- a/pods/front/package.json
+++ b/pods/front/package.json
@@ -21,7 +21,7 @@
     "docker:push": "../../common/scripts/docker_tag.sh hardcoreeng/front",
     "docker:tbuild": "docker build -t hardcoreeng/front . --platform=linux/amd64 && ../../common/scripts/docker_tag_push.sh hardcoreeng/front",
     "format": "format src",
-    "run-local": "cross-env MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin MINIO_ENDPOINT=localhost TRANSACTOR_URL=ws://localhost:3333 SERVER_SECRET='secret' ACCOUNTS_URL=http://localhost:3000 UPLOAD_URL=/files ELASTIC_URL=http://localhost:9200 MODEL_VERSION=$(node ../../common/scripts/show_version.js) PUBLIC_DIR='.' ts-node ./src/__start.ts",
+    "run-local": "cross-env MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin MINIO_ENDPOINT=localhost SERVER_SECRET='secret' ACCOUNTS_URL=http://localhost:3000 UPLOAD_URL=/files ELASTIC_URL=http://localhost:9200 MODEL_VERSION=$(node ../../common/scripts/show_version.js) PUBLIC_DIR='.' ts-node ./src/__start.ts",
     "test": "jest --passWithNoTests --silent --forceExit",
     "_phase:build": "compile transpile src",
     "_phase:test": "jest --passWithNoTests --silent --forceExit",

--- a/pods/front/run.sh
+++ b/pods/front/run.sh
@@ -2,7 +2,6 @@
 
 export ACCOUNTS_URL=http://localhost:3333
 export UPLOAD_URL=http://localhost:3333/files
-export TRANSACTOR_URL=ws://localhost:3333
 export ELASTIC_URL=http://elastic:9200
 export COLLABORATOR_URL=ws://localhost:3078
 export COLLABORATOR_API_URL=http://localhost:3078

--- a/server/front/readme.md
+++ b/server/front/readme.md
@@ -5,7 +5,6 @@ Front service is suited to deliver application bundles and resource assets, it a
 ## Configuration
 
 * SERVER_PORT: Specifies the port number on which the server will listen.
-* TRANSACTOR_URL: Specifies the URL of the transactor.
 * MONGO_URL: Specifies the URL of the MongoDB database.
 * ELASTIC_URL: Specifies the URL of the Elasticsearch service.
 * ACCOUNTS_URL: Specifies the URL of the accounts service.

--- a/server/front/run.sh
+++ b/server/front/run.sh
@@ -2,7 +2,6 @@
 
 export ACCOUNTS_URL=http://localhost:3333
 export UPLOAD_URL=http://localhost:3333/files
-export TRANSACTOR_URL=ws://localhost:3333
 export ELASTIC_URL=http://elastic:9200
 export MINIO_ENDPOINT=minio
 export MINIO_ACCESS_KEY=minioadmin

--- a/server/front/src/index.ts
+++ b/server/front/src/index.ts
@@ -221,7 +221,6 @@ async function getFile (
 export function start (
   ctx: MeasureContext,
   config: {
-    transactorEndpoint: string
     elasticUrl: string
     storageAdapter: StorageAdapter
     accountsUrl: string

--- a/server/front/src/starter.ts
+++ b/server/front/src/starter.ts
@@ -24,12 +24,6 @@ import { start } from '.'
 export function startFront (ctx: MeasureContext, extraConfig?: Record<string, string | undefined>): void {
   const SERVER_PORT = parseInt(process.env.SERVER_PORT ?? '8080')
 
-  const transactorEndpoint = process.env.TRANSACTOR_URL
-  if (transactorEndpoint === undefined) {
-    console.error('please provide transactor url')
-    process.exit(1)
-  }
-
   const url = process.env.MONGO_URL
   if (url === undefined) {
     console.error('please provide mongodb url')
@@ -117,7 +111,6 @@ export function startFront (ctx: MeasureContext, extraConfig?: Record<string, st
   setMetadata(serverToken.metadata.Secret, serverSecret)
 
   const config = {
-    transactorEndpoint,
     elasticUrl,
     storageAdapter,
     accountsUrl,

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -67,7 +67,6 @@ services:
       - ACCOUNTS_URL=http://localhost:3003
       - MONGO_URL=mongodb://mongodb:27018
       - UPLOAD_URL=/files
-      - TRANSACTOR_URL=ws://localhost:3334
       - ELASTIC_URL=http://elastic:9200
       - GMAIL_URL=http://localhost:8088
       - CALENDAR_URL=http://localhost:8095


### PR DESCRIPTION
Remove not used TRANSACTOR_URL env variable from front service configuration.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjZhNzUxYjJkOTA4MTUzNTY4M2M0MjIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.JzR14GkZ15kGeJJxZbgSnK2Nsqqfnfyxv9y6daKZFII">Huly&reg;: <b>UBERF-7252</b></a></sub>