### PR TITLE
EZQMS-974: Fix space type selector in document and product spaces

### DIFF
--- a/plugins/controlled-documents-resources/src/components/docspace/CreateDocumentsSpace.svelte
+++ b/plugins/controlled-documents-resources/src/components/docspace/CreateDocumentsSpace.svelte
@@ -74,6 +74,8 @@
 
     rolesAssignment = getRolesAssignment()
   }
+  $: descriptors =
+    spaceType?.descriptor !== undefined ? [spaceType.descriptor] : [documents.descriptor.DocumentSpaceType]
 
   function getRolesAssignment (): RolesAssignment {
     if (docSpace === undefined || spaceType?.targetClass === undefined || spaceType?.$lookup?.roles === undefined) {
@@ -239,7 +241,7 @@
 
       <SpaceTypeSelector
         disabled={!isNew}
-        descriptors={[documents.descriptor.DocumentSpaceType]}
+        {descriptors}
         type={typeId}
         focusIndex={4}
         kind="regular"

--- a/plugins/view-resources/src/components/SpaceTypeSelector.svelte
+++ b/plugins/view-resources/src/components/SpaceTypeSelector.svelte
@@ -28,7 +28,7 @@
 
   let types: SpaceType[] = []
   const typesQ = createQuery()
-  const query = {
+  $: query = {
     descriptor: { $in: descriptors }
   }
   $: typesQ.query(core.class.SpaceType, query, (result) => {


### PR DESCRIPTION
* Fixes space type selector in controlled documents and products spaces

Related to: https://front.hc.engineering/workbench/platform/tracker/EZQMS-974

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjZhYzA0MzJkOTA4MTUzNTY4M2M1NzEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.sDTUIqYpgRxlXCXtEBzkUE8T-hfXK8eaYOuJLVoqYic">Huly&reg;: <b>UBERF-7255</b></a></sub>