### PR TITLE
Added Emoji Support in Inline and Side Menu in Collaborative Text Editor

### DIFF
--- a/packages/text-editor/src/components/CollaborativeTextEditor.svelte
+++ b/packages/text-editor/src/components/CollaborativeTextEditor.svelte
@@ -32,6 +32,7 @@
     themeStore
   } from '@hcengineering/ui'
   import view from '@hcengineering/view'
+  import activity from '../../../../plugins/activity'
   import { AnyExtension, Editor, FocusPosition, mergeAttributes } from '@tiptap/core'
   import Collaboration, { isChangeOrigin } from '@tiptap/extension-collaboration'
   import CollaborationCursor from '@tiptap/extension-collaboration-cursor'
@@ -202,6 +203,9 @@
     insertSeparatorLine: () => {
       editor?.commands.setHorizontalRule()
     },
+    insertEmoji: () => {
+      editor?.commands.setHorizontalRule()
+    },
     focus: () => {
       focus()
     }
@@ -308,7 +312,8 @@
             ...(canEmbedImages ? [{ id: 'image', label: textEditorPlugin.string.Image, icon: view.icon.Image }] : []),
             { id: 'table', label: textEditorPlugin.string.Table, icon: view.icon.Table2 },
             { id: 'code-block', label: textEditorPlugin.string.CodeBlock, icon: view.icon.CodeBlock },
-            { id: 'separator-line', label: textEditorPlugin.string.SeparatorLine, icon: view.icon.SeparatorLine }
+            { id: 'separator-line', label: textEditorPlugin.string.SeparatorLine, icon: view.icon.SeparatorLine },
+            { id: 'emoji', label: textEditorPlugin.string.Emoji, icon: activity.icon.Emoji }
           ],
           handleSelect: handleLeftMenuClick
         })
@@ -403,6 +408,9 @@
         editor.commands.focus(pos, { scrollIntoView: false })
         break
       case 'separator-line':
+        editor.commands.setHorizontalRule()
+        break
+      case 'emoji':
         editor.commands.setHorizontalRule()
         break
     }

--- a/packages/text-editor/src/components/ReferenceInput.svelte
+++ b/packages/text-editor/src/components/ReferenceInput.svelte
@@ -94,6 +94,9 @@
     insertSeparatorLine: () => {
       textEditor?.insertSeparatorLine()
     },
+    insertEmoji: () => {
+      textEditor?.insertSeparatorLine()
+    },
     insertContent: (content) => {
       textEditor?.insertContent(content)
     },

--- a/packages/text-editor/src/components/StyledTextBox.svelte
+++ b/packages/text-editor/src/components/StyledTextBox.svelte
@@ -232,6 +232,9 @@
       case 'separator-line':
         textEditor.editorHandler.insertSeparatorLine()
         break
+      case 'emoji':
+        textEditor.editorHandler.insertSeparatorLine()
+        break
     }
   }
 

--- a/packages/text-editor/src/components/StyledTextEditor.svelte
+++ b/packages/text-editor/src/components/StyledTextEditor.svelte
@@ -102,6 +102,9 @@
     insertSeparatorLine: () => {
       textEditor?.insertSeparatorLine()
     },
+    insertEmoji() {
+      textEditor?.insertSeparatorLine()
+    },
     insertContent: (value, options) => {
       textEditor?.insertContent(value, options)
     },

--- a/packages/text-editor/src/components/TextEditor.svelte
+++ b/packages/text-editor/src/components/TextEditor.svelte
@@ -111,6 +111,11 @@
   export function insertSeparatorLine (): void {
     editor.commands.setHorizontalRule()
   }
+
+  export function insertEmoji (): void {
+    editor.commands.setHorizontalRule()
+  }
+
   export function insertContent (
     value: Content,
     options?: {

--- a/packages/text-editor/src/components/extensions.ts
+++ b/packages/text-editor/src/components/extensions.ts
@@ -14,6 +14,7 @@
 //
 
 import view from '@hcengineering/view'
+import activity from '../../../../plugins/activity'
 import { type Editor, type Range } from '@tiptap/core'
 
 import { type CompletionOptions } from '../Completion'
@@ -129,7 +130,7 @@ export const completionConfig: Partial<CompletionOptions> = {
   }
 }
 
-const inlineCommandsIds = ['image', 'table', 'code-block', 'separator-line'] as const
+const inlineCommandsIds = ['image', 'table', 'code-block', 'separator-line', 'emoji'] as const
 export type InlineCommandId = (typeof inlineCommandsIds)[number]
 
 /**
@@ -146,7 +147,8 @@ export function inlineCommandsConfig (
           { id: 'image', label: plugin.string.Image, icon: view.icon.Image },
           { id: 'table', label: plugin.string.Table, icon: view.icon.Table2 },
           { id: 'code-block', label: plugin.string.CodeBlock, icon: view.icon.CodeBlock },
-          { id: 'separator-line', label: plugin.string.SeparatorLine, icon: view.icon.SeparatorLine }
+          { id: 'separator-line', label: plugin.string.SeparatorLine, icon: view.icon.SeparatorLine },
+          { id: 'emoji', label: plugin.string.Emoji, icon: activity.icon.Emoji}
         ].filter(({ id }) => !excludedCommands.includes(id as InlineCommandId))
       },
       command: ({ editor, range, props }: { editor: Editor, range: Range, props: any }) => {

--- a/packages/text-editor/src/types.ts
+++ b/packages/text-editor/src/types.ts
@@ -15,6 +15,7 @@ export interface TextEditorHandler {
   insertTable: (options: { rows?: number, cols?: number, withHeaderRow?: boolean }) => void
   insertCodeBlock: (pos?: number) => void
   insertSeparatorLine: () => void
+  insertEmoji: () => void
   insertContent: (
     value: Content,
     options?: {


### PR DESCRIPTION
What Does this PR Do?
It adds support in Collaborative Text Editor to add Emjois using inline command `/` or side menu

Earlier only 4 options were there in the menu :

* Image
* Table
* Code block
* Separator Line

Added a new option : Emoji , later can be extended easily to support Emoji popup

Screenshot
Inline Command
![Screenshot 2024-06-14 at 6 13 08 PM](https://github.com/hcengineering/platform/assets/39734798/7515f087-ff61-4b55-918d-ca8a798c1b7a)

Side Menu
![Screenshot 2024-06-14 at 6 13 19 PM](https://github.com/hcengineering/platform/assets/39734798/26fd5a5d-d839-41be-99cc-6e737ccff749)