### PR TITLE
UBERF-7244: Show default menu when right click on text 

### DIFF
--- a/packages/theme/styles/_layouts.scss
+++ b/packages/theme/styles/_layouts.scss
@@ -109,6 +109,7 @@ li {
 
 p {
   user-select: text;
+  cursor: auto;
   
   a {
     word-break: break-all;

--- a/packages/theme/styles/prose.scss
+++ b/packages/theme/styles/prose.scss
@@ -359,6 +359,7 @@ table.proseTable {
   border-radius: .25rem;
   padding: .5rem;
   user-select: text;
+  cursor: auto;
 
   pre { white-space: pre-wrap; }
 }

--- a/plugins/activity-resources/src/components/activity-message/ActivityMessageTemplate.svelte
+++ b/plugins/activity-resources/src/components/activity-message/ActivityMessageTemplate.svelte
@@ -104,6 +104,42 @@
   }
 
   $: isShort = canDisplayShort(type, isSaved)
+
+  function isInside (x: number, y: number, rect: DOMRect): boolean {
+    return x >= rect.left && y >= rect.top && x <= rect.right && y <= rect.bottom
+  }
+
+  function isTextClicked (element: HTMLElement | null, x: number, y: number): boolean {
+    if (element == null) {
+      return false
+    }
+
+    const nodes = element.childNodes
+    const range = document.createRange()
+
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i]
+
+      if (node.nodeType !== Node.TEXT_NODE) continue
+
+      range.selectNodeContents(node)
+
+      if (isInside(x, y, range.getBoundingClientRect())) {
+        return true
+      }
+    }
+    return false
+  }
+
+  function handleContextMenu (event: MouseEvent): void {
+    const showCustomPopup = !isTextClicked(event.target as HTMLElement, event.clientX, event.clientY)
+    if (showCustomPopup) {
+      showMenu(event, { object: message, baseMenuClass: activity.class.ActivityMessage }, () => {
+        isActionsOpened = false
+      })
+      isActionsOpened = true
+    }
+  }
 </script>
 
 {#if !isHidden}
@@ -123,12 +159,7 @@
       class:borderedHover={hoverStyles === 'borderedHover'}
       class:filledHover={hoverStyles === 'filledHover'}
       on:click={onClick}
-      on:contextmenu={(evt) => {
-        showMenu(evt, { object: message, baseMenuClass: activity.class.ActivityMessage }, () => {
-          isActionsOpened = false
-        })
-        isActionsOpened = true
-      }}
+      on:contextmenu={handleContextMenu}
     >
       {#if showNotify && !embedded && !isShort}
         <div class="notify" />


### PR DESCRIPTION
Show default menu when right click on text  to allow copy and other system functions
Also show "text" cursor in chat when hover on text

https://github.com/hcengineering/platform/assets/113431133/00c1fd71-d7c1-4da4-9caa-8175b560096f

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjZjNTY4ZTJkOTA4MTUzNTY4M2NjNjkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.WSS94vilA9BnCF1JpiI5pgeGoY3hMU8VNjnHUEPWHWM">Huly&reg;: <b>UBERF-7283</b></a></sub>