### PR TITLE
Add attachments block for companies and comment input for it's members

### DIFF
--- a/models/contact/src/index.ts
+++ b/models/contact/src/index.ts
@@ -276,6 +276,11 @@ export function createModel (builder: Builder): void {
     components: { input: chunter.component.ChatMessageInput }
   })
 
+  builder.createDoc(activity.class.ActivityExtension, core.space.Model, {
+    ofClass: contact.class.Member,
+    components: { input: chunter.component.ChatMessageInput }
+  })
+
   builder.mixin(contact.mixin.Employee, core.class.Class, view.mixin.ObjectFactory, {
     component: contact.component.CreateEmployee
   })

--- a/plugins/contact-resources/src/components/EditOrganizationPanel.svelte
+++ b/plugins/contact-resources/src/components/EditOrganizationPanel.svelte
@@ -32,7 +32,7 @@
   const dispatch = createEventDispatcher()
   const inboxClient = getResource(notification.function.GetInboxNotificationsClient).then((res) => res())
 
-  const ignoreKeys = ['comments', 'name', 'channels', 'description', 'attachments']
+  const ignoreKeys = ['comments', 'name', 'channels', 'description']
 
   let object: Organization | undefined = undefined
   let lastId: Ref<Organization> | undefined = undefined
@@ -144,6 +144,7 @@
           {object}
           key={{ key: 'description', attr: descriptionKey }}
           placeholder={core.string.Description}
+          enableAttachments={false}
           on:saved={(evt) => {
             saved = evt.detail
           }}


### PR DESCRIPTION
Add attachments block for companies like we have for Person.
Allow sending comments for members of the organization
![image](https://github.com/hcengineering/platform/assets/37306501/cb903a32-a392-4b00-b532-481d41fded40)
![image](https://github.com/hcengineering/platform/assets/37306501/acf48a31-5a78-43da-99be-a685cf2517fc)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjcwYjg2YzQ0NjVhYzg4MTBhNzBlNTAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.5t6nKK-LNwZWyCIjkPeMVNhcDWXyu1_VUfB-3DI9BLw">Huly&reg;: <b>UBERF-7305</b></a></sub>