### PR TITLE
UBERF-7350: Add more OAuth logs

### DIFF
--- a/pods/authProviders/src/github.ts
+++ b/pods/authProviders/src/github.ts
@@ -38,7 +38,7 @@ export function registerGithub (
   router.get('/auth/github', async (ctx, next) => {
     measureCtx.info('try auth via', { provider: 'github' })
     const host = getHost(ctx.request.headers)
-    const branding = host !== undefined ? brandings[host]?.key ?? '' : ''
+    const branding = host !== undefined ? brandings[host]?.key ?? undefined : undefined
     const state = encodeURIComponent(
       JSON.stringify({
         inviteId: ctx.query?.inviteId,


### PR DESCRIPTION
Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-7350

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Njc0YjVjYzg3NDE2MjNkZGU3YjQ1NzAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.vKeNiDuhJ4M2iOaRGEiamQQG-UEkeAbMFqE7P_lwyBo">Huly&reg;: <b>UBERF-7351</b></a></sub>