### PR TITLE
UBERF-7362: Do not cache branding served from front

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -84,6 +84,7 @@ services:
       - COLLABORATOR_URL=ws://localhost:3078
       - COLLABORATOR_API_URL=http://localhost:3078
       - STORAGE_CONFIG=${STORAGE_CONFIG}
+      - BRANDING_URL=http://localhost:8087/branding.json
     restart: unless-stopped
   collaborator:
     image: hardcoreeng/collaborator

--- a/dev/prod/src/platform.ts
+++ b/dev/prod/src/platform.ts
@@ -205,7 +205,7 @@ export async function configurePlatform() {
   configureI18n()
 
   const config: Config = await (await fetch(devConfig? '/config-dev.json' : '/config.json')).json()
-  const branding: BrandingMap = await (await fetch(config.BRANDING_URL ?? '/branding.json')).json()
+  const branding: BrandingMap = config.BRANDING_URL !== undefined ? await (await fetch(config.BRANDING_URL)).json() : {}
   const myBranding = branding[window.location.host] ?? {}
 
   console.log('loading configuration', config)

--- a/server/front/src/index.ts
+++ b/server/front/src/index.ts
@@ -304,7 +304,15 @@ export function start (
   const dist = resolve(process.env.PUBLIC_DIR ?? cwd(), 'dist')
   console.log('serving static files from', dist)
 
-  const brandingUrl = config.brandingUrl !== undefined ? new URL(config.brandingUrl) : undefined
+  let brandingUrl: URL | undefined
+  if (config.brandingUrl !== undefined) {
+    try {
+      brandingUrl = new URL(config.brandingUrl)
+    } catch (e) {
+      console.error('Invalid branding URL. Must be absolute URL.', e)
+    }
+  }
+
   app.use(
     expressStaticGzip(dist, {
       serveStatic: {

--- a/server/front/src/index.ts
+++ b/server/front/src/index.ts
@@ -304,6 +304,7 @@ export function start (
   const dist = resolve(process.env.PUBLIC_DIR ?? cwd(), 'dist')
   console.log('serving static files from', dist)
 
+  const brandingUrl = config.brandingUrl !== undefined ? new URL(config.brandingUrl) : undefined
   app.use(
     expressStaticGzip(dist, {
       serveStatic: {
@@ -314,7 +315,10 @@ export function start (
         lastModified: true,
         index: false,
         setHeaders (res, path) {
-          if (path.toLowerCase().includes('index.html')) {
+          if (
+            path.toLowerCase().includes('index.html') ||
+            (brandingUrl !== undefined && path.toLowerCase().includes(brandingUrl.pathname))
+          ) {
             res.setHeader('Cache-Control', cacheControlNoCache)
           }
         }

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -78,7 +78,7 @@ services:
       - COLLABORATOR_URL=ws://localhost:3079
       - COLLABORATOR_API_URL=http://localhost:3079
       - STORAGE_CONFIG=${STORAGE_CONFIG}
-      - BRANDING_URL=/branding-test.json
+      - BRANDING_URL=http://localhost:8083/branding-test.json
   transactor:
     image: hardcoreeng/transactor
     pull_policy: never


### PR DESCRIPTION
* Do not cache branding served from front
* Do not load default dev branding by default

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-7362

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Njc1MzVjZDg3NDE2MjNkZGU3YjQ4NDAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.cah4K2U2fCOG3HsUdiQahMmIZASxiMlP2sqEZKZ6C2I">Huly&reg;: <b>UBERF-7363</b></a></sub>