### PR TITLE
Fix chat loading problems

### DIFF
--- a/plugins/chunter-resources/src/components/ChannelScrollView.svelte
+++ b/plugins/chunter-resources/src/components/ChannelScrollView.svelte
@@ -236,7 +236,7 @@
 
     const { scrollHeight, scrollTop, clientHeight } = scrollElement
 
-    return Math.ceil(scrollTop + clientHeight) === scrollHeight
+    return scrollHeight - Math.ceil(scrollTop + clientHeight) <= 0
   }
 
   let scrollToRestore = 0

--- a/plugins/notification-resources/src/components/NotifyContextIcon.svelte
+++ b/plugins/notification-resources/src/components/NotifyContextIcon.svelte
@@ -32,6 +32,9 @@
 
   let object: Doc | undefined = undefined
 
+  $: if (object?._id !== value.attachedTo) {
+    object = undefined
+  }
   $: iconMixin = hierarchy.classHierarchyMixin(value.attachedToClass, view.mixin.ObjectIcon)
   $: iconMixin &&
     query.query(value.attachedToClass, { _id: value.attachedTo }, (res) => {

--- a/plugins/notification-resources/src/inboxNotificationsClient.ts
+++ b/plugins/notification-resources/src/inboxNotificationsClient.ts
@@ -232,6 +232,7 @@ export class InboxNotificationsClientImpl implements InboxNotificationsClient {
     )
 
     for (const notification of notificationsToRead) {
+      notification.isViewed = true
       await client.update(notification, { isViewed: true })
     }
   }


### PR DESCRIPTION
* fixed bug due to which one message could be loaded twice and cause an error (also simplify code)
* improve loading of chunks when scrolling down (sometimes the event did not fire due to non-integer values `clientHeight`)
* mark notification as viewed in store to avoid multiple request due to scrolling

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Njc1ZjcxZTg3NDE2MjNkZGU3YjRjNmQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.YQYRZVjUFL6UtjqPwppfj_lZlepaRtwEj4HEhUIZd2w">Huly&reg;: <b>UBERF-7376</b></a></sub>