### PR TITLE
Reserving height for content in FilePreview

### DIFF
--- a/packages/ui/src/components/Panel.svelte
+++ b/packages/ui/src/components/Panel.svelte
@@ -176,7 +176,7 @@
       {#if !withoutTitle}<slot name="title" />{/if}
     </div>
     <slot name="pre-utils" />
-    <div class="flex-row-center ml-3 no-print">
+    <div class="flex-row-center flex-no-shrink ml-3 no-print">
       <slot name="utils" />
       {#if $$slots.aside && isAside}
         {#if customAside}

--- a/packages/ui/src/components/calendar/Month.svelte
+++ b/packages/ui/src/components/calendar/Month.svelte
@@ -42,6 +42,7 @@
   let monthYear: string
   const today: Date = new Date(Date.now())
   const viewDate: Date = new Date(currentDate ?? today)
+  let selectedDate: Date = new Date(currentDate ?? today)
   $: firstDayOfCurrentMonth = firstDay(viewDate, mondayStart)
   const isToday = (n: number): boolean => {
     if (areDatesEqual(today, new Date(viewDate.getFullYear(), viewDate.getMonth(), n))) return true
@@ -50,8 +51,8 @@
 
   let days: ICell[] = []
   const getDateStyle = (date: Date): TCellStyle => {
-    if (currentDate != null) {
-      const zonedTime = fromCurrentToTz(currentDate, timeZone)
+    if (selectedDate != null) {
+      const zonedTime = fromCurrentToTz(selectedDate, timeZone)
       if (areDatesEqual(zonedTime, date)) {
         return 'selected'
       }
@@ -129,6 +130,7 @@
               : day.dayOfWeek + 2};"
           on:click|stopPropagation={() => {
             viewDate.setDate(i + 1)
+            selectedDate = new Date(viewDate)
             dispatch('update', viewDate)
           }}
         >

--- a/plugins/view-resources/src/components/viewer/ImageViewer.svelte
+++ b/plugins/view-resources/src/components/viewer/ImageViewer.svelte
@@ -21,8 +21,14 @@
   export let metadata: BlobMetadata | undefined
 
   $: p = typeof value === 'string' ? getBlobRef(undefined, value, name) : getBlobRef(value, value._id)
-  $: maxWidth = metadata?.originalWidth ? `min(${metadata.originalWidth}px, 100%)` : undefined
-  $: maxHeight = metadata?.originalHeight ? `min(${metadata.originalHeight}px, 80vh)` : undefined
+  $: maxWidth =
+    metadata?.originalWidth && metadata?.pixelRatio
+      ? `min(${metadata.originalWidth / metadata.pixelRatio}px, 100%)`
+      : undefined
+  $: maxHeight =
+    metadata?.originalHeight && metadata?.pixelRatio
+      ? `min(${metadata.originalHeight / metadata.pixelRatio}px, 80vh)`
+      : undefined
 </script>
 
 {#await p then blobRef}


### PR DESCRIPTION
1. Reserving height for content in FilePreview
2. Minor fixes in the Calendar and Panel

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Njc4NzljNDg3NDE2MjNkZGU3YjRkM2MiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.5msj3MOM-0Mdk5_67KcXaa-VUKcOCX2ZBKymDt9uXh4">Huly&reg;: <b>UBERF-7378</b></a></sub>