### PR TITLE
EQMS-1033 Filter out readonly projects when creating new controlled document

### DIFF
--- a/plugins/controlled-documents-resources/src/components/hierarchy/DocumentSpacePresenter.svelte
+++ b/plugins/controlled-documents-resources/src/components/hierarchy/DocumentSpacePresenter.svelte
@@ -116,7 +116,7 @@
   }
 
   async function selectProject (space: DocumentSpace): Promise<void> {
-    project = getCurrentProject(space._id) ?? (await getLatestProjectId(space._id)) ?? documents.ids.NoProject
+    project = getCurrentProject(space._id) ?? (await getLatestProjectId(space._id, true)) ?? documents.ids.NoProject
   }
 
   function handleDocumentSelected (doc: WithLookup<ProjectDocument>): void {

--- a/plugins/controlled-documents-resources/src/utils.ts
+++ b/plugins/controlled-documents-resources/src/utils.ts
@@ -704,7 +704,7 @@ async function getLatestProject (space: Ref<DocumentSpace>, includeReadonly = fa
 
 export async function getLatestProjectId (
   spaceRef: Ref<DocumentSpace>,
-  editableOnly = false
+  includeReadonly = false
 ): Promise<Ref<Project> | undefined> {
   const client = getClient()
   const space = await client.findOne(
@@ -721,7 +721,7 @@ export async function getLatestProjectId (
 
   if (space !== undefined) {
     if (space.$lookup?.type?.projects ?? false) {
-      const project = await getLatestProject(spaceRef, editableOnly)
+      const project = await getLatestProject(spaceRef, includeReadonly)
       return project?._id
     } else {
       return documents.ids.NoProject


### PR DESCRIPTION
<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Njc5OTUxYjNlOGFhOTFjZTY2YWViOGYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.Y1Eptu1WV1hShu7PONmgRohbIrVmiVuYnGKRNK8PjBo">Huly&reg;: <b>UBERF-7392</b></a></sub>