### PR TITLE
Qfix: remove extra code block extension

### DIFF
--- a/packages/text/src/kits/server-kit.ts
+++ b/packages/text/src/kits/server-kit.ts
@@ -80,7 +80,6 @@ export const ServerKit = Extension.create<ServerKitOptions>({
       }),
       CodeBlockExtension.configure(codeBlockOptions),
       CodeExtension.configure(codeOptions),
-      CodeBlockExtension.configure(codeBlockOptions),
       ...tableExtensions,
       ...taskListExtensions,
       ...fileExtensions,


### PR DESCRIPTION
* Removes extra code block extension

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjdiMmQ4MDNlOGFhOTFjZTY2YWVmOTgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0._Cm5-PdGBT6Os-_cstulivSl2wY_u1wYj66-9zJfUzA">Huly&reg;: <b>UBERF-7399</b></a></sub>