### PR TITLE
EQMS-941 Fix order of list and table extensions

### DIFF
--- a/packages/text-editor/src/kits/editor-kit.ts
+++ b/packages/text-editor/src/kits/editor-kit.ts
@@ -70,6 +70,8 @@ export const EditorKit = Extension.create<EditorKitOptions>({
   addExtensions () {
     const mode = this.options.mode ?? 'full'
     return [
+      // table extensions should go before list items
+      ...tableExtensions,
       DefaultKit.configure({
         ...this.options,
         code: false,
@@ -108,7 +110,6 @@ export const EditorKit = Extension.create<EditorKitOptions>({
         ]
       }),
       NodeUuidExtension,
-      ...tableExtensions,
       ...(this.options.file !== false
         ? [
             FileExtension.configure({


### PR DESCRIPTION
Fix order of list and table extensions to make tab hotkey work properly inside table.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjdiOTg4ODNlOGFhOTFjZTY2YWYwMGMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.I1sXQiCZTK5POg7mfRI7nn4YrP4CXlpXVyFadPMiscE">Huly&reg;: <b>UBERF-7401</b></a></sub>