### PR TITLE
UBERF-7411: Allow to backup blobs with wrong size

### DIFF
--- a/packages/text-editor/src/provider/storage.ts
+++ b/packages/text-editor/src/provider/storage.ts
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import { type Blob, type CollaborativeDoc, type Ref, collaborativeDocParse } from '@hcengineering/core'
-import { getBlobHref } from '@hcengineering/presentation'
+import core, {
+  collaborativeDocParse,
+  type Blob,
+  type BlobLookup,
+  type CollaborativeDoc,
+  type Ref
+} from '@hcengineering/core'
+import { getBlobHref, getClient } from '@hcengineering/presentation'
 import { ObservableV2 as Observable } from 'lib0/observable'
 import { applyUpdate, type Doc as YDoc } from 'yjs'
 
@@ -33,7 +39,11 @@ async function fetchContent (blob: Ref<Blob>, doc: YDoc): Promise<boolean> {
 
 async function fetchBlobContent (_id: Ref<Blob>): Promise<Uint8Array | undefined> {
   try {
-    const href = await getBlobHref(undefined, _id)
+    const blob = (await getClient().findOne(core.class.Blob, { _id })) as BlobLookup
+    if (blob.size === 0) {
+      return undefined
+    }
+    const href = await getBlobHref(blob, _id)
     const res = await fetch(href)
 
     if (res.ok) {

--- a/packages/ui/src/components/Loading.svelte
+++ b/packages/ui/src/components/Loading.svelte
@@ -66,7 +66,7 @@
     opacity: 0;
     animation-name: makeVisible;
     animation-duration: 0.25s;
-    animation-delay: 0.1s;
+    animation-delay: 0.25s;
     animation-fill-mode: forwards;
 
     &.labeled {

--- a/plugins/workbench-resources/src/connect.ts
+++ b/plugins/workbench-resources/src/connect.ts
@@ -90,12 +90,12 @@ export async function connect (title: string): Promise<Client | undefined> {
   setMetadata(presentation.metadata.Token, token)
 
   const fetchWorkspace = await getResource(login.function.FetchWorkspace)
-  let loginInfo = await ctx.with('select-workspace', {}, async () => (await fetchWorkspace(ws))[1])
+  let loginInfo = await ctx.with('fetch-workspace', {}, async () => (await fetchWorkspace(ws))[1])
   if (loginInfo?.creating === true) {
     while (true) {
       if (ws !== getCurrentLocation().path[1]) return
       workspaceCreating.set(loginInfo?.createProgress ?? 0)
-      loginInfo = await ctx.with('select-workspace', {}, async () => (await fetchWorkspace(ws))[1])
+      loginInfo = await ctx.with('fetch-workspace', {}, async () => (await fetchWorkspace(ws))[1])
       workspaceCreating.set(loginInfo?.createProgress)
       if (loginInfo?.creating === false) {
         workspaceCreating.set(-1)

--- a/server/server-storage/src/blobStorage.ts
+++ b/server/server-storage/src/blobStorage.ts
@@ -88,6 +88,8 @@ class StorageBlobAdapter implements DbAdapter {
             blob.contentType = blobStat.contentType
             blob.version = blobStat.version
             blob.size = blobStat.size
+            delete (blob as any).downloadUrl
+            delete (blob as any).downloadUrlExpire
 
             toUpload.push(blob)
           }


### PR DESCRIPTION
UBERF-7411: Allow to backup blobs with wrong size

* Fix backup/restore download url cleanup

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjdkMGU5YzkwNmY3YjdkNmJlN2UwOGYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.RWUZj1wJ30Q624IxuHOeyyJxsMzkeRB7XniHeWcqjdA">Huly&reg;: <b>UBERF-7412</b></a></sub>