### PR TITLE
Change Todo list to Action item, add translations

### DIFF
--- a/packages/text-editor/lang/en.json
+++ b/packages/text-editor/lang/en.json
@@ -51,6 +51,6 @@
     "Unset": "Unset",
     "Image": "Image",
     "SeparatorLine": "Separator line",
-    "TodoList": "Todo list"
+    "TodoList": "Action item"
   }
 }

--- a/packages/text-editor/lang/es.json
+++ b/packages/text-editor/lang/es.json
@@ -48,6 +48,7 @@
     "Height": "Alto",
     "Unset": "Anular",
     "Image": "Imagen",
-    "SeparatorLine": "Línea de separación"
+    "SeparatorLine": "Línea de separación",
+    "TodoList": "Tarea pendiente"
   }
 }

--- a/packages/text-editor/lang/fr.json
+++ b/packages/text-editor/lang/fr.json
@@ -48,6 +48,7 @@
     "Height": "Hauteur",
     "Unset": "Non défini",
     "Image": "Image",
-    "SeparatorLine": "Ligne de séparation"
+    "SeparatorLine": "Ligne de séparation",
+    "TodoList": "À faire"
   }
 }

--- a/packages/text-editor/lang/pt.json
+++ b/packages/text-editor/lang/pt.json
@@ -48,6 +48,7 @@
     "Height": "Altura",
     "Unset": "Anular",
     "Image": "Imagem",
-    "SeparatorLine": "linha separadora"
+    "SeparatorLine": "linha separadora",
+    "TodoList": "Tarefa pendente"
   }
 }

--- a/packages/text-editor/lang/ru.json
+++ b/packages/text-editor/lang/ru.json
@@ -50,6 +50,7 @@
     "Height": "Высота",
     "Unset": "Убрать",
     "Image": "Изображение",
-    "SeparatorLine": "Разделительная линия"
+    "SeparatorLine": "Разделительная линия",
+    "TodoList": "Action item"
   }
 }

--- a/packages/text-editor/lang/zh.json
+++ b/packages/text-editor/lang/zh.json
@@ -50,6 +50,7 @@
     "Height": "高度",
     "Unset": "未设置",
     "Image": "图片",
-    "SeparatorLine": "分隔线"
+    "SeparatorLine": "分隔线",
+    "TodoList": "待办"
   }
 }


### PR DESCRIPTION
Builds upon this PR: <https://github.com/hcengineering/platform/pull/5827>

* Change `Todo list` to `Action item` to stay consistent with new terminology across the platform (Todo --> Action Item)
* Provide translations in other languages based on existing translations of "Todo" (we have not yet found equivalent of Action Item in other languages, and Russian version currently uses English for this concept)
  <img width="276" src="https://github.com/hcengineering/platform/assets/145867967/e2b6a076-9c78-4809-9e9e-be1c31ad3f84" alt="Screenshot 2024-06-28 at 12 31 04 PM">
  <img width="258" src="https://github.com/hcengineering/platform/assets/145867967/ab18d6f5-f604-491c-9491-eee8d4f503ef" alt="Screenshot 2024-06-28 at 12 53 52 PM">

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjdlZjZlZTdlY2UwYzgxMjQ5ZTIzMjciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.viFBXBgWt36Ad96sfQA4c0C_U8Hnx9rhbLG3beoniTE">Huly&reg;: <b>UBERF-7444</b></a></sub>