### PR TITLE
fix overwriting space in elastic doc

### DIFF
--- a/server/core/src/indexer/fulltextPush.ts
+++ b/server/core/src/indexer/fulltextPush.ts
@@ -239,7 +239,7 @@ export function createElasticDoc (upd: DocIndexState): IndexedDoc {
     _class: [upd.objectClass, ...(upd.mixins ?? [])],
     modifiedBy: upd.modifiedBy,
     modifiedOn: upd.modifiedOn,
-    space: upd.space,
+    space: [upd.space],
     attachedTo: upd.attachedTo,
     attachedToClass: upd.attachedToClass
   }
@@ -321,6 +321,8 @@ function updateDoc2Elastic (
 
   const spaceKey = docKey('space', { _class: core.class.Doc })
   if (doc[spaceKey] !== undefined) {
-    doc.space = doc[spaceKey]
+    const existsingSpace = Array.isArray(doc.space) ? doc.space : [doc.space]
+    const newSpaces = Array.isArray(doc[spaceKey]) ? doc[spaceKey] : [doc[spaceKey]]
+    doc.space = [...existsingSpace, ...newSpaces].filter((it, idx, arr) => arr.indexOf(it) === idx)
   }
 }

--- a/server/core/src/indexer/types.ts
+++ b/server/core/src/indexer/types.ts
@@ -107,4 +107,4 @@ export const fieldStateId = 'fld-v15'
 /**
  * @public
  */
-export const fullTextPushStageId = 'fts-v16'
+export const fullTextPushStageId = 'fts-v17'

--- a/server/core/src/types.ts
+++ b/server/core/src/types.ts
@@ -213,7 +213,7 @@ export interface EmbeddingSearchOption {
 export interface IndexedDoc {
   id: Ref<Doc>
   _class: Ref<Class<Doc>>[]
-  space: Ref<Space>
+  space: Ref<Space>[]
   modifiedOn: Timestamp
   modifiedBy: Ref<Account>
   attachedTo?: Ref<Doc>

--- a/server/elastic/src/__tests__/adapter.test.ts
+++ b/server/elastic/src/__tests__/adapter.test.ts
@@ -44,7 +44,7 @@ describe('Elastic Adapter', () => {
       _class: ['class1' as Ref<Class<Doc>>],
       modifiedBy: 'andrey' as Ref<Account>,
       modifiedOn: 0,
-      space: 'space1' as Ref<Space>,
+      space: ['space1' as Ref<Space>],
       content0: 'hey there!'
     }
     await adapter.index(doc)


### PR DESCRIPTION
Prevent overwrite of space by child docs

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjgxZGRmYTdlY2UwYzgxMjQ5ZTI3MTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.8I-ZhIC3u21iLh4pSDwwmX_CZSG6BdluyNjSfHkDnYg">Huly&reg;: <b>UBERF-7456</b></a></sub>