### PR TITLE
Add spinner and disable editbox in todo until save is finished

### DIFF
--- a/plugins/time-resources/src/components/CreateToDo.svelte
+++ b/plugins/time-resources/src/components/CreateToDo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ActionIcon, IconAdd, showPopup, ModernEditbox } from '@hcengineering/ui'
+  import { ActionIcon, IconAdd, showPopup, ModernEditbox, Spinner } from '@hcengineering/ui'
   import { SortingOrder, generateId, getCurrentAccount } from '@hcengineering/core'
   import { PersonAccount } from '@hcengineering/contact'
   import { ToDoPriority } from '@hcengineering/time'
@@ -10,6 +10,7 @@
 
   export let fullSize: boolean = false
   let value: string = ''
+  let disabled: boolean = false
 
   const client = getClient()
   const acc = getCurrentAccount() as PersonAccount
@@ -58,16 +59,22 @@
     width={fullSize ? '100%' : ''}
     size={'medium'}
     autoAction={false}
+    {disabled}
     bind:value
     on:keydown={(e) => {
       if (e.key === 'Enter') {
-        save()
+        disabled = true
+        save().finally(() => (disabled = false))
         e.preventDefault()
         e.stopPropagation()
       }
     }}
   >
-    <ActionIcon icon={IconAdd} action={openPopup} size={'small'} />
+    {#if disabled}
+      <Spinner size={'small'} />
+    {:else}
+      <ActionIcon icon={IconAdd} action={openPopup} size={'small'} />
+    {/if}
   </ModernEditbox>
 </div>
 


### PR DESCRIPTION
Closes #5937.

https://github.com/hcengineering/platform/assets/14805092/4133d85b-32f7-4c4f-a9f0-3c6c9f21c058

How to reproduce:

1. In Planner, start typing some Action Item
2. Disable connection (in browser dev panel)
3. Press enter (several times)
4. Editbox becomes disabled, "add" button is substituted by spinner
5. Once connection is restored, only one Action Item is added, editbox becomes enabled, "add" button replaces spinner, Editbox is cleared

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjgyMzcwZDc0ZmRjOGExYzc1OGE3MTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.ouCJxMOKw97pAoIhf7uMh8MPyzdKd9SpEZnFpm69hiI">Huly&reg;: <b>UBERF-7457</b></a></sub>