### PR TITLE
Change shebangs to /usr/bin/env calls for better portability

### DIFF
--- a/common/scripts/build_docker.sh
+++ b/common/scripts/build_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 roots='./server/server ./server/front ./pods/account ./pods/backup'
 # ./products/tracker is temporary disabled

--- a/common/scripts/docker_build.sh
+++ b/common/scripts/docker_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 version=$(git rev-parse HEAD)
 

--- a/common/scripts/docker_tag.sh
+++ b/common/scripts/docker_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 version=$(git describe --tags --abbrev=0)
 rev_version=$(git rev-parse HEAD)

--- a/common/scripts/docker_tag_push.sh
+++ b/common/scripts/docker_tag_push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "Tagging release $1 with version $2"  
 docker tag "$1" "$1:$2"
 docker push "$1:$2"

--- a/common/scripts/git_version.sh
+++ b/common/scripts/git_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 version=$(git describe --all --long)
 echo \"$version\"

--- a/dev/tool/build.sh
+++ b/dev/tool/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #  Copyright © 2020, 2021 Anticrm Platform Contributors.
 #  Copyright © 2021 Hardcore Engineering Inc.

--- a/pods/account/build.sh
+++ b/pods/account/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #  Copyright © 2020, 2021 Anticrm Platform Contributors.
 #  Copyright © 2021 Hardcore Engineering Inc.

--- a/pods/backup/build.sh
+++ b/pods/backup/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #  Copyright © 2022 Hardcore Engineering Inc.
 #  

--- a/pods/collaborator/build.sh
+++ b/pods/collaborator/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #  Copyright © 2020, 2021 Anticrm Platform Contributors.
 #  Copyright © 2021 Hardcore Engineering Inc.

--- a/pods/front/build.sh
+++ b/pods/front/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #  Copyright © 2020, 2021 Anticrm Platform Contributors.
 #  Copyright © 2021 Hardcore Engineering Inc.

--- a/pods/front/run.sh
+++ b/pods/front/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export ACCOUNTS_URL=http://localhost:3333
 export UPLOAD_URL=http://localhost:3333/files

--- a/pods/server/build.sh
+++ b/pods/server/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #  Copyright © 2020, 2021 Anticrm Platform Contributors.
 #  Copyright © 2021 Hardcore Engineering Inc.

--- a/server/account-service/build.sh
+++ b/server/account-service/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #  Copyright © 2020, 2021 Anticrm Platform Contributors.
 #  Copyright © 2021 Hardcore Engineering Inc.

--- a/server/collaborator/build.sh
+++ b/server/collaborator/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #  Copyright © 2020, 2021 Anticrm Platform Contributors.
 #  Copyright © 2021 Hardcore Engineering Inc.

--- a/server/front/build.sh
+++ b/server/front/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #  Copyright © 2020, 2021 Anticrm Platform Contributors.
 #  Copyright © 2021 Hardcore Engineering Inc.

--- a/server/front/run.sh
+++ b/server/front/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export ACCOUNTS_URL=http://localhost:3333
 export UPLOAD_URL=http://localhost:3333/files

--- a/server/uws/uws.sh
+++ b/server/uws/uws.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 mkdir -p ./.build
 cd ./.build
 if ! test -f ./v20.43.0.zip; then

--- a/tests/build-reload.sh
+++ b/tests/build-reload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Restore workspace contents in mongo/elastic
 rush build

--- a/tests/install-elastic-plugin-setup.sh
+++ b/tests/install-elastic-plugin-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage
 # ./install-elastic-plugin-setup.sh sanity_elastic_1

--- a/tests/install-elastic-plugin.sh
+++ b/tests/install-elastic-plugin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage
 # ./install-elastic-plugin.sh sanity_elastic_1

--- a/tests/prepare-tests.sh
+++ b/tests/prepare-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose -p sanity kill
 docker compose -p sanity down --volumes

--- a/tests/prepare.sh
+++ b/tests/prepare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose -p sanity kill
 docker compose -p sanity down --volumes

--- a/tests/restore-workspace.sh
+++ b/tests/restore-workspace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Restore workspace contents in mongo/elastic
 ./tool.sh backup-restore ./sanity-ws sanity-ws

--- a/tests/tool.sh
+++ b/tests/tool.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export MINIO_ACCESS_KEY=minioadmin
 export MINIO_SECRET_KEY=minioadmin


### PR DESCRIPTION
While I was building the project (by instructions in README), I found some of the scripts didn't work on my machine. Additionally, I changed other scripts, where I found shebangs are referencing `/bin/bash`, substituting it with `/usr/bin/env bash`, which should improve portability.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjgyMzhhODc0ZmRjOGExYzc1OGE3NDgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.cpPf8cChvW2En-yXRYd8Mo3tpvWl1xxNIJ7tD2cbzP4">Huly&reg;: <b>UBERF-7458</b></a></sub>