### PR TITLE
Fixed english not used by default when other translation is not found

### DIFF
--- a/packages/platform/src/i18n.ts
+++ b/packages/platform/src/i18n.ts
@@ -91,9 +91,18 @@ async function getTranslation (id: _IdInfo, locale: string): Promise<IntlString 
     if (messages instanceof Status) {
       return messages
     }
-    return id.kind !== undefined
-      ? (messages[id.kind] as Record<string, IntlString>)?.[id.name]
-      : (messages[id.name] as IntlString)
+    if (id.kind !== undefined) {
+      if ((messages[id.kind] as Record<string, IntlString>)?.[id.name] !== undefined) {
+        return (messages[id.kind] as Record<string, IntlString>)?.[id.name]
+      } else {
+        const englishMessages = await loadTranslationsForComponent(id.component, ENGLISH_LOCALE)
+        if (!(englishMessages instanceof Status)) {
+          return (englishMessages[id.kind] as Record<string, IntlString>)?.[id.name]
+        }
+      }
+    } else {
+      return messages[id.name] as IntlString
+    }
   } catch (err) {
     const status = unknownError(err)
     await setPlatformStatus(status)

--- a/packages/platform/src/i18n.ts
+++ b/packages/platform/src/i18n.ts
@@ -33,6 +33,7 @@ type Messages = Record<string, IntlString | Record<string, IntlString>>
 const loaders = new Map<Plugin, Loader>()
 const translations = new Map<Plugin, Messages | Status>()
 const cache = new Map<IntlString, IntlMessageFormat | Status>()
+const ENGLISH_LOCALE = 'en'
 
 /**
  * @public


### PR DESCRIPTION
Use english translation for the word if translation of that word is not found in the file

[ISSUE: 5950](https://github.com/hcengineering/platform/issues/5950)