### PR TITLE
UBERF-7474: Some logging and reduce calls for query refresh

### DIFF
--- a/packages/query/src/__tests__/query.test.ts
+++ b/packages/query/src/__tests__/query.test.ts
@@ -298,7 +298,7 @@ describe('query', () => {
   it('remove with limit', async () => {
     const { liveQuery, factory } = await getClient()
 
-    const expectedLength = 2
+    const expectedLength = 1
     let attempt = 0
     const pp = new Promise((resolve) => {
       liveQuery.query<Space>(

--- a/server/core/src/server/index.ts
+++ b/server/core/src/server/index.ts
@@ -135,6 +135,7 @@ export async function createServerStorage (
       metrics.newChild('fulltext', {}),
       modelDb,
       (classes: Ref<Class<Doc>>[]) => {
+        ctx.info('broadcast indexing update', { classes, workspace: conf.workspace })
         const evt: IndexingUpdateEvent = {
           _class: classes
         }


### PR DESCRIPTION
UBERF-7474: Some logging and reduce calls for query refresh

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjgyZWFkNTc0ZmRjOGExYzc1OGFjNmYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.5nPS-AYkvgwkGnW-3kbU2AuK2rIxSWvq2bA0wn0Hgas">Huly&reg;: <b>UBERF-7475</b></a></sub>