### PR TITLE
Qfix: use http for local and test brandings

### DIFF
--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -75,6 +75,7 @@ export interface Branding {
   language?: string
   initWorkspace?: string
   lastNameFirst?: string
+  protocol?: string
 }
 
 export type BrandingMap = Record<string, Branding>

--- a/server/core/src/utils.ts
+++ b/server/core/src/utils.ts
@@ -192,7 +192,8 @@ export function loadBrandingMap (brandingPath?: string): BrandingMap {
     brandings = JSON.parse(fs.readFileSync(brandingPath, 'utf8'))
 
     for (const [host, value] of Object.entries(brandings)) {
-      value.front = `https://${host}/`
+      const protocol = value.protocol ?? 'https'
+      value.front = `${protocol}://${host}/`
     }
   }
 

--- a/tests/branding-test.json
+++ b/tests/branding-test.json
@@ -1,6 +1,8 @@
 {
   "localhost:8083": {
+    "key": "huly",
     "title": "Platform",
+    "protocol": "http",
     "languages": "en,ru,pt,es,zh,fr",
     "defaultLanguage": "en",
     "defaultApplication": "tracker",


### PR DESCRIPTION
* Use http for local and test brandings

Related to: failing tests

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjgzZTkyNDc0ZmRjOGExYzc1OGIxNWQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.83jhv2SixfxCqdip0KyKx56qi_BbwHMKT4JQCfZXgEQ">Huly&reg;: <b>UBERF-7484</b></a></sub>