### PR TITLE
Improve chat message create performance

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -968,6 +968,10 @@ export class LiveQuery implements WithTx, Client {
     result: LookupData<T>
   ): Promise<void> {
     for (const key in lookup._id) {
+      if ((doc as any)[key] === undefined || (doc as any)[key] === 0) {
+        continue
+      }
+
       const value = lookup._id[key]
 
       let _class: Ref<Class<Doc>>

--- a/plugins/chunter-resources/src/channelDataProvider.ts
+++ b/plugins/chunter-resources/src/channelDataProvider.ts
@@ -131,8 +131,10 @@ export class ChannelDataProvider implements IChannelDataProvider {
     const metadata = get(this.metadataStore)
 
     if (mode === 'forward') {
+      const isTailLoading = get(this.isTailLoading)
+      const tail = get(this.tailStore)
       const last = metadata[metadata.length - 1]?.createdOn ?? 0
-      return last > timestamp
+      return last > timestamp && !isTailLoading && tail.length === 0
     } else {
       const first = metadata[0]?.createdOn ?? 0
       return first < timestamp

--- a/plugins/chunter-resources/src/utils.ts
+++ b/plugins/chunter-resources/src/utils.ts
@@ -20,7 +20,6 @@ import {
   type Class,
   type Client,
   type Doc,
-  generateId,
   getCurrentAccount,
   type IdMap,
   type Ref,
@@ -41,10 +40,11 @@ import activity, {
 import {
   archiveContextNotifications,
   InboxNotificationsClientImpl,
+  isActivityNotification,
   isMentionNotification
 } from '@hcengineering/notification-resources'
 import notification, { type DocNotifyContext } from '@hcengineering/notification'
-import { get, type Unsubscriber } from 'svelte/store'
+import { get, type Unsubscriber, writable } from 'svelte/store'
 
 import chunter from './plugin'
 import DirectIcon from './components/DirectIcon.svelte'
@@ -348,6 +348,57 @@ export async function leaveChannel (channel: Channel, value: Ref<Account> | Arra
   }
 }
 
+// NOTE: Store timestamp updates to avoid unnecessary updates when if the server takes a long time to respond
+const contextsTimestampStore = writable<Map<Ref<DocNotifyContext>, number>>(new Map())
+// NOTE: Sometimes user can read message before notification is created and we should mark it as viewed when notification is received
+export const chatReadMessagesStore = writable<Set<Ref<ActivityMessage>>>(new Set())
+
+function getAllIds (messages: DisplayActivityMessage[]): Array<Ref<ActivityMessage>> {
+  return messages
+    .map((message) => {
+      const combined =
+        message._class === activity.class.DocUpdateMessage
+          ? (message as DisplayDocUpdateMessage)?.combinedMessagesIds
+          : undefined
+
+      return [message._id, ...(combined ?? [])]
+    })
+    .flat()
+}
+
+export function recheckNotifications (context: DocNotifyContext): void {
+  const client = getClient()
+  const inboxClient = InboxNotificationsClientImpl.getClient()
+
+  const messages = get(chatReadMessagesStore)
+
+  if (messages.size === 0) {
+    return
+  }
+
+  const notifications = get(inboxClient.inboxNotificationsByContext).get(context._id) ?? []
+
+  const toRead = notifications
+    .filter((it) => {
+      if (it.isViewed) {
+        return false
+      }
+
+      if (isMentionNotification(it)) {
+        return messages.has(it.mentionedIn as Ref<ActivityMessage>)
+      }
+
+      if (isActivityNotification(it)) {
+        return messages.has(it.attachedTo)
+      }
+
+      return false
+    })
+    .map((n) => n._id)
+
+  void inboxClient.readNotifications(client, toRead)
+}
+
 export async function readChannelMessages (
   messages: DisplayActivityMessage[],
   context: DocNotifyContext | undefined
@@ -359,40 +410,36 @@ export async function readChannelMessages (
   const inboxClient = InboxNotificationsClientImpl.getClient()
   const client = getClient()
 
-  const allIds = messages
-    .map((message) => {
-      const combined =
-        message._class === activity.class.DocUpdateMessage
-          ? (message as DisplayDocUpdateMessage)?.combinedMessagesIds
-          : undefined
+  const readMessages = get(chatReadMessagesStore)
+  const allIds = getAllIds(messages).filter((id) => !readMessages.has(id))
 
-      return [message._id, ...(combined ?? [])]
-    })
-    .flat()
-  const relatedMentions = get(inboxClient.otherInboxNotifications).filter(
-    (n) => !n.isViewed && isMentionNotification(n) && allIds.includes(n.mentionedIn as Ref<ActivityMessage>)
-  )
+  const notifications = get(inboxClient.activityInboxNotifications)
+    .filter(({ _id, attachedTo }) => allIds.includes(attachedTo))
+    .map((n) => n._id)
 
-  const ops = getClient().apply(generateId())
+  const relatedMentions = get(inboxClient.otherInboxNotifications)
+    .filter((n) => !n.isViewed && isMentionNotification(n) && allIds.includes(n.mentionedIn as Ref<ActivityMessage>))
+    .map((n) => n._id)
 
-  void inboxClient.readMessages(ops, allIds).then(() => {
-    void ops.commit()
-  })
+  chatReadMessagesStore.update((store) => new Set([...store, ...allIds]))
 
-  void inboxClient.readNotifications(
-    client,
-    relatedMentions.map((n) => n._id)
-  )
+  void inboxClient.readNotifications(client, [...notifications, ...relatedMentions])
 
   if (context === undefined) {
     return
   }
 
-  const lastTimestamp = messages[messages.length - 1].createdOn ?? 0
+  const storedTimestampUpdates = get(contextsTimestampStore).get(context._id)
+  const newTimestamp = messages[messages.length - 1].createdOn ?? 0
+  const prevTimestamp = Math.max(storedTimestampUpdates ?? 0, context.lastViewedTimestamp ?? 0)
 
-  if ((context.lastViewedTimestamp ?? 0) < lastTimestamp) {
-    context.lastViewedTimestamp = lastTimestamp
-    void client.update(context, { lastViewedTimestamp: lastTimestamp })
+  if (prevTimestamp < newTimestamp) {
+    context.lastViewedTimestamp = newTimestamp
+    contextsTimestampStore.update((store) => {
+      store.set(context._id, newTimestamp)
+      return store
+    })
+    void client.update(context, { lastViewedTimestamp: newTimestamp })
   }
 }
 

--- a/plugins/notification-resources/src/inboxNotificationsClient.ts
+++ b/plugins/notification-resources/src/inboxNotificationsClient.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import activity, { type ActivityMessage } from '@hcengineering/activity'
+import activity from '@hcengineering/activity'
 import {
   SortingOrder,
   generateId,
@@ -216,29 +216,10 @@ export class InboxNotificationsClientImpl implements InboxNotificationsClient {
     })
   }
 
-  async readMessages (client: TxOperations, ids: Array<Ref<ActivityMessage>>): Promise<void> {
-    const alreadyReadIds = get(this.activityInboxNotifications)
-      .filter(({ attachedTo, isViewed }) => ids.includes(attachedTo) && isViewed)
-      .map(({ attachedTo }) => attachedTo)
-
-    const toReadIds = ids.filter((id) => !alreadyReadIds.includes(id))
-
-    if (toReadIds.length === 0) {
-      return
-    }
-
-    const notificationsToRead = get(this.activityInboxNotifications).filter(({ attachedTo }) =>
-      toReadIds.includes(attachedTo)
-    )
-
-    for (const notification of notificationsToRead) {
-      notification.isViewed = true
-      await client.update(notification, { isViewed: true })
-    }
-  }
-
   async readNotifications (client: TxOperations, ids: Array<Ref<InboxNotification>>): Promise<void> {
-    const notificationsToRead = (get(this.inboxNotifications) ?? []).filter(({ _id }) => ids.includes(_id))
+    const notificationsToRead = (get(this.inboxNotifications) ?? []).filter(
+      ({ _id, isViewed }) => ids.includes(_id) && !isViewed
+    )
 
     for (const notification of notificationsToRead) {
       await client.update(notification, { isViewed: true })

--- a/plugins/notification/src/index.ts
+++ b/plugins/notification/src/index.ts
@@ -286,7 +286,6 @@ export interface InboxNotificationsClient {
 
   readDoc: (client: TxOperations, _id: Ref<Doc>) => Promise<void>
   forceReadDoc: (client: TxOperations, _id: Ref<Doc>, _class: Ref<Class<Doc>>) => Promise<void>
-  readMessages: (client: TxOperations, ids: Ref<ActivityMessage>[]) => Promise<void>
   readNotifications: (client: TxOperations, ids: Array<Ref<InboxNotification>>) => Promise<void>
   unreadNotifications: (client: TxOperations, ids: Array<Ref<InboxNotification>>) => Promise<void>
   archiveNotifications: (client: TxOperations, ids: Array<Ref<InboxNotification>>) => Promise<void>


### PR DESCRIPTION
* Do not load lookup data for collections if collection is empty
* Avoid attachments queries if they are not exist
* Reduce requests to read notifications when chat is scrolling
* Fix notifications reading when notification received after message is read

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Njg0MjQxMDc0ZmRjOGExYzc1OGIyNWUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.6lMaMZzYUf0anvppZ6y_CaCvIf8jE4xUdYxSxTkwVDE">Huly&reg;: <b>UBERF-7486</b></a></sub>