### PR TITLE
Reduce the number of findAll requests

### DIFF
--- a/plugins/chunter-resources/src/channelDataProvider.ts
+++ b/plugins/chunter-resources/src/channelDataProvider.ts
@@ -26,7 +26,6 @@ import {
 } from '@hcengineering/core'
 
 import { derived, get, type Readable, writable } from 'svelte/store'
-import { onDestroy } from 'svelte'
 import { type ActivityMessage } from '@hcengineering/activity'
 import attachment from '@hcengineering/attachment'
 import { combineActivityMessages } from '@hcengineering/activity-resources'

--- a/plugins/chunter-resources/src/channelDataProvider.ts
+++ b/plugins/chunter-resources/src/channelDataProvider.ts
@@ -66,7 +66,7 @@ interface IChannelDataProvider {
 }
 
 export class ChannelDataProvider implements IChannelDataProvider {
-  public readonly limit = 30
+  public readonly limit = 50
 
   private readonly metadataQuery = createQuery(true)
   private readonly tailQuery = createQuery(true)

--- a/plugins/chunter-resources/src/channelDataProvider.ts
+++ b/plugins/chunter-resources/src/channelDataProvider.ts
@@ -111,10 +111,6 @@ export class ChannelDataProvider implements IChannelDataProvider {
     this.msgClass = _class
     this.selectedMsgId = selectedMsgId
     this.loadData(loadAll)
-
-    onDestroy(() => {
-      this.destroy()
-    })
   }
 
   public destroy (): void {

--- a/server-plugins/activity-resources/src/index.ts
+++ b/server-plugins/activity-resources/src/index.ts
@@ -38,6 +38,7 @@ import {
   createCollaboratorNotifications,
   removeDocInboxNotifications
 } from '@hcengineering/server-notification-resources'
+import { PersonAccount } from '@hcengineering/contact'
 
 import { getDocUpdateAction, getTxAttributesUpdates } from './utils'
 import { ReferenceTrigger } from './references'
@@ -127,7 +128,7 @@ export async function createReactionNotifications (
 
   res = res.concat(
     await createCollabDocInfo(
-      [user],
+      [user] as Ref<PersonAccount>[],
       control,
       tx.tx,
       tx,

--- a/server-plugins/love-resources/src/index.ts
+++ b/server-plugins/love-resources/src/index.ts
@@ -269,12 +269,7 @@ export async function OnKnock (tx: Tx, control: TriggerControl): Promise<Tx[]> {
             const body = await translate(love.string.IsKnocking, {
               name: formatName(from.name, control.branding?.lastNameFirst)
             })
-            const person = (await control.findAll(contact.class.Person, { _id: userAcc.person }))[0]
-            const info = {
-              account: userAcc,
-              person
-            }
-            await createPushNotification(control, info, title, body, request._id, from, path)
+            await createPushNotification(control, userAcc._id, title, body, request._id, from, path)
           }
         }
         return res
@@ -305,11 +300,7 @@ export async function OnInvite (tx: Tx, control: TriggerControl): Promise<Tx[]> 
               name: formatName(from.name, control.branding?.lastNameFirst)
             })
             : await translate(love.string.InivitingLabel, {})
-        const info = {
-          account: userAcc,
-          person: target
-        }
-        await createPushNotification(control, info, title, body, invite._id, from, path)
+        await createPushNotification(control, userAcc._id, title, body, invite._id, from, path)
       }
     }
   }

--- a/server-plugins/love-resources/src/index.ts
+++ b/server-plugins/love-resources/src/index.ts
@@ -269,7 +269,12 @@ export async function OnKnock (tx: Tx, control: TriggerControl): Promise<Tx[]> {
             const body = await translate(love.string.IsKnocking, {
               name: formatName(from.name, control.branding?.lastNameFirst)
             })
-            await createPushNotification(control, userAcc._id, title, body, request._id, from, path)
+            const person = (await control.findAll(contact.class.Person, { _id: userAcc.person }))[0]
+            const info = {
+              account: userAcc,
+              person
+            }
+            await createPushNotification(control, info, title, body, request._id, from, path)
           }
         }
         return res
@@ -300,7 +305,11 @@ export async function OnInvite (tx: Tx, control: TriggerControl): Promise<Tx[]> 
               name: formatName(from.name, control.branding?.lastNameFirst)
             })
             : await translate(love.string.InivitingLabel, {})
-        await createPushNotification(control, userAcc._id, title, body, invite._id, from, path)
+        const info = {
+          account: userAcc,
+          person: target
+        }
+        await createPushNotification(control, info, title, body, invite._id, from, path)
       }
     }
   }

--- a/server-plugins/notification-resources/src/types.ts
+++ b/server-plugins/notification-resources/src/types.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 import { BaseNotificationType } from '@hcengineering/notification'
+import { Person, PersonAccount } from '@hcengineering/contact'
 
 /**
  * @public
@@ -36,4 +37,9 @@ export interface NotifyParams {
   isOwn: boolean
   isSpace: boolean
   shouldUpdateTimestamp: boolean
+}
+
+export interface UserInfo {
+  account: PersonAccount
+  person?: Person
 }

--- a/server-plugins/notification-resources/src/types.ts
+++ b/server-plugins/notification-resources/src/types.ts
@@ -14,6 +14,7 @@
 //
 import { BaseNotificationType } from '@hcengineering/notification'
 import { Person, PersonAccount } from '@hcengineering/contact'
+import { Account, Ref } from '@hcengineering/core'
 
 /**
  * @public
@@ -40,6 +41,7 @@ export interface NotifyParams {
 }
 
 export interface UserInfo {
-  account: PersonAccount
+  _id: Ref<Account>
+  account?: PersonAccount
   person?: Person
 }

--- a/server-plugins/request-resources/src/index.ts
+++ b/server-plugins/request-resources/src/index.ts
@@ -13,14 +13,20 @@
 // limitations under the License.
 //
 
-import core, { Doc, Tx, TxCUD, TxCollectionCUD, TxCreateDoc, TxUpdateDoc, TxProcessor } from '@hcengineering/core'
+import core, { Doc, Tx, TxCUD, TxCollectionCUD, TxCreateDoc, TxUpdateDoc, TxProcessor, Ref } from '@hcengineering/core'
 import request, { Request, RequestStatus } from '@hcengineering/request'
 import { getResource, translate } from '@hcengineering/platform'
 import type { TriggerControl } from '@hcengineering/server-core'
 import { pushDocUpdateMessages } from '@hcengineering/server-activity-resources'
 import { DocUpdateMessage } from '@hcengineering/activity'
 import notification from '@hcengineering/notification'
-import { getNotificationTxes, getCollaborators, getTextPresenter } from '@hcengineering/server-notification-resources'
+import {
+  getNotificationTxes,
+  getCollaborators,
+  getTextPresenter,
+  getUsersInfo
+} from '@hcengineering/server-notification-resources'
+import { PersonAccount } from '@hcengineering/contact'
 
 /**
  * @public
@@ -140,14 +146,24 @@ async function getRequestNotificationTx (tx: TxCollectionCUD<Doc, Request>, cont
   const notifyContexts = await control.findAll(notification.class.DocNotifyContext, {
     attachedTo: doc._id
   })
+  const usersInfo = await getUsersInfo([...collaborators, tx.modifiedBy] as Ref<PersonAccount>[], control)
+  const senderInfo = usersInfo.find((info) => info.account._id === tx.modifiedBy)
+
+  if (senderInfo === undefined) {
+    return res
+  }
 
   for (const target of collaborators) {
+    const targetInfo = usersInfo.find((info) => info.account._id === target)
+    if (targetInfo === undefined) continue
+
     const txes = await getNotificationTxes(
       control,
       request,
       tx.tx,
       tx,
-      target,
+      targetInfo,
+      senderInfo,
       { isOwn: true, isSpace: false, shouldUpdateTimestamp: true },
       notifyContexts,
       messages,

--- a/server-plugins/request-resources/src/index.ts
+++ b/server-plugins/request-resources/src/index.ts
@@ -147,14 +147,12 @@ async function getRequestNotificationTx (tx: TxCollectionCUD<Doc, Request>, cont
     attachedTo: doc._id
   })
   const usersInfo = await getUsersInfo([...collaborators, tx.modifiedBy] as Ref<PersonAccount>[], control)
-  const senderInfo = usersInfo.find((info) => info.account._id === tx.modifiedBy)
-
-  if (senderInfo === undefined) {
-    return res
+  const senderInfo = usersInfo.find(({ _id }) => _id === tx.modifiedBy) ?? {
+    _id: tx.modifiedBy
   }
 
   for (const target of collaborators) {
-    const targetInfo = usersInfo.find((info) => info.account._id === target)
+    const targetInfo = usersInfo.find(({ _id }) => _id === target)
     if (targetInfo === undefined) continue
 
     const txes = await getNotificationTxes(

--- a/server-plugins/time-resources/src/index.ts
+++ b/server-plugins/time-resources/src/index.ts
@@ -185,18 +185,20 @@ export async function OnToDoCreate (tx: TxCUD<Doc>, control: TriggerControl): Pr
     return []
   }
 
-  const senderAccount = await control.modelDb.findOne(contact.class.PersonAccount, {
-    _id: tx.modifiedBy as Ref<PersonAccount>
-  })
-  if (senderAccount === undefined) return []
-
   const object = (await control.findAll(todo.attachedToClass, { _id: todo.attachedTo }))[0]
 
   if (object === undefined) return []
 
-  const senderPerson = (await control.findAll(contact.class.Person, { _id: senderAccount.person }))[0]
+  const senderAccount = await control.modelDb.findOne(contact.class.PersonAccount, {
+    _id: tx.modifiedBy as Ref<PersonAccount>
+  })
+  const senderPerson =
+    senderAccount !== undefined
+      ? (await control.findAll(contact.class.Person, { _id: senderAccount.person }))[0]
+      : undefined
 
   const senderInfo: UserInfo = {
+    _id: tx.modifiedBy,
     account: senderAccount,
     person: senderPerson
   }
@@ -216,6 +218,7 @@ export async function OnToDoCreate (tx: TxCUD<Doc>, control: TriggerControl): Pr
   const person = (await control.modelDb.findAll(contact.class.Person, { _id: account.person }))[0]
 
   const receiverInfo: UserInfo = {
+    _id: account._id,
     account,
     person
   }

--- a/server-plugins/time-resources/src/index.ts
+++ b/server-plugins/time-resources/src/index.ts
@@ -37,7 +37,8 @@ import type { TriggerControl } from '@hcengineering/server-core'
 import {
   getCommonNotificationTxes,
   getNotificationContent,
-  isShouldNotifyTx
+  isShouldNotifyTx,
+  UserInfo
 } from '@hcengineering/server-notification-resources'
 import task, { makeRank } from '@hcengineering/task'
 import { jsonToMarkup, nodeDoc, nodeParagraph, nodeText } from '@hcengineering/text'
@@ -184,13 +185,25 @@ export async function OnToDoCreate (tx: TxCUD<Doc>, control: TriggerControl): Pr
     return []
   }
 
+  const senderAccount = await control.modelDb.findOne(contact.class.PersonAccount, {
+    _id: tx.modifiedBy as Ref<PersonAccount>
+  })
+  if (senderAccount === undefined) return []
+
   const object = (await control.findAll(todo.attachedToClass, { _id: todo.attachedTo }))[0]
 
   if (object === undefined) return []
 
+  const senderPerson = (await control.findAll(contact.class.Person, { _id: senderAccount.person }))[0]
+
+  const senderInfo: UserInfo = {
+    account: senderAccount,
+    person: senderPerson
+  }
+
   const res: Tx[] = []
-  const notifyResult = await isShouldNotifyTx(control, createTx, tx, todo, account._id, true, false)
-  const content = await getNotificationContent(tx, account._id, todo, control)
+  const notifyResult = await isShouldNotifyTx(control, createTx, tx, todo, account, true, false)
+  const content = await getNotificationContent(tx, account, senderInfo, todo, control)
   const data: Partial<Data<CommonInboxNotification>> = {
     ...content,
     header: time.string.ToDo,
@@ -200,13 +213,20 @@ export async function OnToDoCreate (tx: TxCUD<Doc>, control: TriggerControl): Pr
     messageHtml: jsonToMarkup(nodeDoc(nodeParagraph(nodeText(todo.title))))
   }
 
+  const person = (await control.modelDb.findAll(contact.class.Person, { _id: account.person }))[0]
+
+  const receiverInfo: UserInfo = {
+    account,
+    person
+  }
+
   res.push(
     ...(await getCommonNotificationTxes(
       control,
       object,
       data,
-      account._id,
-      tx.modifiedBy,
+      receiverInfo,
+      senderInfo,
       object._id,
       object._class,
       object.space,


### PR DESCRIPTION
Request all persons to send notifications with one `findAll`

With this updates we have only 3 `findAll` requests per message and the number does't depend on the channel participants

<img width="1476" src="https://github.com/hcengineering/platform/assets/113431133/dbcebe09-ed34-42a3-8046-f10d5f783088" alt="Screenshot 2024-07-04 at 23 13 44">

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Njg2ZjhiOWRjNmMyYTYxOTE2Mzk1OWQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.KRz9GooeIftPp48xIeC_LlSNRcg3qlGuOQ7SQMQ9N1o">Huly&reg;: <b>UBERF-7517</b></a></sub>