### PR TITLE
UBERF-7520: Use Bulk for index query updates

### DIFF
--- a/tests/sanity/tests/model/tracker/issues-page.ts
+++ b/tests/sanity/tests/model/tracker/issues-page.ts
@@ -61,7 +61,6 @@ export class IssuesPage extends CommonTrackerPage {
   textPopupAddAttachmentsFile = (): Locator => this.page.locator('div.popup-tooltip div.item div.name')
   buttonCollapsedCategories = (): Locator => this.page.locator('div.categoryHeader.collapsed')
   pupupTagsPopup = (): Locator => this.page.locator('.popup#TagsPopup')
-  issupeByName = (issueName: string): Locator => this.page.locator('a', { hasText: issueName })
   issueNotExist = (issueName: string): Locator => this.page.locator('tr', { hasText: issueName })
   filterRowExists = (issueName: string): Locator => this.page.locator('div.row span', { hasText: issueName })
   issueListGrid = (): Locator => this.page.locator('div.listGrid')
@@ -491,7 +490,7 @@ export class IssuesPage extends CommonTrackerPage {
   }
 
   async openIssueByName (issueName: string): Promise<void> {
-    await this.issupeByName(issueName).click()
+    await this.issueByName(issueName).click()
   }
 
   async checkIssueNotExist (issueName: string): Promise<void> {
@@ -519,7 +518,7 @@ export class IssuesPage extends CommonTrackerPage {
   }
 
   async doActionOnIssue (issueName: string, action: string): Promise<void> {
-    await this.issupeByName(issueName).click({ button: 'right' })
+    await this.issueByName(issueName).click({ button: 'right' })
     await this.selectFromDropdown(this.page, action)
   }
 
@@ -543,8 +542,10 @@ export class IssuesPage extends CommonTrackerPage {
     await this.issueAnchorById(issueId).click()
   }
 
-  async checkIssuesCount (issueName: string, count: number): Promise<void> {
-    await expect(this.issueAnchorByName(issueName)).toHaveCount(count)
+  async checkIssuesCount (issueName: string, count: number, timeout?: number): Promise<void> {
+    await expect(this.issueAnchorByName(issueName)).toHaveCount(count, {
+      timeout: timeout !== undefined ? timeout * 1000 : undefined
+    })
   }
 
   async selectTemplate (templateName: string): Promise<void> {

--- a/tests/sanity/tests/tracker/issues-duplicate.spec.ts
+++ b/tests/sanity/tests/tracker/issues-duplicate.spec.ts
@@ -52,10 +52,13 @@ test.describe('Tracker duplicate issue tests', () => {
     await trackerNavigationMenuPage.openTemplateForProject('Default')
     await trackerNavigationMenuPage.openIssuesForProject('Default')
     await issuesPage.searchIssueByName(secondIssue.title)
+
+    await issuesPage.checkIssuesCount(secondIssue.title, 2, 30)
+
     const secondIssueId = await issuesPage.getIssueId(secondIssue.title, 0)
 
     expect(firstIssueId).not.toEqual(secondIssueId)
-    await issuesPage.checkIssuesCount(firstIssue.title, 2)
+    await issuesPage.checkIssuesCount(firstIssue.title, 2, 30)
 
     await test.step('Update the first issue title', async () => {
       const newIssueTitle = `Duplicate Update issue-${generateId()}`


### PR DESCRIPTION
UBERF-7520: Use Bulk for index query udpates

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Njg3Y2Y3NmRjNmMyYTYxOTE2Mzk3OTgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.uoStK8qFo2-EgSr43eIDljbqCvix5aZAdnDy3Pr1V6k">Huly&reg;: <b>UBERF-7521</b></a></sub>