### PR TITLE
EQMS-912 Show document name tooltip in controlled documents

### DIFF
--- a/plugins/controlled-documents-resources/src/components/hierarchy/DocHierarchyLevel.svelte
+++ b/plugins/controlled-documents-resources/src/components/hierarchy/DocHierarchyLevel.svelte
@@ -123,6 +123,7 @@
       actions={getMoreActions !== undefined ? () => getDocMoreActions(prjdoc) : undefined}
       {level}
       {collapsedPrefix}
+      shouldTooltip
       on:click={() => {
         dispatch('selected', prjdoc)
       }}


### PR DESCRIPTION
<img width="282" src="https://github.com/hcengineering/platform/assets/5876715/c63cd588-a993-440a-9bb2-142a25e5a5ca" alt="Screenshot 2024-07-08 at 15 45 52">

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjhiYTc0ZGRjNmMyYTYxOTE2MzlhMjQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.3DSQwwNjKD_r-0NSGsUVqOCQR3DxnmDYtiKZZoOEyuQ">Huly&reg;: <b>UBERF-7530</b></a></sub>