### PR TITLE
fix: hide wiki history sidebar tab

### DIFF
--- a/plugins/document-resources/src/components/EditDoc.svelte
+++ b/plugins/document-resources/src/components/EditDoc.svelte
@@ -185,11 +185,11 @@
     {
       id: 'references',
       icon: document.icon.References
-    },
-    {
-      id: 'history',
-      icon: document.icon.History
     }
+    // {
+    //   id: 'history',
+    //   icon: document.icon.History
+    // }
   ]
   let selectedAside: string | boolean = false
 


### PR DESCRIPTION
<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjkxNWNmMjE2OGQ5ZTUzMzk0MTVlZmMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.fb6LSsGRrN1DIQR175Vv2QZe-0fDX138d5dO86dd-8U">Huly&reg;: <b>UBERF-7586</b></a></sub>