### PR TITLE
UBERF-7595: Do not use /api/v1/version on connect

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -269,6 +269,10 @@ export async function createClient (
   const oldOnConnect: ((event: ClientConnectEvent) => Promise<void>) | undefined = conn.onConnect
   conn.onConnect = async (event) => {
     console.log('Client: onConnect', event)
+    if (event === ClientConnectEvent.Maintenance) {
+      await oldOnConnect?.(ClientConnectEvent.Maintenance)
+      return
+    }
     // Find all new transactions and apply
     const loadModelResponse = await ctx.with(
       'connect',

--- a/plugins/chunter-resources/src/components/chat/utils.ts
+++ b/plugins/chunter-resources/src/components/chat/utils.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import notification, { type DocNotifyContext } from '@hcengineering/notification'
+import notification, { type DocNotifyContext, type InboxNotification } from '@hcengineering/notification'
 import {
   generateId,
   type Ref,
@@ -409,7 +409,7 @@ export async function removeActivityChannels (contexts: DocNotifyContext[]): Pro
       const notifications = notificationsByContext.get(context._id) ?? []
       await client.archiveNotifications(
         ops,
-        notifications.map(({ _id }) => _id)
+        notifications.map(({ _id }: InboxNotification) => _id)
       )
       await ops.remove(context)
     }

--- a/plugins/guest-resources/src/connect.ts
+++ b/plugins/guest-resources/src/connect.ts
@@ -55,10 +55,6 @@ export async function connect (title: string): Promise<Client | undefined> {
   _token = token
 
   let version: Version | undefined
-  let serverEndpoint = endpoint.replace(/^ws/g, 'http')
-  if (serverEndpoint.endsWith('/')) {
-    serverEndpoint = serverEndpoint.substring(0, serverEndpoint.length - 1)
-  }
   const clientFactory = await getResource(client.function.GetClient)
   _client = await clientFactory(
     token,
@@ -98,21 +94,15 @@ export async function connect (title: string): Promise<Client | undefined> {
               location.reload()
               versionError.set(`${currentVersionStr} != ${reconnectVersionStr}`)
             }
-            const serverVersion: { version: string } = await (
-              await fetch(serverEndpoint + '/api/v1/version', {})
-            ).json()
-
-            console.log('Server version', serverVersion.version)
-            if (serverVersion.version !== '' && serverVersion.version !== currentVersionStr) {
+            console.log('Server version', reconnectVersionStr)
+            if (reconnectVersionStr !== '' && reconnectVersionStr !== currentVersionStr) {
               if (typeof sessionStorage !== 'undefined') {
-                if (sessionStorage.getItem(versionStorageKey) !== serverVersion.version) {
-                  sessionStorage.setItem(versionStorageKey, serverVersion.version)
+                if (sessionStorage.getItem(versionStorageKey) !== reconnectVersionStr) {
+                  sessionStorage.setItem(versionStorageKey, reconnectVersionStr)
                   location.reload()
                 }
-              } else {
-                location.reload()
               }
-              versionError.set(`${currentVersionStr} => ${serverVersion.version}`)
+              versionError.set(`${currentVersionStr} => ${reconnectVersionStr}`)
             }
           }
         })()
@@ -145,23 +135,6 @@ export async function connect (title: string): Promise<Client | undefined> {
         versionError.set(`${versionStr} => ${requiredVersion}`)
         return undefined
       }
-    }
-
-    try {
-      const serverVersion: { version: string } = await (await fetch(serverEndpoint + '/api/v1/version', {})).json()
-
-      console.log('Server version', serverVersion.version, version !== undefined ? versionToString(version) : '')
-      if (
-        serverVersion.version !== '' &&
-        (version === undefined || serverVersion.version !== versionToString(version))
-      ) {
-        const versionStr = version !== undefined ? versionToString(version) : 'unknown'
-        versionError.set(`${versionStr} => ${serverVersion.version}`)
-        return
-      }
-    } catch (err: any) {
-      versionError.set('server version not available')
-      return
     }
   } catch (err: any) {
     Analytics.handleError(err)


### PR DESCRIPTION
UBERF-7595: Do not use /api/v1/version on connect

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Njk2MTJlZDEwNmQ1ZmVkZWI1ZWI0ZTIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.nkVjwn2Qm9fFBDHb9336Y4DprOZ7mIRR65o6Kgl09dE">Huly&reg;: <b>UBERF-7596</b></a></sub>