### PR TITLE
UBERF-7597: Get rid of formats in preview.ts

### DIFF
--- a/server/front/readme.md
+++ b/server/front/readme.md
@@ -28,11 +28,11 @@ A `;` separated list of triples, providerName|previewUrl|supportedFormats.
 
 - providerName - a provider name should be same as in Storage configuration.
   It coult be empty and it will match by content types.
-- previewUrl - an Url with :workspace, :blobId, :downloadFile, :size, :format placeholders, they will be replaced in UI with an appropriate blob values.
+- previewUrl - an Url with :workspace, :blobId, :downloadFile, :size placeholders, they will be replaced in UI with an appropriate blob values.
 - supportedFormats - a `,` separated list of file extensions.
 - contentTypes - a ',' separated list of content type patterns.
 
-PREVIEW_CONFIG=*|https://front.hc.engineering/files/:workspace/api/preview/?format=:format&width=:size&image=:downloadFile
+PREVIEW_CONFIG=*|https://front.hc.engineering/files/:workspace/api/preview/?width=:size&image=:downloadFile
 
 ## Variables
 
@@ -40,7 +40,6 @@ PREVIEW_CONFIG=*|https://front.hc.engineering/files/:workspace/api/preview/?form
 - :blobId - an uniq blob _id identifier.
 - :size - a numeric value to determine required size of the image, image will not be upscaled, only downscaled. If -1 is passed, original image size value will be used.
 - :downloadFile - an URI encoded component value of full download URI, could be presigned uri to S3 storage.
-- :format - an a conversion file format, `avif`,`webp` etc.
 
 ## Passing default variant.
 
@@ -50,7 +49,7 @@ providerName could be set to `*` in this case it will be default preview provide
 
 If no preview config are specified, a default one targating a front service preview/resize functionality will be used.
 
-`/files/${getCurrentWorkspaceUrl()}?file=:blobId.:format&size=:size`
+`/files/${getCurrentWorkspaceUrl()}?file=:blobId&size=:size`
 
 ## Testing with dev-production/etc.
 

--- a/server/front/src/starter.ts
+++ b/server/front/src/starter.ts
@@ -103,7 +103,7 @@ export function startFront (ctx: MeasureContext, extraConfig?: Record<string, st
 
   if (previewConfig === undefined) {
     // Use universal preview config
-    previewConfig = `*|${uploadUrl}/:workspace?file=:blobId.:format&size=:size`
+    previewConfig = `*|${uploadUrl}/:workspace?file=:blobId&size=:size`
   }
 
   const pushPublicKey = process.env.PUSH_PUBLIC_KEY


### PR DESCRIPTION
UBERF-7597: Get rid of formats in preview.ts

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Njk2MjMxMDEwNmQ1ZmVkZWI1ZWI1MWMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.kTCdwa5F82LHlghMm_NFTLnlF63HuSHiFuIpnoTlY-k">Huly&reg;: <b>UBERF-7598</b></a></sub>