### PR TITLE
Enable keep-alive for front service

### DIFF
--- a/server/front/src/index.ts
+++ b/server/front/src/index.ts
@@ -723,6 +723,9 @@ export function start (
   })
 
   const server = app.listen(port)
+
+  server.keepAliveTimeout = 60 * 1000 + 1000
+  server.headersTimeout = 60 * 1000 + 2000
   return () => {
     server.close()
   }


### PR DESCRIPTION
Enable keep-alive for front service

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Njk2MjkzNjEwNmQ1ZmVkZWI1ZWI1NGYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.-Ep6av3AKXMxncK0tCXqbzH2Jvu2KxJmtw72uqMNGW8">Huly&reg;: <b>UBERF-7599</b></a></sub>