### PR TITLE
EZQMS-1140: Controlled doc content display improvements

### DIFF
--- a/plugins/controlled-documents-resources/src/components/document/DocSectionEditor.svelte
+++ b/plugins/controlled-documents-resources/src/components/document/DocSectionEditor.svelte
@@ -154,7 +154,9 @@
     <slot name="before-header" />
   </svelte:fragment>
   <svelte:fragment slot="index">
-    {index + 1}
+    <span class="sectionTitle">
+      {index + 1}
+    </span>
   </svelte:fragment>
   <svelte:fragment slot="header">
     <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -164,6 +166,7 @@
       class:text-editor-highlighted-node-warning={isActiveSectionNode ||
         $groupedDocumentComments.hasDocumentComments(value.key)}
       class:text-editor-highlighted-node-selected={isActiveSectionNode}
+      class="sectionTitle"
       bind:this={sectionElement}
       on:click={handleDisplayDocumentComments}
     >
@@ -203,3 +206,10 @@
     />
   </svelte:fragment>
 </FieldSectionEditor>
+
+<style lang="scss">
+  .sectionTitle {
+    font-size: 1.75rem;
+    line-height: 150%;
+  }
+</style>

--- a/plugins/controlled-documents-resources/src/components/document/EditDocContent.svelte
+++ b/plugins/controlled-documents-resources/src/components/document/EditDocContent.svelte
@@ -214,6 +214,7 @@
             </div>
           {/each}
         {/if}
+        <div class="bottomSpacing no-print" />
       </div>
     </Scroller>
   </div>
@@ -269,6 +270,9 @@
     }
   }
 
+  .bottomSpacing {
+    padding-bottom: 30vh;
+  }
   .drag-over-highlight {
     opacity: 0.2;
   }


### PR DESCRIPTION
* Updates section header style to match H1
* Adds padding at the bottom of the document for better interactive UX

Related to:

* https://front.hc.engineering/workbench/platform/tracker/EZQMS-1140
* https://front.hc.engineering/workbench/platform/tracker/EZQMS-1135

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjliODUwZTc1ZDI5MTQ0YTk2ODY2ODAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.QkcmBRZ3j8ALvzDbUnPrvMu4P6ksONdtkXAH3AD_AO0">Huly&reg;: <b>UBERF-7641</b></a></sub>