### PR TITLE
EZQMS-1004: Fix typo in trainings

### DIFF
--- a/plugins/questions-assets/lang/en.json
+++ b/plugins/questions-assets/lang/en.json
@@ -8,7 +8,7 @@
     "CorrectAnswers": "Correct Answers",
     "Duplicate": "Duplicate",
     "Failed": "Failed",
-    "MultipleChoice": "Select mulitple",
+    "MultipleChoice": "Select multiple",
     "MultipleChoiceAssessment": "Multiple selection",
     "MultipleChoiceQuestion": "Multiple selection (not rated)",
     "NoQuestions": "No Questions",


### PR DESCRIPTION
* Fixes typo in trainings

Related to: https://front.hc.engineering/workbench/platform/tracker/EZQMS-1004

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjllNDY0NTc1ZDI5MTQ0YTk2ODY4NzAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.TE8IFEQ501XQoLjJbgknwfoXKqf0sqe_zWjj5Vz1GTU">Huly&reg;: <b>UBERF-7645</b></a></sub>