### PR TITLE
UBERF-7543: Add low level groupBy api and improve security space lookup

### DIFF
--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -67,6 +67,9 @@ export interface LowLevelStorage {
 
   // Remove a list of documents.
   clean: (ctx: MeasureContext, domain: Domain, docs: Ref<Doc>[]) => Promise<void>
+
+  // Low level direct group API
+  groupBy: <T>(ctx: MeasureContext, domain: Domain, field: string) => Promise<Set<T>>
 }
 
 export interface Branding {

--- a/server/core/src/adapter.ts
+++ b/server/core/src/adapter.ts
@@ -113,6 +113,8 @@ export interface DbAdapter {
   upload: (ctx: MeasureContext, domain: Domain, docs: Doc[]) => Promise<void>
   clean: (ctx: MeasureContext, domain: Domain, docs: Ref<Doc>[]) => Promise<void>
 
+  groupBy: <T>(ctx: MeasureContext, domain: Domain, field: string) => Promise<Set<T>>
+
   // Bulk update operations
   update: (ctx: MeasureContext, domain: Domain, operations: Map<Ref<Doc>, DocumentUpdate<Doc>>) => Promise<void>
 }

--- a/server/core/src/mem.ts
+++ b/server/core/src/mem.ts
@@ -74,6 +74,10 @@ export class DummyDbAdapter implements DbAdapter {
   async clean (ctx: MeasureContext, domain: Domain, docs: Ref<Doc>[]): Promise<void> {}
 
   async update (ctx: MeasureContext, domain: Domain, operations: Map<Ref<Doc>, DocumentUpdate<Doc>>): Promise<void> {}
+
+  async groupBy<T>(ctx: MeasureContext, domain: Domain, field: string): Promise<Set<T>> {
+    return new Set()
+  }
 }
 
 class InMemoryAdapter extends DummyDbAdapter implements DbAdapter {

--- a/server/core/src/pipeline.ts
+++ b/server/core/src/pipeline.ts
@@ -117,6 +117,12 @@ class PipelineImpl implements Pipeline {
       : await this.storage.findAll(ctx.ctx, _class, query, options)
   }
 
+  async groupBy<T>(ctx: MeasureContext, domain: Domain, field: string): Promise<Set<T>> {
+    return this.head !== undefined
+      ? await this.head.groupBy(ctx, domain, field)
+      : await this.storage.groupBy(ctx, domain, field)
+  }
+
   async searchFulltext (ctx: SessionContext, query: SearchQuery, options: SearchOptions): Promise<SearchResult> {
     return this.head !== undefined
       ? await this.head.searchFulltext(ctx, query, options)

--- a/server/core/src/server/storage.ts
+++ b/server/core/src/server/storage.ts
@@ -430,6 +430,10 @@ export class TServerStorage implements ServerStorage {
     return this.model.filter((it) => it.modifiedOn > lastModelTx)
   }
 
+  async groupBy<T>(ctx: MeasureContext, domain: Domain, field: string): Promise<Set<T>> {
+    return await this.getAdapter(domain, false).groupBy(ctx, domain, field)
+  }
+
   async findAll<T extends Doc>(
     ctx: MeasureContext,
     clazz: Ref<Class<T>>,

--- a/server/core/src/types.ts
+++ b/server/core/src/types.ts
@@ -96,6 +96,8 @@ export interface Middleware {
     query: DocumentQuery<T>,
     options?: FindOptions<T>
   ) => Promise<FindResult<T>>
+
+  groupBy: <T>(ctx: MeasureContext, domain: Domain, field: string) => Promise<Set<T>>
   handleBroadcast: HandleBroadcastFunc
   searchFulltext: (ctx: SessionContext, query: SearchQuery, options: SearchOptions) => Promise<SearchResult>
 }

--- a/server/elastic/src/backup.ts
+++ b/server/elastic/src/backup.ts
@@ -61,6 +61,10 @@ class ElasticDataAdapter implements DbAdapter {
     this.getDocId = (fulltext) => fulltext.slice(0, -1 * (this.workspaceString.length + 1)) as Ref<Doc>
   }
 
+  async groupBy<T>(ctx: MeasureContext, domain: Domain, field: string): Promise<Set<T>> {
+    return new Set()
+  }
+
   async findAll<T extends Doc>(
     ctx: MeasureContext,
     _class: Ref<Class<T>>,

--- a/server/middleware/src/base.ts
+++ b/server/middleware/src/base.ts
@@ -23,7 +23,9 @@ import {
   SearchOptions,
   SearchQuery,
   SearchResult,
-  Tx
+  Tx,
+  type Domain,
+  type MeasureContext
 } from '@hcengineering/core'
 import { Middleware, SessionContext, TxMiddlewareResult, type ServerStorage } from '@hcengineering/server-core'
 
@@ -43,6 +45,17 @@ export abstract class BaseMiddleware {
     options?: FindOptions<T>
   ): Promise<FindResult<T>> {
     return await this.provideFindAll(ctx, _class, query, options)
+  }
+
+  async providerGroupBy<T>(ctx: MeasureContext, domain: Domain, field: string): Promise<Set<T>> {
+    if (this.next !== undefined) {
+      return await this.next.groupBy(ctx, domain, field)
+    }
+    return await this.storage.groupBy(ctx, domain, field)
+  }
+
+  async groupBy<T>(ctx: MeasureContext, domain: Domain, field: string): Promise<Set<T>> {
+    return await this.providerGroupBy(ctx, domain, field)
   }
 
   async searchFulltext (ctx: SessionContext, query: SearchQuery, options: SearchOptions): Promise<SearchResult> {

--- a/server/middleware/src/spaceSecurity.ts
+++ b/server/middleware/src/spaceSecurity.ts
@@ -450,30 +450,8 @@ export class SpaceSecurityMiddleware extends BaseMiddleware implements Middlewar
   }
 
   async loadDomainSpaces (ctx: MeasureContext, domain: Domain): Promise<Set<Ref<Space>>> {
-    const map = new Set<Ref<Space>>()
     const field = this.getKey(domain)
-    while (true) {
-      const nin = Array.from(map.values())
-      const spaces = await this.storage.findAll(
-        ctx,
-        core.class.Doc,
-        nin.length > 0
-          ? {
-              [field]: { $nin: nin }
-            }
-          : {},
-        {
-          projection: { [field]: 1 },
-          limit: 1000,
-          domain
-        }
-      )
-      if (spaces.length === 0) {
-        break
-      }
-      spaces.forEach((p) => map.add((p as any)[field] as Ref<Space>))
-    }
-    return map
+    return await this.storage.groupBy<Ref<Space>>(ctx, domain, field)
   }
 
   async getDomainSpaces (domain: Domain): Promise<Set<Ref<Space>>> {

--- a/server/mongo/src/storage.ts
+++ b/server/mongo/src/storage.ts
@@ -740,6 +740,8 @@ abstract class MongoAdapterBase implements DbAdapter {
                 }
                 if (options?.projection !== undefined) {
                   findOptions.projection = this.calcProjection<T>(options, _class)
+                } else {
+                  findOptions.projection = { '%hash%': 0 }
                 }
 
                 const doc = await coll.findOne(mongoQuery, findOptions)
@@ -759,6 +761,8 @@ abstract class MongoAdapterBase implements DbAdapter {
             if (projection != null) {
               cursor = cursor.project(projection)
             }
+          } else {
+            cursor = cursor.project({ '%hash%': 0 })
           }
           let total: number = -1
           if (options != null) {

--- a/server/mongo/src/storage.ts
+++ b/server/mongo/src/storage.ts
@@ -80,7 +80,8 @@ import {
   type Filter,
   type FindCursor,
   type Sort,
-  type UpdateFilter
+  type UpdateFilter,
+  type FindOptions as MongoFindOptions
 } from 'mongodb'
 import { DBCollectionHelper, getMongoClient, getWorkspaceDB, type MongoClientReference } from './utils'
 
@@ -732,7 +733,16 @@ abstract class MongoAdapterBase implements DbAdapter {
               'find-one',
               {},
               async (ctx) => {
-                const doc = await coll.findOne(mongoQuery)
+                const findOptions: MongoFindOptions = {}
+
+                if (options?.sort !== undefined) {
+                  findOptions.sort = this.collectSort<T>(options, _class)
+                }
+                if (options?.projection !== undefined) {
+                  findOptions.projection = this.calcProjection<T>(options, _class)
+                }
+
+                const doc = await coll.findOne(mongoQuery, findOptions)
                 if (doc != null) {
                   return toFindResult([doc as unknown as T])
                 }

--- a/server/server-storage/src/blobStorage.ts
+++ b/server/server-storage/src/blobStorage.ts
@@ -53,6 +53,10 @@ class StorageBlobAdapter implements DbAdapter {
     return await this.blobAdapter.findAll(ctx, _class, query, options)
   }
 
+  async groupBy<T>(ctx: MeasureContext, domain: Domain, field: string): Promise<Set<T>> {
+    return await this.blobAdapter.groupBy(ctx, domain, field)
+  }
+
   async tx (ctx: MeasureContext, ...tx: Tx[]): Promise<TxResult[]> {
     throw new PlatformError(unknownError('Direct Blob operations are not possible'))
   }

--- a/server/ws/src/__tests__/server.test.ts
+++ b/server/ws/src/__tests__/server.test.ts
@@ -72,6 +72,7 @@ describe('server', () => {
       close: async () => {},
       storage: {} as unknown as ServerStorage,
       domains: async () => [],
+      groupBy: async () => new Set(),
       find: (ctx: MeasureContext, domain: Domain) => ({
         next: async (ctx: MeasureContext) => undefined,
         close: async (ctx: MeasureContext) => {}
@@ -170,6 +171,7 @@ describe('server', () => {
           return toFindResult([d as unknown as T])
         },
         tx: async (ctx: SessionContext, tx: Tx): Promise<[TxResult, Tx[], string[] | undefined]> => [{}, [], undefined],
+        groupBy: async () => new Set(),
         close: async () => {},
         storage: {} as unknown as ServerStorage,
         domains: async () => [],


### PR DESCRIPTION
UBERF-7543: Add low level groupBy api and improve security space lookup

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmEwZjMxYjc1ZDI5MTQ0YTk2ODZkOGEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.-DRee6UlKtZsz3uzhcR8Y33f2Qta_s2JWJVfdfSeHDg">Huly&reg;: <b>UBERF-7659</b></a></sub>