### PR TITLE
UBERF-7675: Remove heading text action from compact editors

### DIFF
--- a/models/text-editor/src/plugin.ts
+++ b/models/text-editor/src/plugin.ts
@@ -30,6 +30,7 @@ export default mergeIds(textEditorId, textEditor, {
     MoreImageActions: '' as Resource<TextActionFunction>,
 
     IsEditableTableActive: '' as Resource<TextActionVisibleFunction>,
-    IsEditable: '' as Resource<TextActionVisibleFunction>
+    IsEditable: '' as Resource<TextActionVisibleFunction>,
+    IsHeadingVisible: '' as Resource<TextActionVisibleFunction>
   }
 })

--- a/plugins/text-editor-resources/src/index.ts
+++ b/plugins/text-editor-resources/src/index.ts
@@ -16,7 +16,7 @@
 
 import { type Resources } from '@hcengineering/platform'
 import { formatLink } from './kits/default-kit'
-import { isEditable } from './kits/editor-kit'
+import { isEditable, isHeadingVisible } from './kits/editor-kit'
 import { openTableOptions, isEditableTableActive } from './components/extension/table/table'
 import { openImage, expandImage, moreImageActions } from './components/extension/imageExt'
 
@@ -87,6 +87,7 @@ export default async (): Promise<Resources> => ({
     ExpandImage: expandImage,
     MoreImageActions: moreImageActions,
     IsEditableTableActive: isEditableTableActive,
-    IsEditable: isEditable
+    IsEditable: isEditable,
+    IsHeadingVisible: isHeadingVisible
   }
 })

--- a/plugins/text-editor-resources/src/kits/editor-kit.ts
+++ b/plugins/text-editor-resources/src/kits/editor-kit.ts
@@ -276,5 +276,5 @@ export async function isEditable (editor: Editor): Promise<boolean> {
 }
 
 export async function isHeadingVisible (editor: Editor, ctx: ActionContext): Promise<boolean> {
-  return await isEditable(editor) && ctx.mode === 'full'
+  return (await isEditable(editor)) && ctx.mode === 'full'
 }

--- a/plugins/text-editor-resources/src/kits/editor-kit.ts
+++ b/plugins/text-editor-resources/src/kits/editor-kit.ts
@@ -21,7 +21,7 @@ import TableHeader from '@tiptap/extension-table-header'
 import 'prosemirror-codemark/dist/codemark.css'
 import { getBlobRef, getClient } from '@hcengineering/presentation'
 import { CodeBlockExtension, codeBlockOptions, CodeExtension, codeOptions } from '@hcengineering/text'
-import textEditor, { type ExtensionCreator, type TextEditorMode } from '@hcengineering/text-editor'
+import textEditor, { type ActionContext, type ExtensionCreator, type TextEditorMode } from '@hcengineering/text-editor'
 
 import { DefaultKit, type DefaultKitOptions } from './default-kit'
 import { HardBreakExtension } from '../components/extension/hardBreak'
@@ -247,6 +247,7 @@ async function buildEditorKit (): Promise<Extension<EditorKitOptions, any>> {
                     element: this.options.toolbar?.element,
                     isHidden: this.options.toolbar?.isHidden,
                     ctx: {
+                      mode,
                       objectId: this.options.objectId,
                       objectClass: this.options.objectClass,
                       objectSpace: this.options.objectSpace
@@ -272,4 +273,8 @@ async function buildEditorKit (): Promise<Extension<EditorKitOptions, any>> {
 
 export async function isEditable (editor: Editor): Promise<boolean> {
   return editor.isEditable
+}
+
+export async function isHeadingVisible (editor: Editor, ctx: ActionContext): Promise<boolean> {
+  return await isEditable(editor) && ctx.mode === 'full'
 }

--- a/plugins/text-editor/src/types.ts
+++ b/plugins/text-editor/src/types.ts
@@ -99,6 +99,7 @@ export type TextEditorCommand = (props: TextEditorCommandProps) => boolean
  * @public
  */
 export interface ActionContext {
+  mode: TextEditorMode
   objectId?: Ref<Doc>
   objectClass?: Ref<Class<Doc>>
   objectSpace?: Ref<Space>


### PR DESCRIPTION
* Removes Heading text action from compact editors (like activity/message/etc)

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-7675
Closes https://github.com/hcengineering/platform/issues/6139

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmEyNWE0OTNiZTliOTJkMjE3OGY5NWQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.vTlBkLn4E-Lg0WUIGDf1bXDBpLixNYO-JyDNMNmd4x8">Huly&reg;: <b>UBERF-7681</b></a></sub>