### PR TITLE
UBERF-7682: Fix mongo cursor on backup

### DIFF
--- a/server/mongo/src/storage.ts
+++ b/server/mongo/src/storage.ts
@@ -845,6 +845,7 @@ abstract class MongoAdapterBase implements DbAdapter {
         let d = await ctx.with('next', { mode }, async () => await iterator.next())
         if (d == null && mode === 'hashed') {
           mode = 'non-hashed'
+          await iterator.close()
           iterator = coll.find({ '%hash%': { $in: ['', null] } })
           d = await ctx.with('next', { mode }, async () => await iterator.next())
         }


### PR DESCRIPTION
UBERF-7682: Fix mongo cursor on backup

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmEyNmNiZDNiZTliOTJkMjE3OGZhNmYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.fPwcJcVqOsts9Pkdo_DRLPnNZKkSQsr2NsVuv-ygpJo">Huly&reg;: <b>UBERF-7683</b></a></sub>