### PR TITLE
Password validation feature / Fix for 4638

### DIFF
--- a/plugins/login-assets/lang/en.json
+++ b/plugins/login-assets/lang/en.json
@@ -3,7 +3,11 @@
     "RequiredField": "Required field {field}",
     "FieldsDoNotMatch": "{field} don't match {field2}",
     "ConnectingToServer": "Connecting to server....",
-    "IncorrectValue": "Incorrect value {field}"
+    "IncorrectValue": "Incorrect value {field}",
+    "PasswordLength": "Password must be at least 8 characters long",
+      "PasswordNumber": "Password must contain at least one number",
+      "PasswordLowercase": "Password must contain at least one lowercase letter",
+      "PasswordUppercase": "Password must contain at least one uppercase letter"
   },
   "string": {
     "LogIn": "Log In",
@@ -42,6 +46,11 @@
     "ConfirmationSent": "A message has been sent to your email containing a link to confirm your address.",
     "ConfirmationSent2": "Please follow the link to complete your sign up.",
     "Slogan": "A unique place to manage all of your work\nWelcome to the Platform",
-    "ContinueWith": "Continue with {provider}"
+    "ContinueWith": "Continue with {provider}",
+    "PasswordSuggestion": "General Password Suggestion for Improved Security",
+    "PasswordWeak": "Password is Weak",
+    "PasswordModerate": "Password is Moderate",
+    "PasswordStrong": "Password is Strong",
+    "PasswordVeryStrong": "Password is Very Strong"
   }
 }

--- a/plugins/login-assets/lang/es.json
+++ b/plugins/login-assets/lang/es.json
@@ -3,7 +3,11 @@
     "RequiredField": "Campo obligatorio: {field}",
     "FieldsDoNotMatch": "{field} no coincide con {field2}",
     "ConnectingToServer": "Conectando al servidor...",
-    "IncorrectValue": "Valor incorrecto para {field}"
+    "IncorrectValue": "Valor incorrecto para {field}",
+    "PasswordLength": "La contraseña debe tener al menos 8 caracteres",
+    "PasswordNumber": "La contraseña debe contener al menos un número",
+    "PasswordLowercase": "La contraseña debe contener al menos una letra minúscula",
+    "PasswordUppercase": "La contraseña debe contener al menos una letra mayúscula"
   },
   "string": {
     "LogIn": "Iniciar sesión",
@@ -42,6 +46,11 @@
     "ConfirmationSent": "Se ha enviado un mensaje a su correo electrónico con un enlace para confirmar su dirección.",
     "ConfirmationSent2": "Por favor, siga el enlace para completar su registro.",
     "Slogan": "Un lugar único para gestionar todo tu trabajo\nBienvenido/a a la Plataforma",
-    "ContinueWith": "Continuar com {provider}"
+    "ContinueWith": "Continuar com {provider}",
+    "PasswordSuggestion": "Sugerencia General de Contraseña para una Mejor Seguridad",
+    "PasswordWeak": "Débil",
+  "PasswordModerate": "Moderado",
+  "PasswordStrong": "Fuerte",
+  "PasswordVeryStrong": "Muy Fuerte"
   }
 }

--- a/plugins/login-assets/lang/fr.json
+++ b/plugins/login-assets/lang/fr.json
@@ -3,7 +3,11 @@
     "RequiredField": "Champ requis {field}",
     "FieldsDoNotMatch": "{field} ne correspond pas à {field2}",
     "ConnectingToServer": "Connexion au serveur...",
-    "IncorrectValue": "Valeur incorrecte {field}"
+    "IncorrectValue": "Valeur incorrecte {field}",
+    "PasswordLength": "Le mot de passe doit comporter au moins 8 caractères",
+    "PasswordNumber": "Le mot de passe doit contenir au moins un chiffre",
+    "PasswordLowercase": "Le mot de passe doit contenir au moins une lettre minuscule",
+    "PasswordUppercase": "Le mot de passe doit contenir au moins une lettre majuscule"
   },
   "string": {
     "LogIn": "Connexion",
@@ -42,6 +46,11 @@
     "ConfirmationSent": "Un message a été envoyé à votre adresse e-mail contenant un lien pour confirmer votre adresse.",
     "ConfirmationSent2": "Veuillez suivre le lien pour compléter votre inscription.",
     "Slogan": "Un lieu unique pour gérer tout votre travail\nBienvenue sur la plateforme",
-    "ContinueWith": "Continuer avec {provider}"
+    "ContinueWith": "Continuer avec {provider}",
+    "PasswordSuggestion": "Conseil Général pour un Mot de Passe Sécurisé",
+    "PasswordWeak": "Faible",
+    "PasswordModerate": "Modéré",
+    "PasswordStrong": "Fort",
+    "PasswordVeryStrong": "Très Fort"
   }
 }

--- a/plugins/login-assets/lang/pt.json
+++ b/plugins/login-assets/lang/pt.json
@@ -3,7 +3,11 @@
     "RequiredField": "Campo obrigatório {field}",
     "FieldsDoNotMatch": "{field} não coincidem com {field2}",
     "ConnectingToServer": "A ligar ao servidor....",
-    "IncorrectValue": "Valor incorreto {field}"
+    "IncorrectValue": "Valor incorreto {field}",
+    "PasswordLength": "A senha deve ter pelo menos 8 caracteres",
+    "PasswordNumber": "A senha deve conter pelo menos um número",
+    "PasswordLowercase": "A senha deve conter pelo menos uma letra minúscula",
+    "PasswordUppercase": "A senha deve conter pelo menos uma letra maiúscula"
   },
   "string": {
     "LogIn": "Iniciar Sessão",
@@ -42,6 +46,11 @@
     "ConfirmationSent": "Foi enviada uma mensagem para o seu email contendo um link para confirmar o seu endereço.",
     "ConfirmationSent2": "Por favor, siga o link para concluir o seu registo.",
     "Slogan": "Um local único para gerir todo o seu trabalho\nBem-vindo à Plataforma",
-    "ContinueWith": "Continuar com {provider}"
+    "ContinueWith": "Continuar com {provider}",
+    "PasswordSuggestion": "Sugestão Geral de Senha para Melhor Segurança",
+    "PasswordWeak": "Fraca",
+  "PasswordModerate": "Moderada",
+  "PasswordStrong": "Forte",
+  "PasswordVeryStrong": "Muito Forte"
   }
 }

--- a/plugins/login-assets/lang/ru.json
+++ b/plugins/login-assets/lang/ru.json
@@ -3,7 +3,11 @@
     "RequiredField": "Требуется заполнить {field}",
     "FieldsDoNotMatch": "{field} не совпадает {field2}",
     "ConnectingToServer": "Подключение к серверу....",
-    "IncorrectValue": "Неправильное значение {field}"
+    "IncorrectValue": "Неправильное значение {field}",
+    "PasswordLength": "Пароль должен быть длиной не менее 8 символов",
+    "PasswordNumber": "Пароль должен содержать хотя бы одну цифру",
+    "PasswordLowercase": "Пароль должен содержать хотя бы одну строчную букву",
+    "PasswordUppercase": "Пароль должен содержать хотя бы одну заглавную букву"
   },
   "string": {
     "LogIn": "Вход",
@@ -42,6 +46,11 @@
     "ConfirmationSent": "На Вашу почту отправлено сообщение, c ссылкой для подтверждения email.",
     "ConfirmationSent2": "Пожалуйста, перейдите по ссылке для завершения регистрации.",
     "Slogan": "Уникальное место для организации всей вашей работы\nДобро пожаловать в Платформу",
-    "ContinueWith": "Войти через {provider}"
+    "ContinueWith": "Войти через {provider}",
+    "PasswordSuggestion": "Общий Совет по Паролям для Улучшения Безопасности",
+    "PasswordWeak": "Слабый пароль",
+  "PasswordModerate": "Умеренный пароль",
+  "PasswordStrong": "Надежный пароль",
+  "PasswordVeryStrong": "Очень Надежный пароль"
   }
 }

--- a/plugins/login-assets/lang/zh.json
+++ b/plugins/login-assets/lang/zh.json
@@ -3,7 +3,11 @@
     "RequiredField": "必填字段 {field}",
     "FieldsDoNotMatch": "{field} 与 {field2} 不匹配",
     "ConnectingToServer": "正在连接服务器....",
-    "IncorrectValue": "不正确的值 {field}"
+    "IncorrectValue": "不正确的值 {field}",
+    "PasswordLength": "密码长度必须至少为8个字符",
+    "PasswordNumber": "密码必须包含至少一个数字",
+    "PasswordLowercase": "密码必须包含至少一个小写字母",
+    "PasswordUppercase": "密码必须包含至少一个大写字母"
   },
   "string": {
     "LogIn": "登录",
@@ -42,6 +46,11 @@
     "ConfirmationSent": "已发送确认邮件到您的邮箱，包含一个确认地址的链接。",
     "ConfirmationSent2": "请点击链接完成注册。",
     "Slogan": "一个独特的地方来管理你所有的工作\n欢迎来到平台",
-    "ContinueWith": "继续使用 {provider}"
+    "ContinueWith": "继续使用 {provider}",
+    "PasswordSuggestion": "提高安全性的密码一般建议",
+    "PasswordWeak": "弱",
+  "PasswordModerate": "中等",
+  "PasswordStrong": "强",
+  "PasswordVeryStrong": "非常强"
   }
 }

--- a/plugins/login-resources/src/components/SignupForm.svelte
+++ b/plugins/login-resources/src/components/SignupForm.svelte
@@ -21,11 +21,38 @@
   import { goTo, signUp } from '../utils'
   import Form from './Form.svelte'
 
+  const passwordValidationRules = [
+    {
+      rule: /.{8,}/,
+      notMatch: false,
+      ruleDescr: login.status.PasswordLength,
+      disabled: true
+    },
+    {
+      rule: /[0-9]/,
+      notMatch: false,
+      ruleDescr: login.status.PasswordNumber,
+      disabled: false
+    },
+    {
+      rule: /[a-z]/,
+      notMatch: false,
+      ruleDescr: login.status.PasswordLowercase,
+      disabled: false
+    },
+    {
+      rule: /[A-Z]/,
+      notMatch: false,
+      ruleDescr: login.status.PasswordUppercase,
+      disabled: false
+    }
+  ]
+
   const fields = [
     { id: 'given-name', name: 'first', i18n: login.string.FirstName, short: true },
     { id: 'family-name', name: 'last', i18n: login.string.LastName, short: true },
     { id: 'email', name: 'username', i18n: login.string.Email },
-    { id: 'new-password', name: 'password', i18n: login.string.Password, password: true },
+    { id: 'new-password', name: 'password', i18n: login.string.Password, password: true, rules: passwordValidationRules },
     { id: 'new-password', name: 'password2', i18n: login.string.PasswordRepeat, password: true }
   ]
 

--- a/plugins/login-resources/src/plugin.ts
+++ b/plugins/login-resources/src/plugin.ts
@@ -24,7 +24,11 @@ export default mergeIds(loginId, login, {
     RequiredField: '' as StatusCode<{ field: string }>,
     FieldsDoNotMatch: '' as StatusCode<{ field: string, field2: string }>,
     ConnectingToServer: '' as StatusCode,
-    IncorrectValue: '' as StatusCode<{ field: string }>
+    IncorrectValue: '' as StatusCode<{ field: string }>,
+    PasswordLength: '' as StatusCode,
+    PasswordNumber: '' as StatusCode,
+    PasswordLowercase: '' as StatusCode,
+    PasswordUppercase: '' as StatusCode
   },
   string: {
     CreateWorkspace: '' as IntlString,
@@ -59,6 +63,11 @@ export default mergeIds(loginId, login, {
     ConfirmationSent: '' as IntlString,
     ConfirmationSent2: '' as IntlString,
     Slogan: '' as IntlString,
-    ContinueWith: '' as IntlString
+    ContinueWith: '' as IntlString,
+    PasswordSuggestion: '' as IntlString,
+    PasswordWeak: '' as IntlString,
+    PasswordModerate: '' as IntlString,
+    PasswordStrong: '' as IntlString,
+    PasswordVeryStrong: '' as IntlString
   }
 })


### PR DESCRIPTION
Created a password validation feature.

<img width="509" src="https://github.com/user-attachments/assets/cf579fd7-9735-417e-987f-5571b2bfa803" alt="Screenshot 2024-07-26 133558">

As per request stated in the https://github.com/hcengineering/platform/pull/5224 :
-Users aren't forced to meet specified requirements for the password.
-Password strength is validated based on rules provided and displays to users under the password input.
-Any validation rule can be enabled/disabled.
-General suggestion informational block displays all enabled password rules.
-All text is aligned with system languages.

Possible future fix:
Email validation - now user is able to sign up with invalid email.