### PR TITLE
UBERF-7016: Hide channels without any activity long time

### DIFF
--- a/models/chunter/src/actions.ts
+++ b/models/chunter/src/actions.ts
@@ -1,0 +1,249 @@
+//
+// Copyright © 2024 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { type Builder } from '@hcengineering/model'
+import view, { actionTemplates as viewTemplates, createAction, template } from '@hcengineering/model-view'
+import notification, { notificationActionTemplates } from '@hcengineering/model-notification'
+import activity from '@hcengineering/activity'
+import workbench from '@hcengineering/model-workbench'
+
+import chunter from './plugin'
+
+const actionTemplates = template({
+  removeChannel: {
+    action: chunter.actionImpl.RemoveChannel,
+    label: view.string.Archive,
+    icon: view.icon.Delete,
+    input: 'focus',
+    keyBinding: ['Backspace'],
+    category: chunter.category.Chunter,
+    target: notification.class.DocNotifyContext,
+    context: { mode: ['context', 'browser'], group: 'remove' }
+  }
+})
+
+export function defineActions (builder: Builder): void {
+  createAction(
+    builder,
+    {
+      action: chunter.actionImpl.ReplyToThread,
+      label: chunter.string.ReplyToThread,
+      icon: chunter.icon.Thread,
+      input: 'focus',
+      category: chunter.category.Chunter,
+      target: activity.class.ActivityMessage,
+      visibilityTester: chunter.function.CanReplyToThread,
+      inline: true,
+      context: {
+        mode: 'context',
+        group: 'edit'
+      }
+    },
+    chunter.action.ReplyToThreadAction
+  )
+
+  createAction(
+    builder,
+    {
+      action: view.actionImpl.CopyTextToClipboard,
+      actionProps: {
+        textProvider: chunter.function.GetLink
+      },
+      label: chunter.string.CopyLink,
+      icon: chunter.icon.Copy,
+      input: 'none',
+      category: chunter.category.Chunter,
+      target: activity.class.ActivityMessage,
+      visibilityTester: chunter.function.CanCopyMessageLink,
+      context: {
+        mode: ['context', 'browser'],
+        application: chunter.app.Chunter,
+        group: 'copy'
+      }
+    },
+    chunter.action.CopyChatMessageLink
+  )
+
+  createAction(
+    builder,
+    {
+      action: chunter.actionImpl.UnarchiveChannel,
+      label: chunter.string.UnarchiveChannel,
+      icon: view.icon.Archive,
+      input: 'focus',
+      category: chunter.category.Chunter,
+      target: chunter.class.Channel,
+      query: {
+        archived: true
+      },
+      context: {
+        mode: 'context',
+        group: 'tools'
+      }
+    },
+    chunter.action.UnarchiveChannel
+  )
+
+  createAction(
+    builder,
+    {
+      action: chunter.actionImpl.ConvertDmToPrivateChannel,
+      label: chunter.string.ConvertToPrivate,
+      icon: chunter.icon.Lock,
+      input: 'focus',
+      category: chunter.category.Chunter,
+      target: chunter.class.DirectMessage,
+      context: {
+        mode: 'context',
+        group: 'edit'
+      }
+    },
+    chunter.action.ConvertToPrivate
+  )
+
+  createAction(
+    builder,
+    {
+      action: chunter.actionImpl.ArchiveChannel,
+      label: chunter.string.ArchiveChannel,
+      icon: view.icon.Archive,
+      input: 'focus',
+      category: chunter.category.Chunter,
+      target: chunter.class.Channel,
+      query: {
+        archived: false
+      },
+      context: {
+        mode: 'context',
+        group: 'tools'
+      }
+    },
+    chunter.action.ArchiveChannel
+  )
+
+  createAction(builder, {
+    ...viewTemplates.open,
+    target: chunter.class.Channel,
+    context: {
+      mode: ['browser', 'context'],
+      group: 'create'
+    },
+    action: workbench.actionImpl.Navigate,
+    actionProps: {
+      mode: 'space'
+    }
+  })
+
+  createAction(
+    builder,
+    {
+      action: chunter.actionImpl.DeleteChatMessage,
+      label: view.string.Delete,
+      icon: view.icon.Delete,
+      input: 'focus',
+      keyBinding: ['Backspace'],
+      category: chunter.category.Chunter,
+      target: chunter.class.ChatMessage,
+      visibilityTester: chunter.function.CanDeleteMessage,
+      context: { mode: ['context', 'browser'], group: 'remove' }
+    },
+    chunter.action.DeleteChatMessage
+  )
+
+  createAction(
+    builder,
+    {
+      ...actionTemplates.removeChannel,
+      icon: view.icon.EyeCrossed,
+      label: view.string.Hide,
+      query: {
+        attachedToClass: { $nin: [chunter.class.DirectMessage, chunter.class.Channel] }
+      }
+    },
+    chunter.action.RemoveChannel
+  )
+
+  createAction(
+    builder,
+    {
+      ...actionTemplates.removeChannel,
+      label: chunter.string.CloseConversation,
+      query: {
+        attachedToClass: chunter.class.DirectMessage
+      }
+    },
+    chunter.action.CloseConversation
+  )
+
+  createAction(
+    builder,
+    {
+      ...actionTemplates.removeChannel,
+      action: chunter.actionImpl.LeaveChannel,
+      label: chunter.string.LeaveChannel,
+      query: {
+        attachedToClass: chunter.class.Channel
+      }
+    },
+    chunter.action.LeaveChannel
+  )
+
+  createAction(builder, {
+    ...notificationActionTemplates.pinContext,
+    label: chunter.string.StarChannel,
+    query: {
+      attachedToClass: chunter.class.Channel
+    },
+    override: [notification.action.PinDocNotifyContext]
+  })
+
+  createAction(builder, {
+    ...notificationActionTemplates.unpinContext,
+    label: chunter.string.UnstarChannel,
+    query: {
+      attachedToClass: chunter.class.Channel
+    }
+  })
+
+  createAction(builder, {
+    ...notificationActionTemplates.pinContext,
+    label: chunter.string.StarConversation,
+    query: {
+      attachedToClass: chunter.class.DirectMessage
+    }
+  })
+
+  createAction(builder, {
+    ...notificationActionTemplates.unpinContext,
+    label: chunter.string.UnstarConversation,
+    query: {
+      attachedToClass: chunter.class.DirectMessage
+    }
+  })
+
+  createAction(builder, {
+    ...notificationActionTemplates.pinContext,
+    query: {
+      attachedToClass: { $nin: [chunter.class.DirectMessage, chunter.class.Channel] }
+    }
+  })
+
+  createAction(builder, {
+    ...notificationActionTemplates.unpinContext,
+    query: {
+      attachedToClass: { $nin: [chunter.class.DirectMessage, chunter.class.Channel] }
+    }
+  })
+}

--- a/models/chunter/src/index.ts
+++ b/models/chunter/src/index.ts
@@ -48,18 +48,20 @@ import {
   TypeRef,
   TypeString,
   TypeTimestamp,
-  UX
+  UX,
+  Hidden
 } from '@hcengineering/model'
 import attachment from '@hcengineering/model-attachment'
 import core, { TClass, TDoc, TSpace } from '@hcengineering/model-core'
-import notification, { notificationActionTemplates, TDocNotifyContext } from '@hcengineering/model-notification'
-import view, { createAction, template, actionTemplates as viewTemplates } from '@hcengineering/model-view'
+import notification, { TDocNotifyContext } from '@hcengineering/model-notification'
+import view from '@hcengineering/model-view'
 import workbench from '@hcengineering/model-workbench'
 import type { IntlString } from '@hcengineering/platform'
 import { TActivityMessage } from '@hcengineering/model-activity'
 import { type DocNotifyContext } from '@hcengineering/notification'
 
 import chunter from './plugin'
+import { defineActions } from './actions'
 
 export { chunterId } from '@hcengineering/chunter'
 export { chunterOperation } from './migration'
@@ -148,19 +150,6 @@ export class TChatInfo extends TDoc implements ChatInfo {
   hidden!: Ref<DocNotifyContext>[]
   timestamp!: Timestamp
 }
-
-const actionTemplates = template({
-  removeChannel: {
-    action: chunter.actionImpl.RemoveChannel,
-    label: view.string.Archive,
-    icon: view.icon.Delete,
-    input: 'focus',
-    keyBinding: ['Backspace'],
-    category: chunter.category.Chunter,
-    target: notification.class.DocNotifyContext,
-    context: { mode: ['context', 'browser'], group: 'remove' }
-  }
-})
 
 export function createModel (builder: Builder): void {
   builder.createModel(
@@ -254,26 +243,6 @@ export function createModel (builder: Builder): void {
     chunter.category.Chunter
   )
 
-  createAction(
-    builder,
-    {
-      action: chunter.actionImpl.ArchiveChannel,
-      label: chunter.string.ArchiveChannel,
-      icon: view.icon.Archive,
-      input: 'focus',
-      category: chunter.category.Chunter,
-      target: chunter.class.Channel,
-      query: {
-        archived: false
-      },
-      context: {
-        mode: 'context',
-        group: 'tools'
-      }
-    },
-    chunter.action.ArchiveChannel
-  )
-
   builder.createDoc(
     view.class.Viewlet,
     core.space.Model,
@@ -287,43 +256,6 @@ export function createModel (builder: Builder): void {
       props: { enableChecking: false }
     },
     chunter.viewlet.Channels
-  )
-
-  createAction(
-    builder,
-    {
-      action: chunter.actionImpl.UnarchiveChannel,
-      label: chunter.string.UnarchiveChannel,
-      icon: view.icon.Archive,
-      input: 'focus',
-      category: chunter.category.Chunter,
-      target: chunter.class.Channel,
-      query: {
-        archived: true
-      },
-      context: {
-        mode: 'context',
-        group: 'tools'
-      }
-    },
-    chunter.action.UnarchiveChannel
-  )
-
-  createAction(
-    builder,
-    {
-      action: chunter.actionImpl.ConvertDmToPrivateChannel,
-      label: chunter.string.ConvertToPrivate,
-      icon: chunter.icon.Lock,
-      input: 'focus',
-      category: chunter.category.Chunter,
-      target: chunter.class.DirectMessage,
-      context: {
-        mode: 'context',
-        group: 'edit'
-      }
-    },
-    chunter.action.ConvertToPrivate
   )
 
   builder.createDoc(
@@ -347,28 +279,6 @@ export function createModel (builder: Builder): void {
   builder.mixin(chunter.class.ThreadMessage, core.class.Class, view.mixin.LinkProvider, {
     encode: chunter.function.GetThreadLink
   })
-
-  createAction(
-    builder,
-    {
-      action: view.actionImpl.CopyTextToClipboard,
-      actionProps: {
-        textProvider: chunter.function.GetLink
-      },
-      label: chunter.string.CopyLink,
-      icon: chunter.icon.Copy,
-      input: 'none',
-      category: chunter.category.Chunter,
-      target: activity.class.ActivityMessage,
-      visibilityTester: chunter.function.CanCopyMessageLink,
-      context: {
-        mode: ['context', 'browser'],
-        application: chunter.app.Chunter,
-        group: 'copy'
-      }
-    },
-    chunter.action.CopyChatMessageLink
-  )
 
   builder.mixin(chunter.class.Channel, core.class.Class, view.mixin.ClassFilters, {
     filters: []
@@ -446,19 +356,6 @@ export function createModel (builder: Builder): void {
     chunter.ids.ThreadNotification
   )
 
-  createAction(builder, {
-    ...viewTemplates.open,
-    target: chunter.class.Channel,
-    context: {
-      mode: ['browser', 'context'],
-      group: 'create'
-    },
-    action: workbench.actionImpl.Navigate,
-    actionProps: {
-      mode: 'space'
-    }
-  })
-
   builder.createDoc(activity.class.ActivityMessagesFilter, core.space.Model, {
     label: chunter.string.Comments,
     position: 60,
@@ -495,105 +392,6 @@ export function createModel (builder: Builder): void {
     },
     chunter.ids.ThreadMessageViewlet
   )
-
-  createAction(
-    builder,
-    {
-      action: chunter.actionImpl.DeleteChatMessage,
-      label: view.string.Delete,
-      icon: view.icon.Delete,
-      input: 'focus',
-      keyBinding: ['Backspace'],
-      category: chunter.category.Chunter,
-      target: chunter.class.ChatMessage,
-      visibilityTester: chunter.function.CanDeleteMessage,
-      context: { mode: ['context', 'browser'], group: 'remove' }
-    },
-    chunter.action.DeleteChatMessage
-  )
-
-  createAction(
-    builder,
-    {
-      ...actionTemplates.removeChannel,
-      query: {
-        attachedToClass: { $nin: [chunter.class.DirectMessage, chunter.class.Channel] }
-      }
-    },
-    chunter.action.RemoveChannel
-  )
-
-  createAction(
-    builder,
-    {
-      ...actionTemplates.removeChannel,
-      label: chunter.string.CloseConversation,
-      query: {
-        attachedToClass: chunter.class.DirectMessage
-      }
-    },
-    chunter.action.CloseConversation
-  )
-
-  createAction(
-    builder,
-    {
-      ...actionTemplates.removeChannel,
-      action: chunter.actionImpl.LeaveChannel,
-      label: chunter.string.LeaveChannel,
-      query: {
-        attachedToClass: chunter.class.Channel
-      }
-    },
-    chunter.action.LeaveChannel
-  )
-
-  createAction(builder, {
-    ...notificationActionTemplates.pinContext,
-    label: chunter.string.StarChannel,
-    query: {
-      attachedToClass: chunter.class.Channel
-    },
-    override: [notification.action.PinDocNotifyContext]
-  })
-
-  createAction(builder, {
-    ...notificationActionTemplates.unpinContext,
-    label: chunter.string.UnstarChannel,
-    query: {
-      attachedToClass: chunter.class.Channel
-    }
-  })
-
-  createAction(builder, {
-    ...notificationActionTemplates.pinContext,
-    label: chunter.string.StarConversation,
-    query: {
-      attachedToClass: chunter.class.DirectMessage
-    }
-  })
-
-  createAction(builder, {
-    ...notificationActionTemplates.unpinContext,
-    label: chunter.string.UnstarConversation,
-    query: {
-      attachedToClass: chunter.class.DirectMessage
-    }
-  })
-
-  createAction(builder, {
-    ...notificationActionTemplates.pinContext,
-    query: {
-      attachedToClass: { $nin: [chunter.class.DirectMessage, chunter.class.Channel] }
-    }
-  })
-
-  createAction(builder, {
-    ...notificationActionTemplates.unpinContext,
-    query: {
-      attachedToClass: { $nin: [chunter.class.DirectMessage, chunter.class.Channel] }
-    }
-  })
 
   builder.createDoc(activity.class.ActivityExtension, core.space.Model, {
     ofClass: chunter.class.Channel,
@@ -645,25 +443,6 @@ export function createModel (builder: Builder): void {
     function: chunter.function.ReplyToThread
   })
 
-  createAction(
-    builder,
-    {
-      action: chunter.actionImpl.ReplyToThread,
-      label: chunter.string.ReplyToThread,
-      icon: chunter.icon.Thread,
-      input: 'focus',
-      category: chunter.category.Chunter,
-      target: activity.class.ActivityMessage,
-      visibilityTester: chunter.function.CanReplyToThread,
-      inline: true,
-      context: {
-        mode: 'context',
-        group: 'edit'
-      }
-    },
-    chunter.action.ReplyToThreadAction
-  )
-
   builder.mixin(chunter.class.Channel, core.class.Class, view.mixin.ClassFilters, {
     filters: ['name', 'topic', 'private', 'archived', 'members'],
     strict: true
@@ -680,6 +459,8 @@ export function createModel (builder: Builder): void {
     ignoredTypes: [],
     enabledTypes: [chunter.ids.DMNotification, chunter.ids.ChannelNotification, chunter.ids.ThreadNotification]
   })
+
+  defineActions(builder)
 }
 
 export default chunter

--- a/models/chunter/src/index.ts
+++ b/models/chunter/src/index.ts
@@ -22,10 +22,12 @@ import {
   type ChatMessageViewlet,
   type ChunterSpace,
   type ObjectChatPanel,
-  type ThreadMessage
+  type ThreadMessage,
+  type ChatInfo,
+  type ChannelInfo
 } from '@hcengineering/chunter'
 import presentation from '@hcengineering/model-presentation'
-import contact from '@hcengineering/contact'
+import contact, { type Person } from '@hcengineering/contact'
 import {
   type Class,
   type Doc,
@@ -50,11 +52,12 @@ import {
 } from '@hcengineering/model'
 import attachment from '@hcengineering/model-attachment'
 import core, { TClass, TDoc, TSpace } from '@hcengineering/model-core'
-import notification, { notificationActionTemplates } from '@hcengineering/model-notification'
+import notification, { notificationActionTemplates, TDocNotifyContext } from '@hcengineering/model-notification'
 import view, { createAction, template, actionTemplates as viewTemplates } from '@hcengineering/model-view'
 import workbench from '@hcengineering/model-workbench'
 import type { IntlString } from '@hcengineering/platform'
 import { TActivityMessage } from '@hcengineering/model-activity'
+import { type DocNotifyContext } from '@hcengineering/notification'
 
 import chunter from './plugin'
 
@@ -133,6 +136,19 @@ export class TObjectChatPanel extends TClass implements ObjectChatPanel {
   ignoreKeys!: string[]
 }
 
+@Mixin(chunter.mixin.ChannelInfo, notification.class.DocNotifyContext)
+export class TChannelInfo extends TDocNotifyContext implements ChannelInfo {
+  @Hidden()
+    hidden!: boolean
+}
+
+@Model(chunter.class.ChatInfo, core.class.Doc, DOMAIN_CHUNTER)
+export class TChatInfo extends TDoc implements ChatInfo {
+  user!: Ref<Person>
+  hidden!: Ref<DocNotifyContext>[]
+  timestamp!: Timestamp
+}
+
 const actionTemplates = template({
   removeChannel: {
     action: chunter.actionImpl.RemoveChannel,
@@ -154,7 +170,9 @@ export function createModel (builder: Builder): void {
     TChatMessage,
     TThreadMessage,
     TChatMessageViewlet,
-    TObjectChatPanel
+    TObjectChatPanel,
+    TChatInfo,
+    TChannelInfo
   )
   const spaceClasses = [chunter.class.Channel, chunter.class.DirectMessage]
 

--- a/models/chunter/src/migration.ts
+++ b/models/chunter/src/migration.ts
@@ -63,8 +63,7 @@ export async function createDocNotifyContexts (
       await tx.createDoc(notification.class.DocNotifyContext, core.space.Space, {
         user: user._id,
         attachedTo,
-        attachedToClass,
-        hidden: false
+        attachedToClass
       })
     }
   }

--- a/models/notification/src/index.ts
+++ b/models/notification/src/index.ts
@@ -203,10 +203,6 @@ export class TDocNotifyContext extends TDoc implements DocNotifyContext {
   @Index(IndexKind.Indexed)
     attachedToClass!: Ref<Class<Doc>>
 
-  @Prop(TypeBoolean(), core.string.Archived)
-  @Index(IndexKind.Indexed)
-    hidden!: boolean
-
   @Prop(TypeDate(), core.string.Date)
     lastViewedTimestamp?: Timestamp
 

--- a/models/server-chunter/src/index.ts
+++ b/models/server-chunter/src/index.ts
@@ -20,6 +20,7 @@ import chunter from '@hcengineering/chunter'
 import serverNotification from '@hcengineering/server-notification'
 import serverCore, { type ObjectDDParticipant } from '@hcengineering/server-core'
 import serverChunter from '@hcengineering/server-chunter'
+import notification from '@hcengineering/notification'
 
 export { serverChunterId } from '@hcengineering/server-chunter'
 
@@ -58,6 +59,22 @@ export function createModel (builder: Builder): void {
     txMatch: {
       _class: core.class.TxUpdateDoc,
       objectClass: chunter.class.Channel
+    }
+  })
+
+  builder.createDoc(serverCore.class.Trigger, core.space.Model, {
+    trigger: serverChunter.trigger.OnUserStatus,
+    txMatch: {
+      objectClass: core.class.UserStatus
+    },
+    isAsync: true
+  })
+
+  builder.createDoc(serverCore.class.Trigger, core.space.Model, {
+    trigger: serverChunter.trigger.OnContextUpdate,
+    txMatch: {
+      _class: core.class.TxUpdateDoc,
+      objectClass: notification.class.DocNotifyContext
     }
   })
 

--- a/plugins/chunter-resources/src/channelDataProvider.ts
+++ b/plugins/chunter-resources/src/channelDataProvider.ts
@@ -84,6 +84,8 @@ export class ChannelDataProvider implements IChannelDataProvider {
   private readonly isInitialLoadedStore = writable(false)
   private readonly isTailLoading = writable(false)
 
+  readonly isTailLoaded = writable(false)
+
   public datesStore = writable<Timestamp[]>([])
   public newTimestampStore = writable<Timestamp | undefined>(undefined)
 
@@ -264,6 +266,7 @@ export class ChannelDataProvider implements IChannelDataProvider {
           this.tailStore.set(res.reverse())
         }
 
+        this.isTailLoaded.set(true)
         this.isTailLoading.set(false)
       },
       {
@@ -557,6 +560,7 @@ export class ChannelDataProvider implements IChannelDataProvider {
     this.isInitialLoadedStore.set(false)
     this.tailQuery.unsubscribe()
     this.tailStart = undefined
+    this.isTailLoaded.set(false)
     this.backwardNextPromise = undefined
     this.forwardNextPromise = undefined
     this.forwardNextStore.set(undefined)

--- a/plugins/chunter-resources/src/components/chat/create/CreateChannel.svelte
+++ b/plugins/chunter-resources/src/components/chat/create/CreateChannel.svelte
@@ -63,8 +63,7 @@
     await client.createDoc(notification.class.DocNotifyContext, channelId, {
       user: accountId,
       attachedTo: channelId,
-      attachedToClass: chunter.class.Channel,
-      hidden: false
+      attachedToClass: chunter.class.Channel
     })
 
     openChannel(channelId, chunter.class.Channel)

--- a/plugins/chunter-resources/src/components/chat/create/CreateDirectChat.svelte
+++ b/plugins/chunter-resources/src/components/chat/create/CreateDirectChat.svelte
@@ -81,7 +81,6 @@
     })
 
     if (context !== undefined) {
-      await client.diffUpdate(context, { hidden: false })
       openChannel(dmId, chunter.class.DirectMessage)
 
       return
@@ -90,8 +89,7 @@
     await client.createDoc(notification.class.DocNotifyContext, dmId, {
       user: myAccId,
       attachedTo: dmId,
-      attachedToClass: chunter.class.DirectMessage,
-      hidden: false
+      attachedToClass: chunter.class.DirectMessage
     })
 
     openChannel(dmId, chunter.class.DirectMessage)

--- a/plugins/chunter-resources/src/components/chat/navigator/ChatNavGroup.svelte
+++ b/plugins/chunter-resources/src/components/chat/navigator/ChatNavGroup.svelte
@@ -55,7 +55,6 @@
     notification.class.DocNotifyContext,
     {
       ...model.query,
-      hidden: false,
       user: getCurrentAccount()._id
     },
     (res: DocNotifyContext[]) => {

--- a/plugins/chunter-resources/src/components/chat/navigator/ChatNavGroup.svelte
+++ b/plugins/chunter-resources/src/components/chat/navigator/ChatNavGroup.svelte
@@ -55,6 +55,7 @@
     notification.class.DocNotifyContext,
     {
       ...model.query,
+      [`${chunter.mixin.ChannelInfo}.hidden`]: { $ne: true },
       user: getCurrentAccount()._id
     },
     (res: DocNotifyContext[]) => {

--- a/plugins/chunter-resources/src/components/chat/navigator/ChatNavItem.svelte
+++ b/plugins/chunter-resources/src/components/chat/navigator/ChatNavItem.svelte
@@ -128,6 +128,7 @@
   {count}
   title={item.title}
   description={item.description}
+  secondaryNotifyMarker={(context?.lastViewedTimestamp ?? 0) < (context?.lastUpdateTimestamp ?? 0)}
   {actions}
   {type}
   on:click={() => {

--- a/plugins/chunter-resources/src/components/chat/navigator/NavItem.svelte
+++ b/plugins/chunter-resources/src/components/chat/navigator/NavItem.svelte
@@ -35,6 +35,7 @@
   export let isSelected: boolean = false
   export let isSecondary: boolean = false
   export let count: number | null = null
+  export let secondaryNotifyMarker: boolean = false
   export let title: string | undefined = undefined
   export let intlTitle: IntlString | undefined = undefined
   export let description: string | undefined = undefined
@@ -98,6 +99,10 @@
     {#if count != null && count > 0}
       <div class="antiHSpacer" />
       <NotifyMarker {count} />
+      <div class="antiHSpacer" />
+    {:else if secondaryNotifyMarker}
+      <div class="antiHSpacer" />
+      <NotifyMarker count={0} kind="secondary" size="x-small" />
       <div class="antiHSpacer" />
     {/if}
   </svelte:fragment>

--- a/plugins/chunter/src/index.ts
+++ b/plugins/chunter/src/index.ts
@@ -15,11 +15,12 @@
 
 import { ActivityMessage, ActivityMessageViewlet } from '@hcengineering/activity'
 import type { Class, Doc, Markup, Mixin, Ref, Space, Timestamp } from '@hcengineering/core'
-import { NotificationType } from '@hcengineering/notification'
+import { DocNotifyContext, NotificationType } from '@hcengineering/notification'
 import type { Asset, Plugin } from '@hcengineering/platform'
 import { IntlString, plugin } from '@hcengineering/platform'
 import { AnyComponent } from '@hcengineering/ui'
 import { Action } from '@hcengineering/view'
+import { Person } from '@hcengineering/contact'
 
 /**
  * @public
@@ -72,6 +73,16 @@ export interface ChatMessageViewlet extends ActivityMessageViewlet {
   label?: IntlString
 }
 
+export interface ChatInfo extends Doc {
+  user: Ref<Person>
+  hidden: Ref<DocNotifyContext>[]
+  timestamp: Timestamp
+}
+
+export interface ChannelInfo extends DocNotifyContext {
+  hidden: boolean
+}
+
 /**
  * @public
  */
@@ -110,10 +121,12 @@ export default plugin(chunterId, {
     Channel: '' as Ref<Class<Channel>>,
     DirectMessage: '' as Ref<Class<DirectMessage>>,
     ChatMessage: '' as Ref<Class<ChatMessage>>,
-    ChatMessageViewlet: '' as Ref<Class<ChatMessageViewlet>>
+    ChatMessageViewlet: '' as Ref<Class<ChatMessageViewlet>>,
+    ChatInfo: '' as Ref<Class<ChatInfo>>
   },
   mixin: {
-    ObjectChatPanel: '' as Ref<Mixin<ObjectChatPanel>>
+    ObjectChatPanel: '' as Ref<Mixin<ObjectChatPanel>>,
+    ChannelInfo: '' as Ref<Mixin<ChannelInfo>>
   },
   string: {
     Reactions: '' as IntlString,

--- a/plugins/notification-resources/src/components/NotificationPresenter.svelte
+++ b/plugins/notification-resources/src/components/NotificationPresenter.svelte
@@ -27,7 +27,7 @@
   $: notifyContext = $contextByDocStore.get(value._id)
   $: inboxNotifications = notifyContext ? $inboxNotificationsByContextStore.get(notifyContext._id) ?? [] : []
 
-  $: hasNotification = !notifyContext?.hidden && inboxNotifications.some(({ isViewed }) => !isViewed)
+  $: hasNotification = inboxNotifications.some(({ isViewed }) => !isViewed)
 </script>
 
 {#if hasNotification}

--- a/plugins/notification-resources/src/components/NotifyMarker.svelte
+++ b/plugins/notification-resources/src/components/NotifyMarker.svelte
@@ -14,19 +14,24 @@
 -->
 <script lang="ts">
   export let count: number = 0
-  export let size: 'small' | 'medium' = 'small'
+  export let kind: 'primary' | 'secondary' = 'primary'
+  export let size: 'x-small' | 'small' | 'medium' = 'small'
 
   const maxNumber = 9
 </script>
 
 {#if count > 0}
-  <div class="notifyMarker {size}">
+  <div class="notifyMarker {size} {kind}">
     {#if count > maxNumber}
       {maxNumber}+
     {:else}
       {count}
     {/if}
   </div>
+{/if}
+
+{#if count === 0 && kind === 'secondary'}
+  <div class="notifyMarker {size} {kind}" />
 {/if}
 
 <style lang="scss">
@@ -36,9 +41,21 @@
     justify-content: center;
     flex-shrink: 0;
     border-radius: 50%;
-    background-color: var(--global-higlight-Color);
-    color: var(--global-on-accent-TextColor);
     font-weight: 700;
+
+    &.primary {
+      background-color: var(--global-higlight-Color);
+      color: var(--global-on-accent-TextColor);
+    }
+
+    &.secondary {
+      background-color: var(--global-subtle-BackgroundColor);
+    }
+
+    &.x-small {
+      width: 0.75rem;
+      height: 0.75rem;
+    }
 
     &.small {
       width: 1rem;

--- a/plugins/notification-resources/src/inboxNotificationsClient.ts
+++ b/plugins/notification-resources/src/inboxNotificationsClient.ts
@@ -73,7 +73,7 @@ export class InboxNotificationsClientImpl implements InboxNotificationsClient {
       return inboxNotifications.reduce((result, notification) => {
         const notifyContext = notifyContexts.find(({ _id }) => _id === notification.docNotifyContext)
 
-        if (notifyContext === undefined || notifyContext.hidden) {
+        if (notifyContext === undefined) {
           return result
         }
 
@@ -207,13 +207,6 @@ export class InboxNotificationsClientImpl implements InboxNotificationsClient {
         }
       )
     }
-
-    await client.createDoc(notification.class.DocNotifyContext, doc.space, {
-      attachedTo: _id,
-      attachedToClass: _class,
-      user: getCurrentAccount()._id,
-      hidden: true
-    })
   }
 
   async readNotifications (client: TxOperations, ids: Array<Ref<InboxNotification>>): Promise<void> {

--- a/plugins/notification-resources/src/utils.ts
+++ b/plugins/notification-resources/src/utils.ts
@@ -87,16 +87,10 @@ export function loadNotificationSettings (): void {
 loadNotificationSettings()
 
 export async function hasDocNotifyContextPinAction (docNotifyContext: DocNotifyContext): Promise<boolean> {
-  if (docNotifyContext.hidden) {
-    return false
-  }
   return docNotifyContext.isPinned !== true
 }
 
 export async function hasDocNotifyContextUnpinAction (docNotifyContext: DocNotifyContext): Promise<boolean> {
-  if (docNotifyContext.hidden) {
-    return false
-  }
   return docNotifyContext.isPinned === true
 }
 

--- a/plugins/notification/src/index.ts
+++ b/plugins/notification/src/index.ts
@@ -276,7 +276,6 @@ export interface DocNotifyContext extends Doc {
   attachedTo: Ref<Doc>
   attachedToClass: Ref<Class<Doc>>
 
-  hidden: boolean
   isPinned?: boolean
   lastViewedTimestamp?: Timestamp
   lastUpdateTimestamp?: Timestamp

--- a/plugins/workbench-resources/src/components/navigator/SpacesNav.svelte
+++ b/plugins/workbench-resources/src/components/navigator/SpacesNav.svelte
@@ -91,7 +91,7 @@
   ): boolean {
     const context = notifyContextByDoc.get(space._id)
 
-    if (context === undefined || context.hidden) {
+    if (context === undefined) {
       return false
     }
 

--- a/plugins/workbench-resources/src/components/navigator/StarredNav.svelte
+++ b/plugins/workbench-resources/src/components/navigator/StarredNav.svelte
@@ -53,7 +53,7 @@
   ): boolean {
     const notifyContext = docUpdates.get(space._id)
     if (notifyContext === undefined) return false
-    return !notifyContext.hidden && !!inboxNotificationsByContext.get(notifyContext._id)?.length
+    return !!inboxNotificationsByContext.get(notifyContext._id)?.length
   }
   $: visibleSpace = spaces.find((space) => currentSpace === space._id)
 </script>

--- a/server-plugins/chunter-resources/src/index.ts
+++ b/server-plugins/chunter-resources/src/index.ts
@@ -14,8 +14,15 @@
 //
 
 import activity, { ActivityMessage, ActivityReference } from '@hcengineering/activity'
-import chunter, { Channel, ChatMessage, chunterId, ChunterSpace, ThreadMessage } from '@hcengineering/chunter'
-import { Person, PersonAccount } from '@hcengineering/contact'
+import chunter, {
+  Channel,
+  ChannelInfo,
+  ChatMessage,
+  chunterId,
+  ChunterSpace,
+  ThreadMessage
+} from '@hcengineering/chunter'
+import contact, { Person, PersonAccount } from '@hcengineering/contact'
 import core, {
   Account,
   AttachedDoc,
@@ -27,6 +34,7 @@ import core, {
   FindResult,
   Hierarchy,
   Ref,
+  Timestamp,
   Tx,
   TxCollectionCUD,
   TxCreateDoc,
@@ -34,9 +42,10 @@ import core, {
   TxMixin,
   TxProcessor,
   TxRemoveDoc,
-  TxUpdateDoc
+  TxUpdateDoc,
+  UserStatus
 } from '@hcengineering/core'
-import notification, { Collaborators, NotificationContent } from '@hcengineering/notification'
+import notification, { Collaborators, DocNotifyContext, NotificationContent } from '@hcengineering/notification'
 import { getMetadata, IntlString, translate } from '@hcengineering/platform'
 import serverCore, { TriggerControl } from '@hcengineering/server-core'
 import {
@@ -49,6 +58,9 @@ import { workbenchId } from '@hcengineering/workbench'
 
 import { NOTIFICATION_BODY_SIZE } from '@hcengineering/server-notification'
 import { encodeObjectURI } from '@hcengineering/view'
+
+const updateChatInfoDelay = 12 * 60 * 60 * 1000 // 12 hours
+const hideChannelDelay = 7 * 24 * 60 * 60 * 1000 // 7 days
 
 /**
  * @public
@@ -453,13 +465,201 @@ async function OnCollaboratorsChanged (tx: TxMixin<Doc, Collaborators>, control:
   return res
 }
 
+async function hideOldDirects (
+  directs: DocNotifyContext[],
+  control: TriggerControl,
+  date: Timestamp
+): Promise<TxMixin<DocNotifyContext, ChannelInfo>[]> {
+  const visibleDirects = directs.filter((context) => {
+    const hasMixin = control.hierarchy.hasMixin(context, chunter.mixin.ChannelInfo)
+    if (!hasMixin) return true
+    const info = control.hierarchy.as(context, chunter.mixin.ChannelInfo)
+
+    return !info.hidden
+  })
+
+  const minVisibleDirects = 10
+
+  if (visibleDirects.length <= minVisibleDirects) return []
+  const canHide = visibleDirects.length - minVisibleDirects
+
+  let toHide: DocNotifyContext[] = []
+
+  for (const context of directs) {
+    const { lastUpdateTimestamp = 0, lastViewedTimestamp = 0 } = context
+
+    if (lastUpdateTimestamp > lastViewedTimestamp) continue
+    if (date - lastUpdateTimestamp < hideChannelDelay) continue
+
+    toHide.push(context)
+  }
+
+  if (toHide.length > canHide) {
+    toHide = toHide.splice(0, toHide.length - canHide)
+  }
+
+  return await hideOldChannels(toHide, control)
+}
+
+async function hideOldActivityChannels (
+  contexts: DocNotifyContext[],
+  control: TriggerControl,
+  date: Timestamp
+): Promise<TxMixin<DocNotifyContext, ChannelInfo>[]> {
+  if (contexts.length === 0) return []
+
+  const { hierarchy } = control
+  const toHide: DocNotifyContext[] = []
+
+  for (const context of contexts) {
+    const { lastUpdateTimestamp = 0, lastViewedTimestamp = 0 } = context
+
+    if (lastUpdateTimestamp > lastViewedTimestamp) continue
+    console.log({ diff: date - lastUpdateTimestamp, delay: hideChannelDelay })
+    if (date - lastUpdateTimestamp < hideChannelDelay) continue
+
+    const params = hierarchy.as(context, chunter.mixin.ChannelInfo)
+    if (params.hidden) continue
+
+    toHide.push(context)
+  }
+
+  return await hideOldChannels(toHide, control)
+}
+
+async function hideOldChannels (
+  contexts: DocNotifyContext[],
+  control: TriggerControl
+): Promise<TxMixin<DocNotifyContext, ChannelInfo>[]> {
+  const res: TxMixin<DocNotifyContext, ChannelInfo>[] = []
+
+  for (const context of contexts) {
+    const tx = control.txFactory.createTxMixin(context._id, context._class, context.space, chunter.mixin.ChannelInfo, {
+      hidden: true
+    })
+    res.push(tx)
+  }
+
+  return res
+}
+
+async function updateChatInfo (control: TriggerControl, status: UserStatus, date: Timestamp): Promise<void> {
+  const account = await control.modelDb.findOne(contact.class.PersonAccount, { _id: status.user as Ref<PersonAccount> })
+  if (account === undefined) return
+
+  const chatUpdates = await control.queryFind(chunter.class.ChatInfo, {})
+  const update = chatUpdates.find(({ user }) => user === account.person)
+  const shouldUpdate = update === undefined || date - update.timestamp > updateChatInfoDelay
+
+  if (!shouldUpdate) return
+
+  const contexts = await control.findAll(notification.class.DocNotifyContext, {
+    user: account._id,
+    isPinned: { $ne: true }
+  })
+
+  if (contexts.length === 0) return
+
+  const { hierarchy } = control
+  const res: Tx[] = []
+
+  const directContexts = contexts.filter(({ attachedToClass }) =>
+    hierarchy.isDerived(attachedToClass, chunter.class.DirectMessage)
+  )
+  const activityContexts = contexts.filter(
+    ({ attachedToClass }) =>
+      !hierarchy.isDerived(attachedToClass, chunter.class.DirectMessage) &&
+      !hierarchy.isDerived(attachedToClass, chunter.class.Channel) &&
+      !hierarchy.isDerived(attachedToClass, chunter.class.Channel)
+  )
+
+  const directTxes = await hideOldDirects(directContexts, control, date)
+  const activityTxes = await hideOldActivityChannels(activityContexts, control, date)
+  const mixinTxes = directTxes.concat(activityTxes)
+  const hidden: Ref<DocNotifyContext>[] = mixinTxes.map((tx) => tx.objectId)
+
+  res.push(...mixinTxes)
+
+  if (update === undefined) {
+    res.push(
+      control.txFactory.createTxCreateDoc(chunter.class.ChatInfo, core.space.Workspace, {
+        user: account.person,
+        hidden,
+        timestamp: date
+      })
+    )
+  } else {
+    res.push(
+      control.txFactory.createTxUpdateDoc(update._class, update.space, update._id, {
+        hidden: Array.from(new Set(update.hidden.concat(hidden))),
+        timestamp: date
+      })
+    )
+  }
+
+  const txIds = res.map((tx) => tx._id)
+
+  await control.apply(res)
+
+  control.operationContext.derived.targets.docNotifyContext = (it) => {
+    if (txIds.includes(it._id)) {
+      return [account.email]
+    }
+  }
+}
+
+async function OnUserStatus (originTx: TxCUD<UserStatus>, control: TriggerControl): Promise<Tx[]> {
+  const tx = TxProcessor.extractTx(originTx) as TxCUD<UserStatus>
+  if (tx.objectClass !== core.class.UserStatus) return []
+  if (tx._class === core.class.TxCreateDoc) {
+    const createTx = tx as TxCreateDoc<UserStatus>
+    const { online } = createTx.attributes
+    if (online) {
+      const status = TxProcessor.createDoc2Doc(createTx)
+      await updateChatInfo(control, status, originTx.modifiedOn)
+    }
+  } else if (tx._class === core.class.TxUpdateDoc) {
+    const updateTx = tx as TxUpdateDoc<UserStatus>
+    const { online } = updateTx.operations
+    if (online === true) {
+      const status = (await control.findAll(core.class.UserStatus, { _id: updateTx.objectId }))[0]
+      await updateChatInfo(control, status, originTx.modifiedOn)
+    }
+  }
+
+  return []
+}
+
+async function OnContextUpdate (tx: TxUpdateDoc<DocNotifyContext>, control: TriggerControl): Promise<Tx[]> {
+  const hasUpdate = 'lastUpdateTimestamp' in tx.operations && tx.operations.lastUpdateTimestamp !== undefined
+  if (!hasUpdate) return []
+
+  const chatUpdates = await control.queryFind(chunter.class.ChatInfo, {})
+  for (const update of chatUpdates) {
+    if (update.hidden.includes(tx.objectId)) {
+      return [
+        control.txFactory.createTxMixin(tx.objectId, tx.objectClass, tx.objectSpace, chunter.mixin.ChannelInfo, {
+          hidden: false
+        }),
+        control.txFactory.createTxUpdateDoc(update._class, update.space, update._id, {
+          hidden: update.hidden.filter((id) => id !== tx.objectId)
+        })
+      ]
+    }
+  }
+
+  return []
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export default async () => ({
   trigger: {
     ChunterTrigger,
     OnChatMessageRemoved,
     OnChannelMembersChanged,
-    ChatNotificationsHandler
+    ChatNotificationsHandler,
+    OnUserStatus,
+    OnContextUpdate
   },
   function: {
     CommentRemove,

--- a/server-plugins/chunter-resources/src/index.ts
+++ b/server-plugins/chunter-resources/src/index.ts
@@ -411,14 +411,12 @@ async function OnChannelMembersChanged (tx: TxUpdateDoc<Channel>, control: Trigg
         attachedTo: tx.objectId,
         attachedToClass: tx.objectClass,
         user: addedMember,
-        hidden: false,
         lastViewedTimestamp: tx.modifiedOn
       })
 
       await control.apply([createTx])
     } else {
       const updateTx = control.txFactory.createTxUpdateDoc(context._class, context.space, context._id, {
-        hidden: false,
         lastViewedTimestamp: tx.modifiedOn
       })
 

--- a/server-plugins/chunter/src/index.ts
+++ b/server-plugins/chunter/src/index.ts
@@ -31,7 +31,9 @@ export default plugin(serverChunterId, {
     ChunterTrigger: '' as Resource<TriggerFunc>,
     OnChatMessageRemoved: '' as Resource<TriggerFunc>,
     OnChannelMembersChanged: '' as Resource<TriggerFunc>,
-    ChatNotificationsHandler: '' as Resource<TriggerFunc>
+    ChatNotificationsHandler: '' as Resource<TriggerFunc>,
+    OnUserStatus: '' as Resource<TriggerFunc>,
+    OnContextUpdate: '' as Resource<TriggerFunc>
   },
   function: {
     CommentRemove: '' as Resource<ObjectDDParticipantFunc>,

--- a/server-plugins/gmail-resources/src/index.ts
+++ b/server-plugins/gmail-resources/src/index.ts
@@ -95,8 +95,7 @@ export async function OnMessageCreate (tx: Tx, control: TriggerControl): Promise
         // )
         res.push(
           control.txFactory.createTxUpdateDoc(doc._class, doc.space, doc._id, {
-            lastUpdateTimestamp: tx.modifiedOn,
-            hidden: false
+            lastUpdateTimestamp: tx.modifiedOn
           })
         )
       }
@@ -106,7 +105,6 @@ export async function OnMessageCreate (tx: Tx, control: TriggerControl): Promise
             user: tx.modifiedBy,
             attachedTo: channel._id,
             attachedToClass: channel._class,
-            hidden: false,
             lastUpdateTimestamp: tx.modifiedOn
             // TODO: push inbox notification
             // txes: [

--- a/server-plugins/notification-resources/src/index.ts
+++ b/server-plugins/notification-resources/src/index.ts
@@ -349,9 +349,6 @@ export async function pushInboxNotifications (
   }
   const context = getDocNotifyContext(contexts, account._id, attachedTo, res)
 
-  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-  const isHidden = !!context?.hidden
-
   let docNotifyContextId: Ref<DocNotifyContext>
 
   if (context === undefined) {
@@ -359,7 +356,6 @@ export async function pushInboxNotifications (
       user: account._id,
       attachedTo,
       attachedToClass,
-      hidden: false,
       lastUpdateTimestamp: shouldUpdateTimestamp ? modifiedOn : undefined
     })
     await control.apply([createContextTx])
@@ -389,18 +385,16 @@ export async function pushInboxNotifications (
     docNotifyContextId = context._id
   }
 
-  if (!isHidden) {
-    const notificationData = {
-      user: account._id,
-      isViewed: false,
-      docNotifyContext: docNotifyContextId,
-      ...data
-    }
-    const notificationTx = control.txFactory.createTxCreateDoc(_class, space, notificationData)
-    res.push(notificationTx)
-
-    return notificationTx
+  const notificationData = {
+    user: account._id,
+    isViewed: false,
+    docNotifyContext: docNotifyContextId,
+    ...data
   }
+  const notificationTx = control.txFactory.createTxCreateDoc(_class, space, notificationData)
+  res.push(notificationTx)
+
+  return notificationTx
 }
 
 async function activityInboxNotificationToText (

--- a/server-plugins/telegram-resources/src/index.ts
+++ b/server-plugins/telegram-resources/src/index.ts
@@ -90,8 +90,7 @@ export async function OnMessageCreate (tx: Tx, control: TriggerControl): Promise
         // )
         res.push(
           control.txFactory.createTxUpdateDoc(doc._class, doc.space, doc._id, {
-            lastUpdateTimestamp: tx.modifiedOn,
-            hidden: false
+            lastUpdateTimestamp: tx.modifiedOn
           })
         )
       }
@@ -101,7 +100,6 @@ export async function OnMessageCreate (tx: Tx, control: TriggerControl): Promise
             user: tx.modifiedBy,
             attachedTo: channel._id,
             attachedToClass: channel._class,
-            hidden: false,
             lastUpdateTimestamp: tx.modifiedOn
             // TODO: push inbox notifications
             // txes: [

--- a/services/github/pod-github/src/notifications.ts
+++ b/services/github/pod-github/src/notifications.ts
@@ -28,9 +28,6 @@ export async function createNotification (
     props: data.props
   })
   if (existing !== undefined) {
-    await client.update(docNotifyContext as DocNotifyContext, {
-      lastUpdateTimestamp: Date.now()
-    })
     await client.update(existing, {
       isViewed: false
     })

--- a/services/github/pod-github/src/notifications.ts
+++ b/services/github/pod-github/src/notifications.ts
@@ -14,7 +14,6 @@ export async function createNotification (
     const docNotifyContextId = await client.createDoc(notification.class.DocNotifyContext, forDoc.space, {
       attachedTo: forDoc._id,
       attachedToClass: forDoc._class,
-      hidden: false,
       user: data.user,
       isPinned: false
     })


### PR DESCRIPTION
- Hide channels (directs or activity channels) if no activity 1 week
- Do not hide directs if there are less than 10 (as Slack)
- Check channels last activity on UserStatus online no more than once every 12 hours
- Add secondary notification marker on channels if channel has new messages, but now notifications for them (if notifications disabled by settings)
<img width="429" alt="Screenshot 2024-07-29 at 23 08 09" src="https://github.com/user-attachments/assets/6a75f12e-0979-42a6-be7e-1837d41d7497">

