### PR TITLE
Show all channels and directs in navigator

### DIFF
--- a/plugins/chunter-resources/src/components/chat/navigator/ChatNavGroup.svelte
+++ b/plugins/chunter-resources/src/components/chat/navigator/ChatNavGroup.svelte
@@ -87,7 +87,7 @@
       const ids = ctx.map(({ attachedTo }) => attachedTo)
       const { query, limit } = objectsQueryByClass.get(_class) ?? {
         query: createQuery(),
-        limit: model.maxSectionItems ?? 5
+        limit: hierarchy.isDerived(_class, chunter.class.ChunterSpace) ? -1 : model.maxSectionItems ?? 5
       }
 
       objectsQueryByClass.set(_class, { query, limit: limit ?? model.maxSectionItems ?? 5 })


### PR DESCRIPTION
We shouldn't use show more for channels/directs because they are sorted alphabetically and user can skip notifications
