### PR TITLE
UBERF-7745 Fix otp code paste in mobile browsers

### DIFF
--- a/packages/ui/src/components/CodeInput.svelte
+++ b/packages/ui/src/components/CodeInput.svelte
@@ -31,7 +31,6 @@
     on:change
     on:keyup
     on:input
-    maxlength={1}
     inputmode="numeric"
     autocomplete="off"
     placeholder=""

--- a/plugins/login-resources/src/components/OtpForm.svelte
+++ b/plugins/login-resources/src/components/OtpForm.svelte
@@ -81,20 +81,26 @@
 
     if (value == null || value === '') return
 
-    const index = fields.findIndex(({ id }) => id === target.id)
-    if (index === -1) return
+    if (value.length === fields.length) {
+      pasteOtpCode(value)
+    } else {
+      const index = fields.findIndex(({ id }) => id === target.id)
+      if (index === -1) return
 
-    if (Object.values(otpData).every((v) => v !== '')) {
-      void validateOtp()
-      return
-    }
+      target.value = value[0]
 
-    const nextField = fields[index + 1]
-    if (nextField === undefined) return
+      if (Object.values(otpData).every((v) => v !== '')) {
+        void validateOtp()
+        return
+      }
 
-    const nextInput = formElement?.querySelector(`input[name="${nextField.name}"]`) as HTMLInputElement
-    if (nextInput != null) {
-      nextInput.focus()
+      const nextField = fields[index + 1]
+      if (nextField === undefined) return
+
+      const nextInput = formElement?.querySelector(`input[name="${nextField.name}"]`) as HTMLInputElement
+      if (nextInput != null) {
+        nextInput.focus()
+      }
     }
   }
 
@@ -139,9 +145,15 @@
     if (e.clipboardData == null) return
 
     const text = e.clipboardData.getData('text')
+    pasteOtpCode(text)
+  }
+
+  function pasteOtpCode (text: string): boolean {
     const digits = text.split('').filter((it) => it !== ' ')
 
-    if (digits.length !== fields.length) return
+    if (digits.length !== fields.length) {
+      return false
+    }
 
     let focusName: string | undefined = undefined
 
@@ -160,6 +172,8 @@
     if (Object.values(otpData).every((v) => v !== '')) {
       void validateOtp()
     }
+
+    return true
   }
 
   $: if (formElement != null) {


### PR DESCRIPTION
When pasting code, mobile browsers produce not `paste` event, but instead they change the input's value.
In this PR I made the following changes:

1. Removed 1 digit limit from the input
2. Handled change event to keep paste the OTP when the entire code is inserted, otherwise keep only the first digit

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmE5ZGRiY2RhNTY1NDI5ZDY2MjVlMTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.zO_RdofEq3tszTZTG6UaSjDwW0R27nZc5Nb_zG2tVvI">Huly&reg;: <b>UBERF-7746</b></a></sub>