### PR TITLE
UBERF-7747 Fix ref input max size

### DIFF
--- a/plugins/attachment-resources/src/components/AttachmentRefInput.svelte
+++ b/plugins/attachment-resources/src/components/AttachmentRefInput.svelte
@@ -323,7 +323,7 @@
   }
 </script>
 
-<div class="no-print" bind:this={refContainer}>
+<div class="flex-col no-print" bind:this={refContainer}>
   <input
     bind:this={inputFile}
     disabled={inputFile == null}
@@ -336,7 +336,7 @@
   />
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div
-    class="container"
+    class="flex-col"
     on:dragover|preventDefault={() => {}}
     on:dragleave={() => {}}
     on:drop|preventDefault|stopPropagation={fileDrop}

--- a/plugins/chunter-resources/src/components/ChannelScrollView.svelte
+++ b/plugins/chunter-resources/src/components/ChannelScrollView.svelte
@@ -783,7 +783,7 @@
     {/if}
   </div>
   {#if object}
-    <div class="ref-input">
+    <div class="ref-input flex-col">
       <ActivityExtensionComponent
         kind="input"
         {extensions}
@@ -800,7 +800,9 @@
   }
 
   .ref-input {
+    flex-shrink: 0;
     margin: 1.25rem 1rem 1rem;
+    max-height: 18.75rem;
   }
 
   .overlay {

--- a/plugins/text-editor-resources/src/components/ReferenceInput.svelte
+++ b/plugins/text-editor-resources/src/components/ReferenceInput.svelte
@@ -28,7 +28,7 @@
   import { createEventDispatcher } from 'svelte'
   import { FocusPosition } from '@tiptap/core'
   import { EditorView } from '@tiptap/pm/view'
-  import textEditor, { RefAction, TextEditorHandler, TextFormatCategory } from '@hcengineering/text-editor'
+  import textEditor, { RefAction, TextEditorHandler } from '@hcengineering/text-editor'
 
   import { Completion } from '../Completion'
   import TextEditor from './TextEditor.svelte'
@@ -246,13 +246,13 @@
   }
 
   .text-input {
-    max-height: 18.75rem;
     overflow: auto;
     min-height: 2.75rem;
     padding: 0.125rem 0.75rem;
   }
 
   .buttons-panel {
+    flex-shrink: 0;
     padding: 0.325rem 0.75rem;
   }
 </style>


### PR DESCRIPTION
1. Remove max-height for ref input
2. Limit ref input height in chat

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmE5ZjQzNWRhNTY1NDI5ZDY2MjVmNjciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.3pZ2N_puHqeho_20j1glTO08aHrPpb4XdC0JDxjOvvU">Huly&reg;: <b>UBERF-7751</b></a></sub>