### PR TITLE
UBERF-7755: Fix image toolbar visibility

### DIFF
--- a/plugins/text-editor-resources/src/components/CollaborativeTextEditor.svelte
+++ b/plugins/text-editor-resources/src/components/CollaborativeTextEditor.svelte
@@ -416,6 +416,7 @@
             toolbar: {
               element: imageToolbarElement,
               boundary,
+              appendTo: () => boundary ?? element,
               isHidden: () => !showToolbar
             }
           }

--- a/plugins/text-editor-resources/src/kits/editor-kit.ts
+++ b/plugins/text-editor-resources/src/kits/editor-kit.ts
@@ -41,6 +41,7 @@ export interface EditorKitOptions extends DefaultKitOptions {
     toolbar?: {
       element: HTMLElement
       boundary?: HTMLElement
+      appendTo?: HTMLElement | (() => HTMLElement)
       isHidden?: () => boolean
     }
   })
@@ -232,7 +233,10 @@ async function buildEditorKit (): Promise<Extension<EditorKitOptions, any>> {
                 if (this.options.image?.toolbar !== undefined) {
                   imageOptions.toolbar = {
                     ...this.options.image?.toolbar,
-                    tippyOptions: getTippyOptions(this.options.image?.toolbar?.boundary)
+                    tippyOptions: getTippyOptions(
+                      this.options.image?.toolbar?.boundary,
+                      this.options.image?.toolbar?.appendTo
+                    )
                   }
                 }
 


### PR DESCRIPTION
* Fixes image toolbar visibility when the image preview dialog is open

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-7755
Closes: https://github.com/hcengineering/platform/issues/6205

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmFhNmIyZmRhNTY1NDI5ZDY2MjY0MDEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.xHSBM0Rec_FwNl-H6qF-3_f1wAZBccpRINo0GBR_JAE">Huly&reg;: <b>UBERF-7758</b></a></sub>