### PR TITLE
fix: drive UX fixes

### DIFF
--- a/packages/presentation/src/components/FilePreview.svelte
+++ b/packages/presentation/src/components/FilePreview.svelte
@@ -82,7 +82,7 @@
   use:resizeObserver={(element) => (parentWidth = element.clientWidth)}
   class="content w-full h-full"
   class:flex-center={fit && !audio}
-  style:min-height={fit ? '100%' : `${minHeight ?? 0}px`}
+  style:min-height={fit ? '0' : `${minHeight ?? 0}px`}
 >
   {#await srcRef then src}
     {#if src === ''}

--- a/plugins/drive-resources/src/components/EditFile.svelte
+++ b/plugins/drive-resources/src/components/EditFile.svelte
@@ -50,7 +50,7 @@
 
 {#if object !== undefined && version !== undefined}
   {#if blob !== undefined}
-    <FilePreview file={blob} name={version.name} metadata={version.metadata} />
+    <FilePreview file={blob} name={version.name} metadata={version.metadata} fit />
   {/if}
 
   {#if object.versions > 1}

--- a/plugins/drive-resources/src/components/EditFileVersions.svelte
+++ b/plugins/drive-resources/src/components/EditFileVersions.svelte
@@ -13,7 +13,7 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  import { FindOptions, SortingOrder } from '@hcengineering/core'
+  import core, { FindOptions, SortingOrder } from '@hcengineering/core'
   import { type File, type FileVersion } from '@hcengineering/drive'
   import { Scroller, Section } from '@hcengineering/ui'
   import { Table } from '@hcengineering/view-resources'
@@ -24,6 +24,7 @@
   export let readonly: boolean = false
 
   const options: FindOptions<FileVersion> = {
+    lookup: { file: core.class.Blob },
     sort: { version: SortingOrder.Descending }
   }
 </script>
@@ -34,7 +35,7 @@
       <Scroller horizontal>
         <Table
           _class={drive.class.FileVersion}
-          config={['version', 'size', 'modifiedOn', 'createdBy']}
+          config={['', 'size', 'modifiedOn', 'createdBy']}
           query={{ attachedTo: object._id }}
           {readonly}
           {options}

--- a/plugins/drive-resources/src/components/FileVersionPresenter.svelte
+++ b/plugins/drive-resources/src/components/FileVersionPresenter.svelte
@@ -15,13 +15,16 @@
 //
 -->
 <script lang="ts">
+  import { WithLookup } from '@hcengineering/core'
   import { type FileVersion } from '@hcengineering/drive'
+  import { FilePreviewPopup } from '@hcengineering/presentation'
+  import { showPopup } from '@hcengineering/ui'
   import { ObjectPresenterType } from '@hcengineering/view'
   import { DocNavLink, ObjectMention } from '@hcengineering/view-resources'
 
   import { formatFileVersion } from '../utils'
 
-  export let value: FileVersion
+  export let value: WithLookup<FileVersion>
   export let inline: boolean = false
   export let disabled: boolean = false
   export let accent: boolean = false
@@ -29,13 +32,36 @@
   export let type: ObjectPresenterType = 'link'
 
   $: version = formatFileVersion(value.version)
+
+  function handleClick (): void {
+    if (disabled) {
+      return
+    }
+
+    if (value.$lookup?.file === undefined) {
+      return
+    }
+
+    const blob = value.$lookup?.file
+
+    showPopup(
+      FilePreviewPopup,
+      {
+        file: blob._id,
+        contentType: blob.contentType,
+        name: value.name,
+        metadata: value.metadata
+      },
+      'centered'
+    )
+  }
 </script>
 
 {#if value}
   {#if inline}
     <ObjectMention object={value} {disabled} {accent} {noUnderline} />
   {:else if type === 'link'}
-    <DocNavLink object={value} {disabled} {accent} {noUnderline}>
+    <DocNavLink object={value} onClick={handleClick} {disabled} {accent} {noUnderline}>
       <div class="flex-presenter">
         <div class="label nowrap flex flex-gap-2" class:no-underline={noUnderline || disabled} class:fs-bold={accent}>
           {version}

--- a/services/love/src/workspaceClient.ts
+++ b/services/love/src/workspaceClient.ts
@@ -67,7 +67,13 @@ export class WorkspaceClient {
         name,
         size: blob.size,
         type: blob.contentType,
-        lastModified: blob.modifiedOn
+        lastModified: blob.modifiedOn,
+        // hardcoded values from preset we use
+        // https://docs.livekit.io/realtime/egress/overview/#EncodingOptionsPreset
+        metadata: {
+          originalHeight: 720,
+          originalWidth: 1280
+        }
       }
       await createFile(this.client, love.space.Drive, drive.ids.Root, data)
     }


### PR DESCRIPTION
this PR makes several fixes in Drive UX:

1. Adjust preview size
2. When uploading love recording to drive, provide default metadata so we know video size
3. Show file version preview on version click

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmFiMmFjZmRhNTY1NDI5ZDY2MjY1MzkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.7JoZEt4w-k3S8GVpXo6eO8ujIDeJCalyW0xZvuefRBU">Huly&reg;: <b>UBERF-7763</b></a></sub>