### PR TITLE
UBERF-7829 Fix embedded image preview

### DIFF
--- a/packages/presentation/src/components/FilePreviewPopup.svelte
+++ b/packages/presentation/src/components/FilePreviewPopup.svelte
@@ -21,7 +21,7 @@
   import presentation from '../plugin'
 
   import { BlobMetadata } from '../types'
-  import { getClient, getFileUrl } from '../utils'
+  import { getFileUrl } from '../utils'
 
   import ActionContext from './ActionContext.svelte'
   import FilePreview from './FilePreview.svelte'
@@ -36,7 +36,6 @@
   export let fullSize = false
   export let showIcon = true
 
-  const client = getClient()
   const dispatch = createEventDispatcher()
 
   let download: HTMLAnchorElement

--- a/packages/text/src/nodes/file.ts
+++ b/packages/text/src/nodes/file.ts
@@ -71,18 +71,6 @@ export const FileNode = Node.create<FileOptions>({
     return [
       {
         tag: `div[data-type="${this.name}"]`
-      },
-      {
-        tag: 'div[data-file-name]'
-      },
-      {
-        tag: 'div[data-file-size]'
-      },
-      {
-        tag: 'div[data-file-type]'
-      },
-      {
-        tag: 'div[data-file-href]'
       }
     ]
   },

--- a/packages/text/src/nodes/image.ts
+++ b/packages/text/src/nodes/image.ts
@@ -73,7 +73,10 @@ export const ImageNode = Node.create<ImageOptions>({
       title: {
         default: null
       },
-      align: getDataAttribute('align')
+      align: getDataAttribute('align'),
+      'data-file-type': {
+        default: null
+      }
     }
   },
 
@@ -120,7 +123,9 @@ export const ImageNode = Node.create<ImageOptions>({
       }
 
       for (const [k, v] of Object.entries(divAttributes)) {
-        container.setAttribute(k, v)
+        if (v !== null) {
+          container.setAttribute(k, v)
+        }
       }
 
       const imgAttributes = mergeAttributes(

--- a/packages/text/src/nodes/utils.ts
+++ b/packages/text/src/nodes/utils.ts
@@ -28,9 +28,8 @@ export function getDataAttribute (
     default: null,
     parseHTML: (element) => element.getAttribute(dataName),
     renderHTML: (attributes) => {
-      // eslint-disable-next-line
-      if (!attributes[name]) {
-        return {}
+      if (attributes[name] == null) {
+        return null
       }
 
       return {

--- a/plugins/text-editor-resources/src/components/extension/fileExt.ts
+++ b/plugins/text-editor-resources/src/components/extension/fileExt.ts
@@ -53,15 +53,6 @@ export const FileExtension = FileNode.extend<FileOptions>({
     return [
       {
         tag: `div[data-type="${this.name}"]`
-      },
-      {
-        tag: 'div[data-file-name]'
-      },
-      {
-        tag: 'div[data-file-size]'
-      },
-      {
-        tag: 'div[data-file-type]'
       }
     ]
   },

--- a/plugins/text-editor-resources/src/components/extension/imageExt.ts
+++ b/plugins/text-editor-resources/src/components/extension/imageExt.ts
@@ -151,7 +151,7 @@ export const ImageExtension = ImageNode.extend<ImageOptions>({
 
             const fileId = node.attrs['file-id'] ?? node.attrs.src
             const fileName = node.attrs.alt ?? ''
-            const fileType = node.attrs['data-file-type'] ?? ''
+            const fileType = node.attrs['data-file-type'] ?? 'image/*'
 
             showPopup(
               FilePreviewPopup,
@@ -211,7 +211,7 @@ export async function openImage (editor: Editor): Promise<void> {
   const attributes = editor.getAttributes('image')
   const fileId = attributes['file-id'] ?? attributes.src
   const fileName = attributes.alt ?? ''
-  const fileType = attributes['data-file-type'] ?? ''
+  const fileType = attributes['data-file-type'] ?? 'image/*'
   await new Promise<void>((resolve) => {
     showPopup(
       FilePreviewPopup,

--- a/plugins/text-editor-resources/src/components/extension/imageUploadExt.ts
+++ b/plugins/text-editor-resources/src/components/extension/imageUploadExt.ts
@@ -153,7 +153,10 @@ async function handleImageUpload (
     const size = await getImageSize(file)
     const node = view.state.schema.nodes.image.create({
       'file-id': attached.file,
+      'data-file-type': file.type,
       src: url,
+      alt: file.name,
+      title: file.name,
       width: Math.round(size.width / size.pixelRatio)
     })
 

--- a/services/github/pod-github/src/markdown/__tests__/textmodel.test.ts
+++ b/services/github/pod-github/src/markdown/__tests__/textmodel.test.ts
@@ -755,7 +755,8 @@ A list of closed updated issues`
                         align: null,
                         height: null,
                         title: null,
-                        'file-id': null
+                        'file-id': null,
+                        'data-file-type': null
                       }
                     }
                   ]


### PR DESCRIPTION
1. Save file type when uploading image
2. Fallback to image/* media type for images that does not have type attribute

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmIzMTNmOGU1NTRjZjllNTY4ZmFhZDkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.fr-J-9Fw1ykzzCkmZ6yZ6NO2zOApBoTL44J6oXmxDpQ">Huly&reg;: <b>UBERF-7830</b></a></sub>