### PR TITLE
EZQMS-1029: Fix permissions check

### DIFF
--- a/plugins/controlled-documents-resources/src/components/hierarchy/DocumentSpacePresenter.svelte
+++ b/plugins/controlled-documents-resources/src/components/hierarchy/DocumentSpacePresenter.svelte
@@ -39,7 +39,8 @@
     setCurrentProject,
     getProjectDocsHierarchy,
     isEditableProject,
-    createDocument
+    createDocument,
+    canCreateChildDocument
   } from '../../utils'
 
   import documents from '../../plugin'
@@ -129,17 +130,19 @@
   async function getSpaceActions (space: DocumentSpace): Promise<Action[]> {
     const actions = await getActions(space)
 
-    const action: Action = {
-      icon: documents.icon.NewDocument,
-      label: documents.string.CreateDocument,
-      group: 'create',
-      action: async () => {
-        await createDocument(space)
-      }
-    }
-
-    if (spaceType?.projects === true && (await isEditableProject(project))) {
-      actions.push(action)
+    if (
+      spaceType?.projects === true &&
+      (await isEditableProject(project)) &&
+      (await canCreateChildDocument(space, true))
+    ) {
+      actions.push({
+        icon: documents.icon.NewDocument,
+        label: documents.string.CreateDocument,
+        group: 'create',
+        action: async () => {
+          await createDocument(space)
+        }
+      })
     }
 
     return orderActions(actions)

--- a/plugins/controlled-documents-resources/src/utils.ts
+++ b/plugins/controlled-documents-resources/src/utils.ts
@@ -605,7 +605,8 @@ export async function canCreateChildTemplate (
 }
 
 export async function canCreateChildDocument (
-  doc?: Document | Document[] | DocumentSpace | DocumentSpace[] | ProjectDocument | ProjectDocument[]
+  doc?: Document | Document[] | DocumentSpace | DocumentSpace[] | ProjectDocument | ProjectDocument[],
+  includeProjects = false
 ): Promise<boolean> {
   if (doc === null || doc === undefined) {
     return false
@@ -625,7 +626,7 @@ export async function canCreateChildDocument (
 
   if (isSpace(hierarchy, doc)) {
     const spaceType = await client.findOne(documents.class.DocumentSpaceType, { _id: doc.type })
-    return spaceType?.projects !== true
+    return includeProjects || spaceType?.projects !== true
   }
 
   if (isProjectDocument(hierarchy, doc)) {


### PR DESCRIPTION
* Fixes permissions check for creating project doc from context menu action

Related to: https://front.hc.engineering/workbench/platform/tracker/EZQMS-1029

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmIzNzI3ZTllYmQxNjllZWExZmQ4YjEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.ozeAnitnEdIy4G52xzAdMB0eoEOyyStmDjcCMMSsr90">Huly&reg;: <b>UBERF-7834</b></a></sub>