### PR TITLE
UBERF-7718: do not use lookup if RefPresenter is set

### DIFF
--- a/plugins/view-resources/src/components/ViewletSetting.svelte
+++ b/plugins/view-resources/src/components/ViewletSetting.svelte
@@ -148,13 +148,14 @@
     return result
   }
 
-  function getValue (name: string, type: Type<any>): string {
+  function getValue (name: string, type: Type<any>, attrClass: Ref<Class<Doc>>): string {
+    const presenter = hierarchy.classHierarchyMixin(attrClass, view.mixin.AttributePresenter)?.presenter
+    if (presenter !== undefined) {
+      return name
+    }
     if (hierarchy.isDerived(type._class, core.class.RefTo)) {
       return '$lookup.' + name
     }
-    // if (hierarchy.isDerived(type._class, core.class.ArrOf)) {
-    //   return getValue(name, (type as ArrOf<any>).of)
-    // }
     return name
   }
 
@@ -162,14 +163,14 @@
     if (attribute.hidden === true || attribute.label === undefined) return
     if (viewlet.configOptions?.hiddenKeys?.includes(attribute.name)) return
     if (hierarchy.isDerived(attribute.type._class, core.class.Collection)) return
-    const value = getValue(attribute.name, attribute.type)
+    const { attrClass, category } = getAttributePresenterClass(hierarchy, attribute)
+    const value = getValue(attribute.name, attribute.type, attrClass)
     for (const res of result) {
       const key = typeof res.value === 'string' ? res.value : res.value?.key
       if (key === undefined) return
       if (key === attribute.name) return
       if (key === value) return
     }
-    const { attrClass, category } = getAttributePresenterClass(hierarchy, attribute)
     const mixin =
       category === 'object'
         ? view.mixin.ObjectPresenter


### PR DESCRIPTION
check for existing AttributePresenter and use it instead of requesting the full object

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmI0YWYzNmYxMGY5OWNkMGIyOWE0YjMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0.6VSei8dJhRYvUvBObjnLSFilPwUM1WYilSAD8hX448A">Huly&reg;: <b>UBERF-7840</b></a></sub>