### PR TITLE
Qfix: change default filter for my docs in controlled documents

### DIFF
--- a/models/controlled-documents/src/index.ts
+++ b/models/controlled-documents/src/index.ts
@@ -164,8 +164,8 @@ export function createModel (builder: Builder): void {
                 [documents.mixin.DocumentTemplate]: { $exists: false }
               },
               config: [
-                ['effective', documents.string.Effective, {}],
                 ['inProgress', documents.string.InProgress, {}],
+                ['effective', documents.string.Effective, {}],
                 ['archived', documents.string.Archived, {}],
                 ['all', documents.string.All, {}]
               ]


### PR DESCRIPTION
* Changes default filter for my docs in controlled documents

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmI0YjZkYWYxMGY5OWNkMGIyOWE0ZjYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIiwicHJvZHVjdElkIjoiIn0._1ftakJ6BRKISbgUe2sPZ2Gb3-LhO6ZmgzaiyFj1c_w">Huly&reg;: <b>UBERF-7841</b></a></sub>