### PR TITLE
Qfix: disable old workspaces

### DIFF
--- a/server/account/src/operations.ts
+++ b/server/account/src/operations.ts
@@ -1050,6 +1050,28 @@ export async function setWorkspaceDisabled (db: Db, workspaceId: Workspace['_id'
   await db.collection<Workspace>(WORKSPACE_COLLECTION).updateOne({ _id: workspaceId }, { $set: { disabled } })
 }
 
+/**
+ * @public
+ */
+export async function setWorkspaceDisabledByWs (
+  db: Db,
+  workspace: Workspace['workspace'],
+  disabled: boolean,
+  uniqueOnly: boolean = true
+): Promise<boolean> {
+  if (uniqueOnly) {
+    const collectionsCount = await db.collection<Workspace>(WORKSPACE_COLLECTION).countDocuments({ workspace })
+
+    if (collectionsCount > 1) {
+      return false
+    }
+  }
+
+  await db.collection<Workspace>(WORKSPACE_COLLECTION).updateOne({ workspace }, { $set: { disabled } })
+
+  return true
+}
+
 export async function cleanInProgressWorkspaces (db: Db): Promise<void> {
   const toDelete = await db.collection<Workspace>(WORKSPACE_COLLECTION).find({ creating: true }).toArray()
 


### PR DESCRIPTION
* Adds a tool to disable old workspaces with `productId` in the DB

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmM4OTU5MWM3MzIyZmIwZWQ0MWRmNzUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.T3Qxtw0WdulAqeBiXO2RxLG5rySDCQMnhy_cd1MXOj4">Huly&reg;: <b>UBERF-7936</b></a></sub>