### PR TITLE
Add tests for 'is typing...' status in channels

### DIFF
--- a/tests/sanity/tests/model/channel-page.ts
+++ b/tests/sanity/tests/model/channel-page.ts
@@ -14,6 +14,7 @@ export class ChannelPage extends CommonPage {
   readonly textMessage = (messageText: string): Locator =>
     this.page.locator('.hulyComponent .activityMessage', { hasText: messageText })
 
+  readonly typingMessage = (text: string): Locator => this.page.locator(`span:has-text("${text}")`)
   readonly channelName = (channel: string): Locator => this.page.getByText('general random').getByText(channel)
   readonly channelTab = (): Locator => this.page.getByRole('link', { name: 'Channels' }).getByRole('button')
   readonly channelTable = (): Locator => this.page.getByRole('table')
@@ -160,6 +161,14 @@ export class ChannelPage extends CommonPage {
 
   async checkIfMessageIsCopied (message: string): Promise<void> {
     expect(this.getClipboardCopyMessage()).toContain(message)
+  }
+
+  async checkIfTypingMessageHasText (message: string, expectHidden = false): Promise<void> {
+    if (expectHidden) {
+      await expect(this.typingMessage(message)).toBeHidden()
+    } else {
+      await expect(this.typingMessage(message)).toBeVisible()
+    }
   }
 
   async clickChooseChannel (channel: string): Promise<void> {


### PR DESCRIPTION
**Add tests for [this PR](https://github.com/hcengineering/platform/pull/6373)**. 

I've added this PR to comply with this project structure and maybe work with us if you're interested.

About PR:
- Create a test suite inside the channel tests file. It contains some tests for the "[username] is typing..." feature
- Work with the current user and 2 temporary users. I've named them Alice and Bob, it's just for fun, I can rename them to user1 and user2 if necessary.
- Use existing methods for now. I think it's possible to create more page object's methods in the future to make my code and the code in this file more compact. I will be happy to do this if we continue to connect.
- I decided to group tests in this case, it doesn't look atomic enough, but I need to check, maybe I will be better to remove nested beforeEach and redesign it.

I hope this PR will be helpful for the team.
I'm going to keeping it in Draft, want to check test running in CI and maybe fix problems.