### PR TITLE
fix: wrap lines in codeblock

### DIFF
--- a/packages/theme/styles/prose.scss
+++ b/packages/theme/styles/prose.scss
@@ -360,8 +360,10 @@ table.proseTable {
   padding: .5rem;
   user-select: text;
   cursor: auto;
+}
 
-  pre { white-space: pre-wrap; }
+pre.proseCodeBlock {
+  white-space: pre-wrap;
 }
 
 // Fixes for MessageViewer


### PR DESCRIPTION
Before
<img width="666" src="https://github.com/user-attachments/assets/2d95beb0-3419-4e2e-adc5-5cd84e60279e" alt="Screenshot 2024-08-27 at 23 19 41">

After
<img width="699" src="https://github.com/user-attachments/assets/23c1389a-8e3c-42e2-b521-545dbc2a0241" alt="Screenshot 2024-08-27 at 23 19 23">

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmNkZmNiYjdhYmM5ZjVjYmY1ZWIzY2EiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.xWJM8QaT75x8T3hNq6kNzsJMQTEfbJB6DpPBBl5xFEI">Huly&reg;: <b>UBERF-7957</b></a></sub>