### PR TITLE
fix: improve codeblock wrapping

### DIFF
--- a/packages/theme/styles/prose.scss
+++ b/packages/theme/styles/prose.scss
@@ -364,6 +364,8 @@ table.proseTable {
 
 pre.proseCodeBlock {
   white-space: pre-wrap;
+  word-wrap: break-word;
+  word-break: normal;
 }
 
 // Fixes for MessageViewer


### PR DESCRIPTION
<img width="556" src="https://github.com/user-attachments/assets/ad154f00-d1ef-440a-b743-59d01d6d5bbc" alt="Screenshot 2024-08-29 at 14 16 14">

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmQwMjA0ZmFjY2U3NzU1MjYyZmM0NTkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.cLlQmrNua5rLfW4dJ0sd5vrXhTi3cRdGW-AQOjj6d7k">Huly&reg;: <b>UBERF-7992</b></a></sub>