### PR TITLE
UBERF-8005: Add tracker projects e2e tests

### DIFF
--- a/tests/sanity/tests/model/tracker/all-projects-page.ts
+++ b/tests/sanity/tests/model/tracker/all-projects-page.ts
@@ -1,0 +1,21 @@
+
+import { expect, type Locator } from '@playwright/test'
+import { CommonTrackerPage } from './common-tracker-page'
+
+export class AllProjectsPage extends CommonTrackerPage {
+  projectTitleColumns = (): Locator => this.page.locator('.antiTable-body__row .antiTable-cells__firstCell')
+
+  async checkProjectExistInTable (projectName: string): Promise<void> {
+    await expect(this.projectTitleColumns().filter({ hasText: projectName })).toBeVisible()
+  }
+
+  async checkProjectNotExistInTable (projectName: string): Promise<void> {
+    await expect(this.projectTitleColumns().filter({ hasText: projectName })).toBeHidden()
+  }
+
+  async joinProject (title: string): Promise<void> {
+    const projectRow = this.page.locator('.antiTable-body__row', { has: this.page.locator(`td:has-text("${title}")`) })
+    const joinButton = projectRow.locator('button:has-text("Join")')
+    await joinButton.click()
+  }
+}

--- a/tests/sanity/tests/model/tracker/all-projects-page.ts
+++ b/tests/sanity/tests/model/tracker/all-projects-page.ts
@@ -18,4 +18,16 @@ export class AllProjectsPage extends CommonTrackerPage {
     const joinButton = projectRow.locator('button:has-text("Join")')
     await joinButton.click()
   }
+
+  async unarchiveProject (title: string): Promise<void> {
+    const projectRow = this.page.locator('.antiTable-body__row', { has: this.page.locator(`td:has-text("${title}")`) })
+    await projectRow.click({ button: 'right' })
+    await this.page.locator('.popup button:has-text("Unarchive")').click()
+    await this.page.locator('.popup button:has-text("Ok")').click()
+  }
+
+  async checkProjecInTableIsNotArchived (title: string): Promise<void> {
+    await this.page.waitForTimeout(3000)
+    await expect(this.projectTitleColumns().filter({ hasText: title })).not.toContainText('(archived)')
+  }
 }

--- a/tests/sanity/tests/model/tracker/tracker-navigation-menu-page.ts
+++ b/tests/sanity/tests/model/tracker/tracker-navigation-menu-page.ts
@@ -9,10 +9,15 @@ export class TrackerNavigationMenuPage extends CommonPage {
     this.page = page
   }
 
-  buttonCreateProject = (): Locator => this.page.locator('div#navGroup-tree-projects').locator('xpath=../button[1]')
+  yoursProjectsMenuSelector = '#navGroup-tree-projects'
+  starredProjectsMenuSelector = '#navGroup-tree-stared'
+
+  buttonCreateProject = (): Locator => this.page.locator(this.yoursProjectsMenuSelector).locator('xpath=../button[1]')
   buttonProjectsParent = (): Locator => this.page.locator('button.hulyNavGroup-header span')
   templateLinkForProject = (projectName: string): Locator =>
     this.page.locator(`a[href$="templates"][href*="${projectName}"]`)
+
+  starredProjectsInMenu = (): Locator => this.page.locator(`${this.starredProjectsMenuSelector} span`)
 
   issuesLinkForProject = (projectName: string): Locator =>
     this.page
@@ -49,6 +54,18 @@ export class TrackerNavigationMenuPage extends CommonPage {
     await expect(this.buttonProjectsParent().filter({ hasText: projectName })).toHaveCount(1)
   }
 
+  async checkProjectStarred (projectName: string): Promise<void> {
+    await expect(this.starredProjectsInMenu().filter({ hasText: projectName })).toHaveCount(1)
+  }
+
+  async checkProjectWillBeRemovedFromYours (projectName: string): Promise<void> {
+    await this.page.waitForSelector(`${this.yoursProjectsMenuSelector} span:has-text("${projectName}")`, { state: 'detached' })
+  }
+
+  async checkProjectWillBeRemovedFromStarred (projectName: string): Promise<void> {
+    await this.page.waitForSelector(`${this.starredProjectsMenuSelector} span:has-text("${projectName}")`, { state: 'detached' })
+  }
+
   async checkProjectNotExist (projectName: string): Promise<void> {
     await expect(this.buttonProjectsParent().filter({ hasText: projectName })).toHaveCount(0)
   }
@@ -68,6 +85,16 @@ export class TrackerNavigationMenuPage extends CommonPage {
   async makeActionWithProject (projectName: string, action: string): Promise<void> {
     await this.buttonProjectsParent().filter({ hasText: projectName }).hover()
     await this.buttonProjectsParent()
+      .filter({ hasText: projectName })
+      .locator('xpath=../..')
+      .locator('div[class*="tools"] button')
+      .click()
+    await this.selectFromDropdown(this.page, action)
+  }
+
+  async makeActionWithStarredProject (projectName: string, action: string): Promise<void> {
+    await this.starredProjectsInMenu().filter({ hasText: projectName }).hover()
+    await this.starredProjectsInMenu()
       .filter({ hasText: projectName })
       .locator('xpath=../..')
       .locator('div[class*="tools"] button')

--- a/tests/sanity/tests/model/tracker/tracker-navigation-menu-page.ts
+++ b/tests/sanity/tests/model/tracker/tracker-navigation-menu-page.ts
@@ -123,4 +123,8 @@ export class TrackerNavigationMenuPage extends CommonPage {
     await expect(this.milestone()).toBeVisible()
     await expect(this.templates()).toBeVisible()
   }
+
+  async openAllProjects (): Promise<void> {
+    await this.allProjects().click()
+  }
 }

--- a/tests/sanity/tests/tracker/projects.spec.ts
+++ b/tests/sanity/tests/tracker/projects.spec.ts
@@ -9,7 +9,7 @@ test.use({
   storageState: PlatformSetting
 })
 
-test.describe('Tracker Projects tests', () => {
+test.describe.only('Tracker Projects tests', () => {
   let trackerNavigationMenuPage: TrackerNavigationMenuPage
   let newProjectPage: NewProjectPage
   let editProjectPage: EditProjectPage
@@ -84,5 +84,52 @@ test.describe('Tracker Projects tests', () => {
     await trackerNavigationMenuPage.makeActionWithProject(archiveProjectData.title, 'Archive')
     await trackerNavigationMenuPage.pressYesForPopup(page)
     await trackerNavigationMenuPage.checkProjectNotExist(archiveProjectData.title)
+  })
+
+  test('Star and Unstar Project', async ({ page }) => {
+    const projectToStarData: NewProject = {
+      title: 'PROJECT_STAR',
+      identifier: 'STAR',
+      description: 'Starred Project description',
+      private: true,
+      defaultAssigneeForIssues: 'Dirak Kainin',
+      defaultIssueStatus: 'In Progress'
+    }
+
+    try {
+      await trackerNavigationMenuPage.checkProjectNotExist(projectToStarData.title)
+    } catch {
+      await trackerNavigationMenuPage.pressCreateProjectButton()
+      await newProjectPage.createNewProject(projectToStarData)
+    }
+
+    await trackerNavigationMenuPage.checkProjectExist(projectToStarData.title)
+
+    await trackerNavigationMenuPage.makeActionWithProject(projectToStarData.title, 'Star')
+    await trackerNavigationMenuPage.checkProjectStarred(projectToStarData.title)
+    await trackerNavigationMenuPage.checkProjectWillBeRemovedFromYours(projectToStarData.title)
+
+    await trackerNavigationMenuPage.makeActionWithStarredProject(projectToStarData.title, 'Unstar')
+    await trackerNavigationMenuPage.checkProjectExist(projectToStarData.title)
+    await trackerNavigationMenuPage.checkProjectWillBeRemovedFromStarred(projectToStarData.title)
+  })
+
+  test.skip('Leave Project', async ({ page }) => {
+    const projectToStarData: NewProject = {
+      title: 'PROJECT_STAR',
+      identifier: 'STAR',
+      description: 'Starred Project description',
+      private: true,
+      defaultAssigneeForIssues: 'Dirak Kainin',
+      defaultIssueStatus: 'In Progress'
+    }
+
+    await trackerNavigationMenuPage.checkProjectNotExist(projectToStarData.title)
+    await trackerNavigationMenuPage.pressCreateProjectButton()
+    await newProjectPage.createNewProject(projectToStarData)
+    await trackerNavigationMenuPage.checkProjectExist(projectToStarData.title)
+    await trackerNavigationMenuPage.makeActionWithProject(projectToStarData.title, 'Star')
+    await trackerNavigationMenuPage.pressYesForPopup(page)
+    await trackerNavigationMenuPage.checkProjectExist(projectToStarData.title)
   })
 })

--- a/tests/sanity/tests/tracker/projects.spec.ts
+++ b/tests/sanity/tests/tracker/projects.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test'
-import { generateProjectPrefix, PlatformSetting, PlatformURI } from '../utils'
+import { generateRandomPrefix, PlatformSetting, PlatformURI } from '../utils'
 import { TrackerNavigationMenuPage } from '../model/tracker/tracker-navigation-menu-page'
 import { NewProjectPage } from '../model/tracker/new-project-page'
 import { NewProject } from '../model/tracker/types'
@@ -25,7 +25,7 @@ test.describe.only('Tracker Projects tests', () => {
   })
 
   test('Create project', async () => {
-    const prefix = generateProjectPrefix()
+    const prefix = generateRandomPrefix()
     const newProjectData: NewProject = {
       title: `${prefix}-NewProject`,
       identifier: prefix,
@@ -44,7 +44,7 @@ test.describe.only('Tracker Projects tests', () => {
   })
 
   test('Edit project', async () => {
-    const prefix = generateProjectPrefix()
+    const prefix = generateRandomPrefix()
 
     const editProjectData: NewProject = {
       title: `${prefix}-EditProject`,
@@ -75,7 +75,7 @@ test.describe.only('Tracker Projects tests', () => {
   })
 
   test('Archive Project', async ({ page }) => {
-    const prefix = generateProjectPrefix()
+    const prefix = generateRandomPrefix()
 
     const archiveProjectData: NewProject = {
       title: `${prefix}-ArchiveProject`,
@@ -96,7 +96,7 @@ test.describe.only('Tracker Projects tests', () => {
   })
 
   test('Star and Unstar Project', async ({ page }) => {
-    const prefix = generateProjectPrefix()
+    const prefix = generateRandomPrefix()
 
     const projectToStarData: NewProject = {
       title: `${prefix}-ProjectToStar`,
@@ -122,7 +122,7 @@ test.describe.only('Tracker Projects tests', () => {
   })
 
   test('Leave and Join Project', async ({ page }) => {
-    const prefix = generateProjectPrefix()
+    const prefix = generateRandomPrefix()
 
     const projectToLeaveData: NewProject = {
       title: `${prefix}-ProjectToLeave`,

--- a/tests/sanity/tests/tracker/projects.spec.ts
+++ b/tests/sanity/tests/tracker/projects.spec.ts
@@ -24,7 +24,7 @@ test.describe.only('Tracker Projects tests', () => {
     await (await page.goto(`${PlatformURI}/workbench/sanity-ws`))?.finished()
   })
 
-  test('Create project', async () => {
+  test('User can create project', async () => {
     const prefix = generateRandomPrefix()
     const newProjectData: NewProject = {
       title: `${prefix}-NewProject`,
@@ -35,15 +35,27 @@ test.describe.only('Tracker Projects tests', () => {
       defaultIssueStatus: 'In Progress'
     }
 
-    await trackerNavigationMenuPage.checkProjectNotExist(newProjectData.title)
-    await trackerNavigationMenuPage.pressCreateProjectButton()
-    await newProjectPage.createNewProject(newProjectData)
-    await trackerNavigationMenuPage.checkProjectExist(newProjectData.title)
+    await test.step('User create project', async () => {
+      await trackerNavigationMenuPage.checkProjectNotExist(newProjectData.title)
+      await trackerNavigationMenuPage.pressCreateProjectButton()
+      await newProjectPage.createNewProject(newProjectData)
+    })
 
-    await trackerNavigationMenuPage.openProject(newProjectData.title)
+    await test.step('User see project in menu', async () => {
+      await trackerNavigationMenuPage.checkProjectExist(newProjectData.title)
+    })
+
+    await test.step('User see project in all projects table', async () => {
+      await trackerNavigationMenuPage.openAllProjects()
+      await allProjectsPage.checkProjectExistInTable(newProjectData.title)
+    })
+
+    await test.step('User can open created project', async () => {
+      await trackerNavigationMenuPage.openProject(newProjectData.title)
+    })
   })
 
-  test('Edit project', async () => {
+  test('User can edit project', async () => {
     const prefix = generateRandomPrefix()
 
     const editProjectData: NewProject = {
@@ -63,18 +75,23 @@ test.describe.only('Tracker Projects tests', () => {
       defaultIssueStatus: 'Done'
     }
 
-    await trackerNavigationMenuPage.checkProjectNotExist(editProjectData.title)
-    await trackerNavigationMenuPage.pressCreateProjectButton()
-    await newProjectPage.createNewProject(editProjectData)
-    await trackerNavigationMenuPage.checkProjectExist(editProjectData.title)
-    await trackerNavigationMenuPage.makeActionWithProject(editProjectData.title, 'Edit project')
-    await editProjectPage.checkProject(editProjectData)
-    await editProjectPage.updateProject(updateProjectData)
-    await trackerNavigationMenuPage.makeActionWithProject(updateProjectData.title, 'Edit project')
-    await editProjectPage.checkProject(updateProjectData)
+    await test.step('User prepare project', async () => {
+      await trackerNavigationMenuPage.checkProjectNotExist(editProjectData.title)
+      await trackerNavigationMenuPage.pressCreateProjectButton()
+      await newProjectPage.createNewProject(editProjectData)
+      await trackerNavigationMenuPage.checkProjectExist(editProjectData.title)
+    })
+
+    await test.step('User edit project', async () => {
+      await trackerNavigationMenuPage.makeActionWithProject(editProjectData.title, 'Edit project')
+      await editProjectPage.checkProject(editProjectData)
+      await editProjectPage.updateProject(updateProjectData)
+      await trackerNavigationMenuPage.makeActionWithProject(updateProjectData.title, 'Edit project')
+      await editProjectPage.checkProject(updateProjectData)
+    })
   })
 
-  test('Archive Project', async ({ page }) => {
+  test('User can archive and unarchive Project', async ({ page }) => {
     const prefix = generateRandomPrefix()
 
     const archiveProjectData: NewProject = {
@@ -86,13 +103,26 @@ test.describe.only('Tracker Projects tests', () => {
       defaultIssueStatus: 'In Progress'
     }
 
-    await trackerNavigationMenuPage.checkProjectNotExist(archiveProjectData.title)
-    await trackerNavigationMenuPage.pressCreateProjectButton()
-    await newProjectPage.createNewProject(archiveProjectData)
-    await trackerNavigationMenuPage.checkProjectExist(archiveProjectData.title)
-    await trackerNavigationMenuPage.makeActionWithProject(archiveProjectData.title, 'Archive')
-    await trackerNavigationMenuPage.pressYesForPopup(page)
-    await trackerNavigationMenuPage.checkProjectNotExist(archiveProjectData.title)
+    await test.step('User prepare project', async () => {
+      await trackerNavigationMenuPage.checkProjectNotExist(archiveProjectData.title)
+      await trackerNavigationMenuPage.pressCreateProjectButton()
+      await newProjectPage.createNewProject(archiveProjectData)
+    })
+
+    await test.step('User archive project', async () => {
+      await trackerNavigationMenuPage.checkProjectExist(archiveProjectData.title)
+      await trackerNavigationMenuPage.makeActionWithProject(archiveProjectData.title, 'Archive')
+      await trackerNavigationMenuPage.pressYesForPopup(page)
+      await trackerNavigationMenuPage.checkProjectNotExist(archiveProjectData.title)
+      await trackerNavigationMenuPage.openAllProjects()
+      await allProjectsPage.checkProjectExistInTable(`${archiveProjectData.title} (archived)`)
+    })
+
+    await test.step('User unarchive project', async () => {
+      await allProjectsPage.unarchiveProject(archiveProjectData.title)
+      await allProjectsPage.checkProjecInTableIsNotArchived(`${archiveProjectData.title}`)
+      await trackerNavigationMenuPage.checkProjectExist(archiveProjectData.title)
+    })
   })
 
   test('Star and Unstar Project', async ({ page }) => {
@@ -107,18 +137,24 @@ test.describe.only('Tracker Projects tests', () => {
       defaultIssueStatus: 'In Progress'
     }
 
-    await trackerNavigationMenuPage.checkProjectNotExist(projectToStarData.title)
-    await trackerNavigationMenuPage.pressCreateProjectButton()
-    await newProjectPage.createNewProject(projectToStarData)
-    await trackerNavigationMenuPage.checkProjectExist(projectToStarData.title)
+    await test.step('User prepare project', async () => {
+      await trackerNavigationMenuPage.checkProjectNotExist(projectToStarData.title)
+      await trackerNavigationMenuPage.pressCreateProjectButton()
+      await newProjectPage.createNewProject(projectToStarData)
+      await trackerNavigationMenuPage.checkProjectExist(projectToStarData.title)
+    })
 
-    await trackerNavigationMenuPage.makeActionWithProject(projectToStarData.title, 'Star')
-    await trackerNavigationMenuPage.checkProjectStarred(projectToStarData.title)
-    await trackerNavigationMenuPage.checkProjectWillBeRemovedFromYours(projectToStarData.title)
+    await test.step('User star project', async () => {
+      await trackerNavigationMenuPage.makeActionWithProject(projectToStarData.title, 'Star')
+      await trackerNavigationMenuPage.checkProjectStarred(projectToStarData.title)
+      await trackerNavigationMenuPage.checkProjectWillBeRemovedFromYours(projectToStarData.title)
+    })
 
-    await trackerNavigationMenuPage.makeActionWithStarredProject(projectToStarData.title, 'Unstar')
-    await trackerNavigationMenuPage.checkProjectExist(projectToStarData.title)
-    await trackerNavigationMenuPage.checkProjectWillBeRemovedFromStarred(projectToStarData.title)
+    await test.step('User unstar project', async () => {
+      await trackerNavigationMenuPage.makeActionWithStarredProject(projectToStarData.title, 'Unstar')
+      await trackerNavigationMenuPage.checkProjectExist(projectToStarData.title)
+      await trackerNavigationMenuPage.checkProjectWillBeRemovedFromStarred(projectToStarData.title)
+    })
   })
 
   test('Leave and Join Project', async ({ page }) => {
@@ -133,18 +169,23 @@ test.describe.only('Tracker Projects tests', () => {
       defaultIssueStatus: 'In Progress'
     }
 
-    await trackerNavigationMenuPage.checkProjectNotExist(projectToLeaveData.title)
-    await trackerNavigationMenuPage.pressCreateProjectButton()
-    await newProjectPage.createNewProject(projectToLeaveData)
-    await trackerNavigationMenuPage.checkProjectExist(projectToLeaveData.title)
+    await test.step('User prepare project', async () => {
+      await trackerNavigationMenuPage.checkProjectNotExist(projectToLeaveData.title)
+      await trackerNavigationMenuPage.pressCreateProjectButton()
+      await newProjectPage.createNewProject(projectToLeaveData)
+      await trackerNavigationMenuPage.checkProjectExist(projectToLeaveData.title)
+    })
 
-    await trackerNavigationMenuPage.makeActionWithProject(projectToLeaveData.title, 'Leave')
-    await trackerNavigationMenuPage.checkProjectWillBeRemovedFromYours(projectToLeaveData.title)
+    await test.step('User leave project', async () => {
+      await trackerNavigationMenuPage.makeActionWithProject(projectToLeaveData.title, 'Leave')
+      await trackerNavigationMenuPage.checkProjectWillBeRemovedFromYours(projectToLeaveData.title)
+    })
 
-    await trackerNavigationMenuPage.openAllProjects()
-    await allProjectsPage.checkProjectExistInTable(projectToLeaveData.title)
-    await allProjectsPage.joinProject(projectToLeaveData.title)
-    await trackerNavigationMenuPage.checkProjectExist(projectToLeaveData.title)
+    await test.step('User join project', async () => {
+      await trackerNavigationMenuPage.openAllProjects()
+      await allProjectsPage.checkProjectExistInTable(projectToLeaveData.title)
+      await allProjectsPage.joinProject(projectToLeaveData.title)
+      await trackerNavigationMenuPage.checkProjectExist(projectToLeaveData.title)
+    })
   })
-
 })

--- a/tests/sanity/tests/tracker/projects.spec.ts
+++ b/tests/sanity/tests/tracker/projects.spec.ts
@@ -10,7 +10,7 @@ test.use({
   storageState: PlatformSetting
 })
 
-test.describe.only('Tracker Projects tests', () => {
+test.describe('Tracker Projects tests', () => {
   let trackerNavigationMenuPage: TrackerNavigationMenuPage
   let newProjectPage: NewProjectPage
   let editProjectPage: EditProjectPage

--- a/tests/sanity/tests/utils.ts
+++ b/tests/sanity/tests/utils.ts
@@ -229,9 +229,9 @@ export async function createAccountAndWorkspace (page: Page, request: APIRequest
 }
 
 /**
-*
-* @returns random 4 capitalized chars like 'AFKXL'
+* @returns string of random capitalized chars to save names
+* @example 'AFRXL'
 */
-export function generateProjectPrefix(): string {
-  return Array.from({ length: 5 }, () => String.fromCharCode(65 + Math.floor(Math.random() * 26))).join('')
+export function generateRandomPrefix (size: number = 5): string {
+  return Array.from({ length: size }, () => String.fromCharCode(65 + Math.floor(Math.random() * 26))).join('')
 }

--- a/tests/sanity/tests/utils.ts
+++ b/tests/sanity/tests/utils.ts
@@ -227,3 +227,11 @@ export async function createAccountAndWorkspace (page: Page, request: APIRequest
   await api.createWorkspaceWithLogin(data.workspaceName, data.userName, '1234')
   await reLogin(page, data)
 }
+
+/**
+*
+* @returns random 4 capitalized chars like 'AFKXL'
+*/
+export function generateProjectPrefix(): string {
+  return Array.from({ length: 5 }, () => String.fromCharCode(65 + Math.floor(Math.random() * 26))).join('')
+}


### PR DESCRIPTION
**Pull Request Requirements:**

- Add tests of star/unstar/unarchive/leave/join actions to Tracker
- Make old tests independent of quantity and order of runs

Issue: https://front.hc.engineering/workbench/platform/tracker/UBERF-8005
