### PR TITLE
add Attach to Browser debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -411,6 +411,16 @@
       "runtimeVersion": "20",
       "sourceMaps": true,
       "cwd": "${workspaceRoot}/services/telegram-bot/pod-telegram-bot"
-    }
+    },
+    {
+      "type": "chrome",
+      "name": "Attach to Browser",
+      "request": "attach",
+      "urlFilter": "http://localhost:8080/*",
+      "port": 9222,
+      "sourceMapPathOverrides": {
+        "webpack://*": "${workspaceFolder}/*",
+      }
+    },
   ]
 }

--- a/dev/prod/webpack.config.js
+++ b/dev/prod/webpack.config.js
@@ -54,7 +54,7 @@ module.exports = [
             options: {
               target: 'es2021',
               keepNames: true,
-              minify: !prod,
+              minify: prod,
               sourcemap: !prod
             }
           }
@@ -148,7 +148,7 @@ module.exports = [
         options: {
           target: 'es2021',
           keepNames: true,
-          minify: !prod,
+          minify: prod,
           sourcemap: true
         },
         exclude: /node_modules/,


### PR DESCRIPTION
Added and Attach to Browser config to launch.json.

Additionally, I had to change the `minify` option in webpack config.
Figured this was a mistake? Why are we minifying in development, but NOT in production?
Doing otherwise will cause problems with the debugger (incorrect variable names)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmQzYTcxNGFjY2U3NzU1MjYyZmNhMjMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.n6xUQPC2HXivIdZzqDGl4v41IrSu9DKLqyzm_LOOaUU">Huly&reg;: <b>UBERF-8010</b></a></sub>