### PR TITLE
EZQMS-1185: Fix delete document availability

### DIFF
--- a/models/controlled-documents/src/index.ts
+++ b/models/controlled-documents/src/index.ts
@@ -684,7 +684,7 @@ export function createModel (builder: Builder): void {
       input: 'any',
       category: view.category.General,
       target: documents.class.Document,
-      visibilityTester: documents.function.IsLatestDraftDoc,
+      visibilityTester: documents.function.CanDeleteDocument,
       query: {
         state: DocumentState.Draft
       },

--- a/plugins/controlled-documents-resources/src/index.ts
+++ b/plugins/controlled-documents-resources/src/index.ts
@@ -20,7 +20,8 @@ import {
   type RelatedDocument,
   SortingOrder,
   type WithLookup,
-  type Doc
+  type Doc,
+  getCurrentAccount
 } from '@hcengineering/core'
 import {
   type Document,
@@ -31,6 +32,7 @@ import {
 import { type Resources } from '@hcengineering/platform'
 import { type ObjectSearchResult, getClient, MessageBox } from '@hcengineering/presentation'
 import { showPopup } from '@hcengineering/ui'
+import { type PersonAccount } from '@hcengineering/contact'
 
 import CreateDocument from './components/CreateDocument.svelte'
 import QmsDocumentWizard from './components/create-doc/QmsDocumentWizard.svelte'
@@ -148,6 +150,22 @@ async function deleteDocuments (obj: Document | Document[]): Promise<void> {
   })
 }
 
+async function canDeleteDocument (obj?: Doc | Doc[]): Promise<boolean> {
+  if (obj == null) {
+    return false
+  }
+
+  const objs = (Array.isArray(obj) ? obj : [obj]) as Document[]
+  const currentUser = getCurrentAccount() as PersonAccount
+  const isOwner = objs.every((doc) => doc.owner === currentUser.person)
+
+  if (!isOwner) {
+    return false
+  }
+
+  return await isLatestDraftDoc(obj)
+}
+
 async function isLatestDraftDoc (obj?: Doc | Doc[]): Promise<boolean> {
   if (obj == null) {
     return false
@@ -261,7 +279,7 @@ export default async (): Promise<Resources> => ({
     DocumentStateSort: sortDocumentStates,
     GetAllDocumentStates: getAllDocumentStates,
     GetDocumentMetaLinkFragment: getDocumentMetaLinkFragment,
-    IsLatestDraftDoc: isLatestDraftDoc,
+    CanDeleteDocument: canDeleteDocument,
     DocumentIdentifierProvider: documentIdentifierProvider,
     ControlledDocumentTitleProvider: getControlledDocumentTitle,
     Comment: comment,

--- a/plugins/controlled-documents-resources/src/plugin.ts
+++ b/plugins/controlled-documents-resources/src/plugin.ts
@@ -231,7 +231,7 @@ export default mergeIds(documentsId, documents, {
     GetAllDocumentStates: '' as Resource<() => Promise<DocumentState[]>>,
     GetVisibleFilters: '' as Resource<(filters: KeyFilter[], space?: Ref<Space>) => Promise<KeyFilter[]>>,
     GetDocumentMetaLinkFragment: '' as Resource<(doc: Doc, props: Record<string, any>) => Promise<Location>>,
-    IsLatestDraftDoc: '' as Resource<(doc?: Doc | Doc[]) => Promise<boolean>>,
+    CanDeleteDocument: '' as Resource<(doc?: Doc | Doc[]) => Promise<boolean>>,
     ControlledDocumentTitleProvider: '' as Resource<(client: Client, ref: Ref<Doc>, doc?: Doc) => Promise<string>>
   }
 })


### PR DESCRIPTION
* Makes delete controlled document action available only for the document owner

Related to: https://front.hc.engineering/workbench/platform/tracker/EZQMS-1185

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmQ5NzFkY2UxNzVjYmM2NmQzYTk1YTAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.HZdFs-2QjFiwBF99YiU8tDsNCESE-QIq_HkjlVg3aMI">Huly&reg;: <b>UBERF-8039</b></a></sub>