### PR TITLE
EZQMS-1171: Drop h4-h6 during import of controlled doc

### DIFF
--- a/dev/doc-import-tool/src/extract/extract.ts
+++ b/dev/doc-import-tool/src/extract/extract.ts
@@ -1,5 +1,6 @@
 import { parseDocument } from 'htmlparser2'
 import { AnyNode, Document } from 'domhandler'
+import { findAll } from 'domutils'
 
 import { FileSpec, FileSpecType, TocFileSpec } from './types'
 import { createMetadataExtractor } from './meta'
@@ -62,6 +63,13 @@ class TocContentExtractor implements ContentExtractor {
 export async function extract (contents: string, spec: FileSpec, headerRoot?: AnyNode): Promise<ExtractedFile> {
   const extractor = new TocContentExtractor(spec)
   const doc = parseDocument(contents)
+
+  // We do not support headers > 3 so
+  // Traverse all Document's childrent and replace all h4-h6 with paragraphs
+  findAll((n) => ['h4', 'h5', 'h6'].includes(n.tagName), doc.childNodes).forEach((node) => {
+    node.name = 'p'
+  })
+
   return extractor.extract(doc, headerRoot)
 }
 


### PR DESCRIPTION
Related to: https://front.hc.engineering/workbench/platform/tracker/EZQMS-1171

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmQ5OTRiZGUxNzVjYmM2NmQzYTk2MDkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.J-U2gUkW9HHXk4g0KeBG4IZj34OmO_DGHEZZhTq49Mg">Huly&reg;: <b>UBERF-8041</b></a></sub>