### PR TITLE
UBERF-8044: staging model version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,7 @@ env:
     .prettierrc
     tools
   PublishTempFolder: publish_artifacts
+  MODEL_VERSION_MODE: ${{ startsWith(github.ref, 'refs/tags/s') && 'tagTime' || 'file' }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/common/scripts/show_version.js
+++ b/common/scripts/show_version.js
@@ -15,12 +15,31 @@
 
 const fs = require('fs')
 const path = require('path')
+const exec = require('child_process').exec
 
-try {
-  const versionFilePath = path.resolve(__dirname, 'version.txt')
-  const version = fs.readFileSync(versionFilePath, 'utf8').trim()
-  
-  console.log(version)
-} catch (error) {
-  console.log('0.6.0')
-}
+exec('git describe --tags --abbrev=0', (err, stdout) => {
+  if (err !== null) {
+    console.log('"0.7.0"')
+    return
+  }
+
+  const tag = stdout.trim()
+
+  if (tag.startsWith('s')) {
+    // Staging model version
+    // Take tagged git commit date as model version
+    exec(`git for-each-ref --shell --format="%(creatordate:format:%s)" "refs/tags/${tag}"`, (err, stdout) => {
+      console.log(`"0.7.${err === null ? stdout.trim().slice(1, -1) : 0}"`)
+    })
+  } else {
+    let version
+    try {
+      const versionFilePath = path.resolve(__dirname, 'version.txt')
+      version = fs.readFileSync(versionFilePath, 'utf8').trim()
+    } catch (error) {
+      version = '"0.6.0"'
+    }
+
+    console.log(version)
+  }
+})

--- a/common/scripts/show_version.js
+++ b/common/scripts/show_version.js
@@ -17,29 +17,38 @@ const fs = require('fs')
 const path = require('path')
 const exec = require('child_process').exec
 
-exec('git describe --tags --abbrev=0', (err, stdout) => {
-  if (err !== null) {
-    console.log('"0.7.0"')
-    return
-  }
-
-  const tag = stdout.trim()
-
-  if (tag.startsWith('s')) {
-    // Staging model version
-    // Take tagged git commit date as model version
-    exec(`git for-each-ref --shell --format="%(creatordate:format:%s)" "refs/tags/${tag}"`, (err, stdout) => {
-      console.log(`"0.7.${err === null ? stdout.trim().slice(1, -1) : 0}"`)
-    })
-  } else {
-    let version
-    try {
-      const versionFilePath = path.resolve(__dirname, 'version.txt')
-      version = fs.readFileSync(versionFilePath, 'utf8').trim()
-    } catch (error) {
-      version = '"0.6.0"'
+function main (mode) {
+  exec('git describe --tags --abbrev=0', (err, stdout) => {
+    if (err !== null) {
+      console.log('"0.7.0"')
+      return
     }
 
-    console.log(version)
-  }
-})
+    const tag = stdout.trim()
+
+    if (mode === 'tagTime') {
+      // Take tagged git commit date as model version
+      exec(`git for-each-ref --shell --format="%(creatordate:format:%s)" "refs/tags/${tag}"`, (err, stdout) => {
+        console.log(`"0.7.${err === null ? stdout.trim().slice(1, -1) : 0}"`)
+      })
+    } else {
+      // Take version from file
+      let version
+      try {
+        const versionFilePath = path.resolve(__dirname, 'version.txt')
+        version = fs.readFileSync(versionFilePath, 'utf8').trim()
+      } catch (error) {
+        version = '"0.6.0"'
+      }
+
+      console.log(version)
+    }
+  })
+}
+
+let mode = process.env.MODEL_VERSION_MODE
+if (mode !== 'tagTime') {
+  mode = 'file'
+}
+
+main(mode)


### PR DESCRIPTION
* Take tagged commit date as model version for staging builds
* Fix attempts query in account service to work properly with old workspaces

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-8044

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmRhZTg4Y2UxNzVjYmM2NmQzYTk3ODMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.BGqQOwKOnjRpunzh04ga1Ia5Jaw76oJhvbMxjArO8No">Huly&reg;: <b>UBERF-8045</b></a></sub>