### PR TITLE
EZQMS-1193: Fix issues with drafting a controlled doc version from effective

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,11 +59,11 @@
       "args": ["src/__start.ts"],
       "env": {
         "ELASTIC_URL": "http://localhost:9200",
-        "MONGO_URL": "postgresql://postgres:example@localhost:5432;mongodb://localhost:27017",
+        "MONGO_URL": "mongodb://localhost:27017",
         "APM_SERVER_URL2": "http://localhost:8200",
         "METRICS_CONSOLE": "false",
         "METRICS_FILE": "${workspaceRoot}/metrics.txt", // Show metrics in console evert 30 seconds.,
-        "STORAGE_CONFIG": "minio|localhost:9000?accessKey=minioadmin&secretKey=minioadmin",
+        "STORAGE_CONFIG": "minio|localhost?accessKey=minioadmin&secretKey=minioadmin",
         "SERVER_SECRET": "secret",
         "ENABLE_CONSOLE": "true",
         "COLLABORATOR_URL": "ws://localhost:3078",

--- a/packages/ui/src/components/PlainTextEditor.svelte
+++ b/packages/ui/src/components/PlainTextEditor.svelte
@@ -48,6 +48,10 @@
   afterUpdate(adjustHeight)
 
   function adjustHeight (): void {
+    if (input == null) {
+      return
+    }
+
     input.style.height = 'auto'
     input.style.height = `${input.scrollHeight + 2}px`
   }

--- a/server/middleware/src/applyTx.ts
+++ b/server/middleware/src/applyTx.ts
@@ -97,7 +97,12 @@ export class ApplyTxMiddleware extends BaseMiddleware implements Middleware {
       return { passed: true, onEnd: () => {} }
     }
     // Wait for synchronized.
-    ;(await this.scopes.get(applyIf.scope)) ?? Promise.resolve()
+    const scopePromise = this.scopes.get(applyIf.scope)
+
+    if (scopePromise != null) {
+      await scopePromise
+    }
+
     let onEnd = (): void => {}
     // Put sync code
     this.scopes.set(


### PR DESCRIPTION
* Fixes the case when it was possible to create 2 drafts from one effective doc
* Fixes exception on "Reason and impact" tab when switching between draft/released doc version
* Fixes issue with waiting scope in ApplyTx middleware

Related to: https://front.hc.engineering/workbench/platform/tracker/EZQMS-1193

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmUxYjYxYjU3NmVmNDVmNWU3YTljYTAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.aE9mjWHS2U3uny8zCQyzoj0-OFaiPWn_ClueMR3u7Qs">Huly&reg;: <b>UBERF-8081</b></a></sub>