### PR TITLE
Adds tests for 'updating workspace name and deleting workspace'

### DIFF
--- a/tests/sanity/tests/model/workspace/owner-pages.ts
+++ b/tests/sanity/tests/model/workspace/owner-pages.ts
@@ -31,6 +31,9 @@ export class OwnersPage {
   updateWorkspaceNameButton = (): Locator => this.page.locator('.ws > .antiButton')
   confirmUpdateWorkspaceName = (): Locator => this.page.locator('.ws > button').first()
   inputWorkspaceName = (): Locator => this.page.getByPlaceholder('Workspace name')
+  deleteWorkspaceButton = (): Locator => this.page.getByRole('button', { name: 'Delete workspace' })
+  cancelDeleteWorkspace = (): Locator => this.page.getByRole('button', { name: 'Cancel' })
+  confirmDeleteWorkspace = (): Locator => this.page.getByRole('button', { name: 'Ok' })
 
   async addMember (memberName: string): Promise<void> {
     await expect(this.spacesAdminText()).toBeVisible()
@@ -83,5 +86,13 @@ export class OwnersPage {
     await this.inputWorkspaceName().fill(newName)
     await this.confirmUpdateWorkspaceName().click()
     await expect(this.inputWorkspaceName()).toHaveValue(newName)
+  }
+
+  async deleteWorkspace (): Promise<void> {
+    await this.deleteWorkspaceButton().click()
+    await this.cancelDeleteWorkspace().click()
+    await this.deleteWorkspaceButton().click()
+    await this.confirmDeleteWorkspace().click()
+    await expect(this.page.getByText('Select workspace')).toBeVisible();
   }
 }

--- a/tests/sanity/tests/model/workspace/owner-pages.ts
+++ b/tests/sanity/tests/model/workspace/owner-pages.ts
@@ -28,6 +28,9 @@ export class OwnersPage {
   emailMask = (): Locator => this.page.getByRole('textbox', { name: 'Type text...' })
   noLimitToggleButton = (): Locator => this.page.locator('label span')
   avatarLarge = (): Locator => this.page.locator('.hulyAvatarSize-medium.ava-image')
+  updateWorkspaceNameButton = (): Locator => this.page.locator('.ws > .antiButton')
+  confirmUpdateWorkspaceName = (): Locator => this.page.locator('.ws > button').first()
+  inputWorkspaceName = (): Locator => this.page.getByPlaceholder('Workspace name')
 
   async addMember (memberName: string): Promise<void> {
     await expect(this.spacesAdminText()).toBeVisible()
@@ -73,5 +76,12 @@ export class OwnersPage {
   async checkIfPictureIsUploaded (): Promise<void> {
     await expect(this.avatarLarge()).toBeVisible()
     await expect(this.avatarLarge()).toHaveAttribute('src')
+  }
+
+  async updateWorkspaceName (newName: string): Promise<void> {
+    await this.updateWorkspaceNameButton().click()
+    await this.inputWorkspaceName().fill(newName)
+    await this.confirmUpdateWorkspaceName().click()
+    await expect(this.inputWorkspaceName()).toHaveValue(newName)
   }
 }

--- a/tests/sanity/tests/workspace/workspace-settings.spec.ts
+++ b/tests/sanity/tests/workspace/workspace-settings.spec.ts
@@ -183,4 +183,22 @@ test.describe('Workspace tests', () => {
     await workspaceSettingsPage.selectWorkspaceSettingsTab(ButtonType.General)
     await ownersPage.updateWorkspaceName(updatedWorkspaceName)
   })
+  
+  test('User is able to delete workspace', async ({ page }) => {
+    newUser = {
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+      email: faker.internet.email(),
+      password: '1234'
+    }
+    const newWorkspaceName = `New Workspace Name - ${generateId(2)}`
+    await loginPage.goto()
+    await loginPage.linkSignUp().click()
+    await signUpPage.signUp(newUser)
+    await selectWorkspacePage.createWorkspace(newWorkspaceName)
+    await userProfilePage.openProfileMenu()
+    await userProfilePage.clickSettings()
+    await workspaceSettingsPage.selectWorkspaceSettingsTab(ButtonType.General)
+    await ownersPage.deleteWorkspace()
+  })
 })

--- a/tests/sanity/tests/workspace/workspace-settings.spec.ts
+++ b/tests/sanity/tests/workspace/workspace-settings.spec.ts
@@ -164,4 +164,23 @@ test.describe('Workspace tests', () => {
     await workspaceSettingsPage.selectWorkspaceSettingsTab(ButtonType.InviteSettings)
     await ownersPage.createEnumWithName(enumTitle, enumName)
   })
+
+  test('User is able to update workspace name', async ({ page }) => {
+    newUser = {
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+      email: faker.internet.email(),
+      password: '1234'
+    }
+    const newWorkspaceName = `New Workspace Name - ${generateId(2)}`
+    const updatedWorkspaceName = `Updated Workspace Name - ${generateId(3)}`
+    await loginPage.goto()
+    await loginPage.linkSignUp().click()
+    await signUpPage.signUp(newUser)
+    await selectWorkspacePage.createWorkspace(newWorkspaceName)
+    await userProfilePage.openProfileMenu()
+    await userProfilePage.clickSettings()
+    await workspaceSettingsPage.selectWorkspaceSettingsTab(ButtonType.General)
+    await ownersPage.updateWorkspaceName(updatedWorkspaceName)
+  })
 })


### PR DESCRIPTION
Tests for PR [UBERF-8017: Support updating workspace name and deleting workspace](https://github.com/hcengineering/platform/pull/6476)

- Added a test to check the ability to rename a workspace:
    - creating a workspace
    - attempt to rename the workspace
    - checking the new workspace name   

- Added a test to check the ability to delete a workspace:
    - creating a workspace
    - attempt to delete the workspace
    - cancel attempt
    - another attempt to delete the workspace
    - checking that the workspace has been deleted

Tested in environment with docker.
