### PR TITLE
UBERF-8149: Reset workspace attempts counter tool

### DIFF
--- a/dev/tool/src/index.ts
+++ b/dev/tool/src/index.ts
@@ -524,7 +524,8 @@ export function devTool (
         await updateWorkspace(db, info, {
           mode: 'active',
           progress: 100,
-          version
+          version,
+          attempts: 0
         })
 
         console.log(metricsToString(measureCtx.metrics, 'upgrade', 60))
@@ -572,7 +573,8 @@ export function devTool (
             await updateWorkspace(db, ws, {
               mode: 'active',
               progress: 100,
-              version
+              version,
+              attempts: 0
             })
           } catch (err: any) {
             console.error(err)
@@ -1569,6 +1571,25 @@ export function devTool (
         await generateWorkspaceData(endpoint, ws, cmd.parallel, email)
         await testFindAll(endpoint, ws, email)
         await dropWorkspace(toolCtx, db, null, ws)
+      })
+    })
+
+  program
+    .command('reset-ws-attempts <name>')
+    .description('Reset workspace creation/upgrade attempts counter')
+    .action(async (workspace) => {
+      const { mongodbUri } = prepareTools()
+      await withDatabase(mongodbUri, async (db) => {
+        const info = await getWorkspaceById(db, workspace)
+        if (info === null) {
+          throw new Error(`workspace ${workspace} not found`)
+        }
+
+        await updateWorkspace(db, info, {
+          attempts: 0
+        })
+
+        console.log('Attempts counter for workspace', workspace, 'has been reset')
       })
     })
 


### PR DESCRIPTION
* Adds a new command `reset-ws-attempts <name>` to reset attempts counter for a workspace creation/upgrade
* Also, resets the counter on any successful upgrade via tool

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-8149
Closes https://github.com/hcengineering/platform/issues/6601

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmU5NTFmNjU2YTcxNjQ4OTUzYTcwMmIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.BT9QOayxHM4VrbWcoP9APjGiKiXq9q-LP7mBxy37aDg">Huly&reg;: <b>UBERF-8152</b></a></sub>