### PR TITLE
UBERF-8139: Check server version when connecting from client

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -73,6 +73,7 @@
         // "SERVER_PROVIDER":"uweb"
         "SERVER_PROVIDER":"ws",
         "MODEL_VERSION": "0.6.287",
+        // "VERSION": "0.6.289",
         "ELASTIC_INDEX_NAME": "local_storage_index",
         "UPLOAD_URL": "/files",
         

--- a/plugins/client-resources/src/connection.ts
+++ b/plugins/client-resources/src/connection.ts
@@ -255,8 +255,9 @@ class Connection implements ClientConnection {
         this.delay = 3
         return
       }
-      if (resp.result?.msg === 'hello') {
-        if ((resp as HelloResponse).binary) {
+      if (resp.result === 'hello') {
+        const helloResp = resp as HelloResponse
+        if (helloResp.binary) {
           this.binaryMode = true
         }
 
@@ -264,7 +265,7 @@ class Connection implements ClientConnection {
         clearTimeout(this.dialTimer)
         this.dialTimer = null
 
-        const serverVersion = resp.result.serverVersion
+        const serverVersion = helloResp.serverVersion
         console.log('Connected to server:', serverVersion)
 
         if (this.opt?.onHello !== undefined && !this.opt.onHello(serverVersion)) {

--- a/plugins/client/src/index.ts
+++ b/plugins/client/src/index.ts
@@ -56,7 +56,7 @@ export enum ClientSocketReadyState {
 }
 
 export interface ClientFactoryOptions {
-  onHello?: (serverVersion: string) => boolean
+  onHello?: (serverVersion?: string) => boolean
   onUpgrade?: () => void
   onUnauthorized?: () => void
   onConnect?: (event: ClientConnectEvent, data: any) => void

--- a/plugins/client/src/index.ts
+++ b/plugins/client/src/index.ts
@@ -56,6 +56,7 @@ export enum ClientSocketReadyState {
 }
 
 export interface ClientFactoryOptions {
+  onHello?: (serverVersion: string) => boolean
   onUpgrade?: () => void
   onUnauthorized?: () => void
   onConnect?: (event: ClientConnectEvent, data: any) => void

--- a/plugins/guest-resources/src/connect.ts
+++ b/plugins/guest-resources/src/connect.ts
@@ -67,6 +67,27 @@ export async function connect (title: string): Promise<Client | undefined> {
   let version: Version | undefined
   const clientFactory = await getResource(client.function.GetClient)
   _client = await clientFactory(token, workspaceLoginInfo.endpoint, {
+    onHello: (serverVersion: string) => {
+      const frontVersion = getMetadata(presentation.metadata.FrontVersion)
+      if (serverVersion !== '' && frontVersion !== undefined && frontVersion !== serverVersion) {
+        const reloaded = localStorage.getItem(`versionUpgrade:s${serverVersion}:f${frontVersion}`)
+
+        if (reloaded === null) {
+          localStorage.setItem(`versionUpgrade:s${serverVersion}:f${frontVersion}`, 't')
+          location.reload()
+          return false
+        } else {
+          versionError.set(`Front version ${frontVersion} is not in sync with server version ${serverVersion}`)
+
+          setTimeout(() => {
+            location.reload()
+          }, 5000)
+          return false
+        }
+      }
+
+      return true
+    },
     onUpgrade: () => {
       location.reload()
     },

--- a/plugins/guest-resources/src/connect.ts
+++ b/plugins/guest-resources/src/connect.ts
@@ -67,9 +67,14 @@ export async function connect (title: string): Promise<Client | undefined> {
   let version: Version | undefined
   const clientFactory = await getResource(client.function.GetClient)
   _client = await clientFactory(token, workspaceLoginInfo.endpoint, {
-    onHello: (serverVersion: string) => {
+    onHello: (serverVersion?: string) => {
       const frontVersion = getMetadata(presentation.metadata.FrontVersion)
-      if (serverVersion !== '' && frontVersion !== undefined && frontVersion !== serverVersion) {
+      if (
+        serverVersion !== undefined &&
+        serverVersion !== '' &&
+        frontVersion !== undefined &&
+        frontVersion !== serverVersion
+      ) {
         const reloaded = localStorage.getItem(`versionUpgrade:s${serverVersion}:f${frontVersion}`)
 
         if (reloaded === null) {

--- a/plugins/workbench-resources/src/connect.ts
+++ b/plugins/workbench-resources/src/connect.ts
@@ -153,6 +153,27 @@ export async function connect (title: string): Promise<Client | undefined> {
     {},
     async (ctx) =>
       await clientFactory(token, endpoint, {
+        onHello: (serverVersion: string) => {
+          const frontVersion = getMetadata(presentation.metadata.FrontVersion)
+          if (serverVersion !== '' && frontVersion !== undefined && frontVersion !== serverVersion) {
+            const reloaded = localStorage.getItem(`versionUpgrade:s${serverVersion}:f${frontVersion}`)
+
+            if (reloaded === null) {
+              localStorage.setItem(`versionUpgrade:s${serverVersion}:f${frontVersion}`, 't')
+              location.reload()
+              return false
+            } else {
+              versionError.set(`Front version ${frontVersion} is not in sync with server version ${serverVersion}`)
+
+              setTimeout(() => {
+                location.reload()
+              }, 5000)
+              return false
+            }
+          }
+
+          return true
+        },
         onUpgrade: () => {
           location.reload()
         },

--- a/plugins/workbench-resources/src/connect.ts
+++ b/plugins/workbench-resources/src/connect.ts
@@ -153,9 +153,14 @@ export async function connect (title: string): Promise<Client | undefined> {
     {},
     async (ctx) =>
       await clientFactory(token, endpoint, {
-        onHello: (serverVersion: string) => {
+        onHello: (serverVersion?: string) => {
           const frontVersion = getMetadata(presentation.metadata.FrontVersion)
-          if (serverVersion !== '' && frontVersion !== undefined && frontVersion !== serverVersion) {
+          if (
+            serverVersion !== undefined &&
+            serverVersion !== '' &&
+            frontVersion !== undefined &&
+            frontVersion !== serverVersion
+          ) {
             const reloaded = localStorage.getItem(`versionUpgrade:s${serverVersion}:f${frontVersion}`)
 
             if (reloaded === null) {

--- a/pods/server/package.json
+++ b/pods/server/package.json
@@ -15,7 +15,7 @@
     "_phase:bundle": "rushx bundle",
     "_phase:docker-build": "rushx docker:build",
     "_phase:docker-staging": "rushx docker:staging",
-    "bundle": "mkdir -p bundle && esbuild src/__start.ts --sourcemap=inline --bundle --keep-names --platform=node --external:*.node --external:bufferutil --external:snappy --external:utf-8-validate --external:msgpackr-extract --define:process.env.MODEL_VERSION=$(node ../../common/scripts/show_version.js) --define:process.env.GIT_REVISION=$(../../common/scripts/git_version.sh) --outfile=bundle/bundle.js --log-level=error --sourcemap=external",
+    "bundle": "mkdir -p bundle && esbuild src/__start.ts --sourcemap=inline --bundle --keep-names --platform=node --external:*.node --external:bufferutil --external:snappy --external:utf-8-validate --external:msgpackr-extract --define:process.env.MODEL_VERSION=$(node ../../common/scripts/show_version.js) --define:process.env.VERSION=$(node ../../common/scripts/show_tag.js) --define:process.env.GIT_REVISION=$(../../common/scripts/git_version.sh) --outfile=bundle/bundle.js --log-level=error --sourcemap=external",
     "docker:build": "../../common/scripts/docker_build.sh hardcoreeng/transactor",
     "docker:tbuild": "docker build -t hardcoreeng/transactor . --platform=linux/amd64 && ../../common/scripts/docker_tag_push.sh hardcoreeng/transactor",
     "docker:abuild": "docker build -t hardcoreeng/transactor . --platform=linux/arm64 && ../../common/scripts/docker_tag_push.sh hardcoreeng/transactor",

--- a/server/rpc/src/rpc.ts
+++ b/server/rpc/src/rpc.ts
@@ -45,6 +45,7 @@ export interface HelloRequest extends Request<any[]> {
 export interface HelloResponse extends Response<any> {
   binary: boolean
   reconnect?: boolean
+  serverVersion: string
 }
 
 function replacer (key: string, value: any): any {

--- a/server/ws/src/__tests__/server.test.ts
+++ b/server/ws/src/__tests__/server.test.ts
@@ -130,7 +130,7 @@ describe('server', () => {
     })
     conn.on('message', (msg: string) => {
       const resp: Response<any> = handler.readResponse(msg, false)
-      expect(resp.result?.msg === 'hello')
+      expect(resp.result === 'hello')
       expect(resp.error?.code).toBe(UNAUTHORIZED.code)
       conn.close(1000)
     })
@@ -242,7 +242,7 @@ describe('server', () => {
               console.log('resp:', msg.toString())
               const parsedMsg: Response<any> = handler.readResponse(msg.toString(), false) // Hello
               if (!helloReceived) {
-                expect(parsedMsg.result.msg === 'hello')
+                expect(parsedMsg.result === 'hello')
                 helloReceived = true
                 return
               }

--- a/server/ws/src/__tests__/server.test.ts
+++ b/server/ws/src/__tests__/server.test.ts
@@ -15,7 +15,7 @@
 //
 
 import { UNAUTHORIZED } from '@hcengineering/platform'
-import { RPCHandler } from '@hcengineering/rpc'
+import { RPCHandler, type Response } from '@hcengineering/rpc'
 import { generateToken } from '@hcengineering/server-token'
 import WebSocket from 'ws'
 import { start } from '../server'
@@ -129,8 +129,8 @@ describe('server', () => {
       conn.close(1000)
     })
     conn.on('message', (msg: string) => {
-      const resp = handler.readResponse(msg, false)
-      expect(resp.result === 'hello')
+      const resp: Response<any> = handler.readResponse(msg, false)
+      expect(resp.result?.msg === 'hello')
       expect(resp.error?.code).toBe(UNAUTHORIZED.code)
       conn.close(1000)
     })
@@ -240,9 +240,9 @@ describe('server', () => {
           newConn.on('message', (msg: Buffer) => {
             try {
               console.log('resp:', msg.toString())
-              const parsedMsg = handler.readResponse(msg.toString(), false) // Hello
+              const parsedMsg: Response<any> = handler.readResponse(msg.toString(), false) // Hello
               if (!helloReceived) {
-                expect(parsedMsg.result === 'hello')
+                expect(parsedMsg.result.msg === 'hello')
                 helloReceived = true
                 return
               }

--- a/server/ws/src/server.ts
+++ b/server/ws/src/server.ts
@@ -91,6 +91,7 @@ class TSessionManager implements SessionManager {
   timeMinutes = 0
 
   modelVersion = process.env.MODEL_VERSION ?? ''
+  serverVersion = process.env.VERSION ?? ''
 
   oldClientErrors: number = 0
   clientErrors: number = 0
@@ -912,7 +913,10 @@ class TSessionManager implements SessionManager {
           }
           const helloResponse: HelloResponse = {
             id: -1,
-            result: 'hello',
+            result: {
+              msg: 'hello',
+              serverVersion: this.serverVersion
+            },
             binary: service.binaryMode,
             reconnect
           }

--- a/server/ws/src/server.ts
+++ b/server/ws/src/server.ts
@@ -913,12 +913,10 @@ class TSessionManager implements SessionManager {
           }
           const helloResponse: HelloResponse = {
             id: -1,
-            result: {
-              msg: 'hello',
-              serverVersion: this.serverVersion
-            },
+            result: 'hello',
             binary: service.binaryMode,
-            reconnect
+            reconnect,
+            serverVersion: this.serverVersion
           }
           ws.send(requestCtx, helloResponse, false, false)
           return

--- a/server/ws/src/server_http.ts
+++ b/server/ws/src/server_http.ts
@@ -428,7 +428,9 @@ export function startHttpServer (
         const resp: Response<any> = {
           id: -1,
           error: UNAUTHORIZED,
-          result: 'hello'
+          result: {
+            msg: 'hello'
+          }
         }
         ws.send(rpcHandler.serialize(resp, false), { binary: false })
         ws.onmessage = (msg) => {

--- a/server/ws/src/server_http.ts
+++ b/server/ws/src/server_http.ts
@@ -428,9 +428,7 @@ export function startHttpServer (
         const resp: Response<any> = {
           id: -1,
           error: UNAUTHORIZED,
-          result: {
-            msg: 'hello'
-          }
+          result: 'hello'
         }
         ws.send(rpcHandler.serialize(resp, false), { binary: false })
         ws.onmessage = (msg) => {


### PR DESCRIPTION
* Checks server version when connecting from client and does smart reload on versions mismatch

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-8139
Closes https://github.com/hcengineering/platform/issues/6591

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmU5YzI5MTU2YTcxNjQ4OTUzYTcxZTUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.Y3XvMi-wVT3En32JlJc_eKY2Mxt_omIQ0P31kDpyJ84">Huly&reg;: <b>UBERF-8155</b></a></sub>