### PR TITLE
feat: improve links behavior in the editor

### DIFF
--- a/plugins/text-editor-resources/src/components/LinkPopup.svelte
+++ b/plugins/text-editor-resources/src/components/LinkPopup.svelte
@@ -27,13 +27,15 @@
   function save (): void {
     dispatch('update', link)
   }
+
+  $: canSave = link === '' || URL.canParse(link)
 </script>
 
 <Card
   label={textEditor.string.Link}
   okLabel={textEditor.string.Save}
   okAction={save}
-  canSave
+  {canSave}
   on:close={() => {
     dispatch('close')
   }}

--- a/plugins/text-editor-resources/src/kits/default-kit.ts
+++ b/plugins/text-editor-resources/src/kits/default-kit.ts
@@ -73,11 +73,14 @@ export const DefaultKit = Extension.create<DefaultKitOptions>({
 export async function formatLink (editor: Editor): Promise<void> {
   const link = editor.getAttributes('link').href
 
-  showPopup(LinkPopup, { link }, undefined, undefined, (newLink) => {
-    if (newLink === '') {
-      editor.chain().focus().extendMarkRange('link').unsetLink().run()
-    } else {
-      editor.chain().focus().extendMarkRange('link').setLink({ href: newLink }).run()
-    }
+  // give editor some time to handle blur event
+  setTimeout(() => {
+    showPopup(LinkPopup, { link }, undefined, undefined, (newLink) => {
+      if (newLink === '') {
+        editor.chain().focus().extendMarkRange('link').unsetLink().run()
+      } else {
+        editor.chain().focus().extendMarkRange('link').setLink({ href: newLink }).run()
+      }
+    })
   })
 }


### PR DESCRIPTION
Changes in this PR:

1. Tiptap 2.6.6 introduced links validation, invalid links will have empty href attribute. We should validate them before saving and not allow to add invalid links
2. Show link popup with timeout to give the editor chance to hide toolbar

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmVhNTkzNjU2YTcxNjQ4OTUzYTczM2QiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.KCr569y-6O3yYiwBvfInwJK5OpzTsCYqWR050n6uHpM">Huly&reg;: <b>UBERF-8159</b></a></sub>