### PR TITLE
UBERF-8175 Better errors handling in uppy uploader

### DIFF
--- a/plugins/uploader-resources/src/components/FileUploadStatusBar.svelte
+++ b/plugins/uploader-resources/src/components/FileUploadStatusBar.svelte
@@ -65,7 +65,7 @@
   class="container flex-row-center flex-gap-2 active"
   class:error={state.error}
   on:click={handleClick}
-  use:tooltip={state.error !== undefined ? { label: getEmbeddedLabel(state.error) } : undefined}
+  use:tooltip={state.error != null ? { label: getEmbeddedLabel(state.error) } : undefined}
 >
   {#if state.error}
     <IconError size={'small'} fill={'var(--negative-button-default)'} />


### PR DESCRIPTION
1. Fix "null" tooltip in file upload status bar
2. Better error handling
3. Do not retry upload on 413 Request Entity Too Large
4. Do not perform post-processing for failed uploads

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmViMTI0MTU1YmFlNTFmZjU5MjEyZTEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.QEkAaS9CWE7QR44H4JIDceJImQBXHo45H1kUck6dwWc">Huly&reg;: <b>UBERF-8176</b></a></sub>