### PR TITLE
New Sidebar tests + fix flaky tests

### DIFF
--- a/tests/sanity/tests/documents/documents-content.spec.ts
+++ b/tests/sanity/tests/documents/documents-content.spec.ts
@@ -151,7 +151,7 @@ test.describe('Content in the Documents tests', () => {
   })
 
   test.describe('Image in the document', () => {
-    test('Check Image alignment setting', async ({ page }) => {
+    test('Check image alignment setting', async ({ page }) => {
       await documentContentPage.addImageToDocument(page)
 
       await test.step('Align image to right', async () => {
@@ -170,9 +170,8 @@ test.describe('Content in the Documents tests', () => {
       })
     })
 
-    test.skip('Check Image view and size actions', async ({ page }) => {
+    test.skip('Check Image size manipulations', async ({ page }) => {
       await documentContentPage.addImageToDocument(page)
-      const imageSrc = await documentContentPage.firstImageInDocument().getAttribute('src')
 
       await test.step('Set size of image to the 25%', async () => {
         await documentContentPage.clickImageSizeButton('25%')
@@ -194,6 +193,11 @@ test.describe('Content in the Documents tests', () => {
         await documentContentPage.clickImageSizeButton('Unset')
         await documentContentPage.checkImageSize(IMAGE_ORIGINAL_SIZE)
       })
+    })
+
+    test('Check Image views', async ({ page, context }) => {
+      await documentContentPage.addImageToDocument(page)
+      const imageSrc = await documentContentPage.firstImageInDocument().getAttribute('src')
 
       await test.step('User can open image in fullscreen on current page', async () => {
         await documentContentPage.clickImageFullscreenButton()
@@ -203,12 +207,11 @@ test.describe('Content in the Documents tests', () => {
       })
 
       await test.step('User can open image original in the new tab', async () => {
-        const [newPage] = await Promise.all([
-          page.waitForEvent('popup'),
-          documentContentPage.clickImageOriginalButton()
-        ])
+        const pagePromise = context.waitForEvent('page')
+        await documentContentPage.clickImageOriginalButton()
+        const newPage = await pagePromise
 
-        await newPage.waitForLoadState('domcontentloaded')
+        await newPage.waitForLoadState()
         expect(newPage.url()).toBe(imageSrc)
         await newPage.close()
       })

--- a/tests/sanity/tests/model/common-page.ts
+++ b/tests/sanity/tests/model/common-page.ts
@@ -16,7 +16,7 @@ export class CommonPage {
   selectPopupButton = (): Locator => this.page.locator('div.selectPopup button')
   selectPopupExpandButton = (): Locator => this.page.locator('div.selectPopup button[data-id="btnExpand"]')
   popupSpanLabel = (point: string): Locator =>
-    this.page.locator('div[class$="opup"] span[class*="label"]', { hasText: point })
+    this.page.locator(`div[class$="opup"] span[class*="label"]:has-text("${point}")`)
 
   readonly inputSearchIcon = (): Locator => this.page.locator('.searchInput-icon')
 

--- a/tests/sanity/tests/model/planning/planning-page.ts
+++ b/tests/sanity/tests/model/planning/planning-page.ts
@@ -16,6 +16,7 @@ export class PlanningPage extends CalendarPage {
   private readonly panel = (): Locator => this.page.locator('div.hulyModal-container')
   private readonly toDosContainer = (): Locator => this.page.locator('div.toDos-container')
   private readonly schedule = (): Locator => this.page.locator('div.hulyComponent.modal')
+  private readonly sidebarSchedule = (): Locator => this.page.locator('#sidebar .calendar-container')
   readonly pageHeader = (): Locator =>
     this.page.locator('div[class*="navigator"] div[class*="header"]', { hasText: 'Planning' })
 
@@ -80,6 +81,9 @@ export class PlanningPage extends CalendarPage {
 
   readonly eventInSchedule = (title: string): Locator =>
     this.schedule().locator('div.event-container', { hasText: title })
+
+  readonly eventInSidebarSchedule = (title: string): Locator =>
+    this.sidebarSchedule().locator('div.event-container', { hasText: title })
 
   readonly toDoInToDos = (hasText: string): Locator =>
     this.toDosContainer().locator('button.hulyToDoLine-container', { hasText })

--- a/tests/sanity/tests/model/recruiting/talent-details-page.ts
+++ b/tests/sanity/tests/model/recruiting/talent-details-page.ts
@@ -98,8 +98,8 @@ export class TalentDetailsPage extends CommonRecruitingPage {
     }
   }
 
-  async checkMergeContacts (talentName: string, title: string, source: string): Promise<void> {
-    await expect(this.page.locator('div.location input')).toHaveValue(talentName)
+  async checkMergeContacts (location: string, title: string, source: string): Promise<void> {
+    await expect(this.page.locator('div.location input')).toHaveValue(location)
     await expect(this.titleAndSourceTalent(title)).toBeVisible()
     await expect(this.titleAndSourceTalent(source)).toBeVisible()
   }

--- a/tests/sanity/tests/model/recruiting/talent-details-page.ts
+++ b/tests/sanity/tests/model/recruiting/talent-details-page.ts
@@ -19,12 +19,13 @@ export class TalentDetailsPage extends CommonRecruitingPage {
   readonly buttonMergeContacts = (): Locator =>
     this.page.locator('button[class*="menuItem"] span', { hasText: 'Merge contacts' })
 
-  readonly buttonFinalContact = (): Locator =>
-    this.page.locator('form[id="contact:string:MergePersons"] button', { hasText: 'Final contact' })
+  readonly formMergeContacts = (): Locator => this.page.locator('form[id="contact:string:MergePersons"]')
 
-  readonly buttonMergeRow = (): Locator => this.page.locator('form[id="contact:string:MergePersons"] div.box')
+  readonly buttonFinalContact = (): Locator => this.formMergeContacts().locator('button', { hasText: 'Final contact' })
+
+  readonly buttonMergeRow = (): Locator => this.formMergeContacts().locator('div.box')
   readonly buttonPopupMergeContacts = (): Locator =>
-    this.page.locator('form[id="contact:string:MergePersons"] button > span', { hasText: 'Merge contacts' })
+    this.formMergeContacts().locator('button:has-text("Merge contacts")')
 
   readonly textAttachmentName = (): Locator => this.page.locator('div.name a')
   readonly titleAndSourceTalent = (title: string): Locator => this.page.locator('button > span', { hasText: title })

--- a/tests/sanity/tests/model/recruiting/talent-details-page.ts
+++ b/tests/sanity/tests/model/recruiting/talent-details-page.ts
@@ -43,6 +43,12 @@ export class TalentDetailsPage extends CommonRecruitingPage {
     await expect(this.textTagItem().first()).toContainText(skillTag)
   }
 
+  async enterLocation (location: string): Promise<void> {
+    const input = this.inputLocation()
+    await input.click()
+    await input.fill(location)
+  }
+
   async addTitle (title: string): Promise<void> {
     await this.buttonInputTitle().click()
     await this.fillToSelectPopup(this.page, title)

--- a/tests/sanity/tests/model/sidebar-page.ts
+++ b/tests/sanity/tests/model/sidebar-page.ts
@@ -1,0 +1,120 @@
+import { expect, Locator, Page } from '@playwright/test'
+import { CommonPage } from './common-page'
+
+export type SidebarTabTypes = 'calendar' | 'office' | 'chat'
+
+export class SidebarPage extends CommonPage {
+  readonly page: Page
+
+  constructor (page: Page) {
+    super(page)
+    this.page = page
+  }
+
+  sidebar = (): Locator => this.page.locator('#sidebar')
+  content = (): Locator => this.sidebar().locator('.content')
+  contentHeaderByTitle = (title: string): Locator =>
+    this.content().locator(`.hulyHeader-titleGroup:has-text("${title}")`)
+
+  contentCloseButton = (): Locator => this.content().locator('.hulyHeader-container button.iconOnly').last()
+
+  calendarSidebarButton = (): Locator => this.sidebar().locator('button[id$="Calendar"]')
+  officeSidebarButton = (): Locator => this.sidebar().locator('button[id$="Office"]')
+  chatSidebarButton = (): Locator => this.sidebar().locator('button[id$="Chat"]')
+
+  verticalTabs = (): Locator => this.sidebar().locator('.tabs').locator('.container')
+  verticalTabByName = (name: string): Locator =>
+    this.sidebar().locator('.tabs').locator(`.container:has-text("${name}")`)
+
+  verticalTabCloseButton = (name: string): Locator => this.verticalTabByName(name).locator('.close-button button')
+  currentYear = new Date().getFullYear().toString()
+
+  plannerSidebarNextDayButton = (): Locator =>
+    this.sidebar().locator('.hulyHeader-buttonsGroup').getByRole('button').last()
+
+  // buttonOpenChannelInSidebar =
+
+  // Actions
+  async checkIfSidebarIsOpen (isOpen: boolean): Promise<void> {
+    await expect(this.content()).toBeVisible({ visible: isOpen })
+  }
+
+  async checkIfSidebarHasVerticalTab (isExist: boolean, tabName: string): Promise<void> {
+    await expect(this.verticalTabByName(tabName)).toBeVisible({ visible: isExist })
+  }
+
+  async clickVerticalTab (tabName: string): Promise<void> {
+    await this.verticalTabByName(tabName).click()
+  }
+
+  async closeVerticalTabByCloseButton (tabName: string): Promise<void> {
+    await this.verticalTabCloseButton(tabName).click()
+  }
+
+  async closeOpenedVerticalTab (): Promise<void> {
+    await this.contentCloseButton().click()
+  }
+
+  async pinVerticalTab (tabName: string): Promise<void> {
+    await this.verticalTabByName(tabName).click({ button: 'right' })
+    await this.page.locator('.popup').locator('button:has-text("Pin")').click()
+  }
+
+  async unpinVerticalTab (tabName: string): Promise<void> {
+    await this.verticalTabByName(tabName).click({ button: 'right' })
+    await this.page.locator('.popup').locator('button:has-text("Unpin")').click()
+  }
+
+  async closeVerticalTabByRightClick (tabName: string): Promise<void> {
+    await this.verticalTabByName(tabName).click({ button: 'right' })
+    await this.page.locator('.popup').locator('button:has-text("Close")').click()
+  }
+
+  async checkIfVerticalTabIsPinned (needBePinned: boolean, tabName: string): Promise<void> {
+    await expect(this.verticalTabCloseButton(tabName)).toBeVisible({ visible: !needBePinned })
+  }
+
+  async checkNumberOfVerticalTabs (count: number): Promise<void> {
+    await expect(this.verticalTabs()).toHaveCount(count)
+  }
+
+  async checkIfPlanerSidebarTabIsOpen (isExist: boolean): Promise<void> {
+    await expect(this.contentHeaderByTitle(this.currentYear)).toBeVisible({ visible: isExist })
+  }
+
+  async checkIfChatSidebarTabIsOpen (isExist: boolean, channelName: string): Promise<void> {
+    await expect(this.contentHeaderByTitle(channelName)).toBeVisible({ visible: isExist })
+  }
+
+  async checkIfOfficeSidebarTabIsOpen (isExist: boolean, channelName: string): Promise<void> {
+    await expect(this.contentHeaderByTitle('Office')).toBeVisible({ visible: isExist })
+  }
+
+  async checkIfSidebarPageButtonIsExist (isExist: boolean, type: SidebarTabTypes): Promise<void> {
+    switch (type) {
+      case 'chat':
+        await expect(this.chatSidebarButton()).toBeVisible({ visible: isExist })
+        break
+      case 'office':
+        await expect(this.officeSidebarButton()).toBeVisible({ visible: isExist })
+        break
+      case 'calendar':
+        await expect(this.calendarSidebarButton()).toBeVisible({ visible: isExist })
+        break
+    }
+  }
+
+  async clickSidebarPageButton (type: SidebarTabTypes): Promise<void> {
+    switch (type) {
+      case 'chat':
+        await this.chatSidebarButton().click()
+        break
+      case 'office':
+        await this.officeSidebarButton().click()
+        break
+      case 'calendar':
+        await this.calendarSidebarButton().click()
+        break
+    }
+  }
+}

--- a/tests/sanity/tests/recruiting/talents.spec.ts
+++ b/tests/sanity/tests/recruiting/talents.spec.ts
@@ -84,7 +84,7 @@ test.describe('candidate/talents tests', () => {
     )
 
     if (!templatesResponse.ok()) {
-      throw new Error('Templates aren\'t loaded')
+      throw new Error('Templates need be loaded')
     }
 
     const documentsResponse = await talentDetailsPage.page.waitForResponse(
@@ -92,7 +92,7 @@ test.describe('candidate/talents tests', () => {
     )
 
     if (!documentsResponse.ok()) {
-      throw new Error('Documents aren\'t loaded')
+      throw new Error('Documents need be loaded')
     }
 
     await talentDetailsPage.inputLocation().fill('Awesome Location Merge1')

--- a/tests/sanity/tests/recruiting/talents.spec.ts
+++ b/tests/sanity/tests/recruiting/talents.spec.ts
@@ -74,14 +74,15 @@ test.describe('candidate/talents tests', () => {
   })
 
   test('Merge contacts', async () => {
+    const firstLocation = 'Location 1'
+    const secondLocation = 'Location 2'
+
     await navigationMenuPage.clickButtonTalents()
     // talent1
     const talentNameFirst = await talentsPage.createNewTalent()
     await talentsPage.openTalentByTalentName(talentNameFirst)
 
-    // Workaround: click() is nesesarry, editbox reset the field without it
-    await talentDetailsPage.inputLocation().click()
-    await talentDetailsPage.inputLocation().fill('Awesome Location Merge1')
+    await talentDetailsPage.enterLocation(firstLocation)
     const titleTalent1 = 'TitleMerge1'
     await talentDetailsPage.addTitle(titleTalent1)
     const sourceTalent1 = 'SourceTalent1'
@@ -93,9 +94,7 @@ test.describe('candidate/talents tests', () => {
     const talentNameSecond = await talentsPage.createNewTalent()
     await talentsPage.openTalentByTalentName(talentNameSecond)
 
-    // Workaround: click() is nesesarry, editbox reset the field without it
-    await talentDetailsPage.inputLocation().click()
-    await talentDetailsPage.inputLocation().fill('Awesome Location Merge2')
+    await talentDetailsPage.enterLocation(secondLocation)
     const titleTalent2 = 'TitleMerge2'
     await talentDetailsPage.addTitle(titleTalent2)
     const sourceTalent2 = 'SourceTalent2'
@@ -110,7 +109,7 @@ test.describe('candidate/talents tests', () => {
       finalContactName: talentNameSecond.lastName,
       name: `${talentNameFirst.lastName} ${talentNameFirst.firstName}`,
       mergeLocation: true,
-      location: 'Awesome Location Merge1',
+      location: firstLocation,
       mergeTitle: true,
       title: titleTalent1,
       mergeSource: true,
@@ -122,7 +121,7 @@ test.describe('candidate/talents tests', () => {
     await talentsPage.openTalentByTalentName(talentNameFirst)
     await talentDetailsPage.checkSocialLinks('Phone', '123123213213')
     await talentDetailsPage.checkSocialLinks('Email', 'test-merge-2@gmail.com')
-    await talentDetailsPage.checkMergeContacts('Awesome Location Merge1', titleTalent2, sourceTalent2)
+    await talentDetailsPage.checkMergeContacts(firstLocation, titleTalent2, sourceTalent2)
   })
 
   test('Match to vacancy', async () => {

--- a/tests/sanity/tests/recruiting/talents.spec.ts
+++ b/tests/sanity/tests/recruiting/talents.spec.ts
@@ -78,6 +78,23 @@ test.describe('candidate/talents tests', () => {
     // talent1
     const talentNameFirst = await talentsPage.createNewTalent()
     await talentsPage.openTalentByTalentName(talentNameFirst)
+
+    const templatesResponse = await talentDetailsPage.page.waitForResponse(
+      (res) => res.url().includes('templates') && res.status() === 200
+    )
+
+    if (!templatesResponse.ok()) {
+      throw new Error('Templates aren\'t loaded')
+    }
+
+    const documentsResponse = await talentDetailsPage.page.waitForResponse(
+      (res) => res.url().includes('documents') && res.status() === 200
+    )
+
+    if (!documentsResponse.ok()) {
+      throw new Error('Documents aren\'t loaded')
+    }
+
     await talentDetailsPage.inputLocation().fill('Awesome Location Merge1')
     const titleTalent1 = 'TitleMerge1'
     await talentDetailsPage.addTitle(titleTalent1)

--- a/tests/sanity/tests/recruiting/talents.spec.ts
+++ b/tests/sanity/tests/recruiting/talents.spec.ts
@@ -79,22 +79,8 @@ test.describe('candidate/talents tests', () => {
     const talentNameFirst = await talentsPage.createNewTalent()
     await talentsPage.openTalentByTalentName(talentNameFirst)
 
-    const templatesResponse = await talentDetailsPage.page.waitForResponse(
-      (res) => res.url().includes('templates') && res.status() === 200
-    )
-
-    if (!templatesResponse.ok()) {
-      throw new Error('Templates need be loaded')
-    }
-
-    const documentsResponse = await talentDetailsPage.page.waitForResponse(
-      (res) => res.url().includes('documents') && res.status() === 200
-    )
-
-    if (!documentsResponse.ok()) {
-      throw new Error('Documents need be loaded')
-    }
-
+    // Workaround: click() is nesesarry, editbox reset the field without it
+    await talentDetailsPage.inputLocation().click()
     await talentDetailsPage.inputLocation().fill('Awesome Location Merge1')
     const titleTalent1 = 'TitleMerge1'
     await talentDetailsPage.addTitle(titleTalent1)
@@ -106,6 +92,9 @@ test.describe('candidate/talents tests', () => {
     await navigationMenuPage.clickButtonTalents()
     const talentNameSecond = await talentsPage.createNewTalent()
     await talentsPage.openTalentByTalentName(talentNameSecond)
+
+    // Workaround: click() is nesesarry, editbox reset the field without it
+    await talentDetailsPage.inputLocation().click()
     await talentDetailsPage.inputLocation().fill('Awesome Location Merge2')
     const titleTalent2 = 'TitleMerge2'
     await talentDetailsPage.addTitle(titleTalent2)


### PR DESCRIPTION
**Add new tests for New Sidebar:**

* Add Channels to Sidebar from the Left Menu
* Pin/Unpin tabs
* Close tabs (via context menu or close button)
* Hide sidebar when user goes to another channel (may be changed)
* Close tabs and close sidebar at the end
* Create sidebar automatically when user replies to message
* Add first small checking of work in sidebar inside of existing planer tests

**Fix flaky tests:**

* Image Original View test
* Merge Contacts test

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmVlYmIwNzEzNTdlNDAxYjg5NjIwYmQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.RR1TQZQlSymiGkyxgOsdTRIJFOJoAA1iDBV-Xj7DExk">Huly&reg;: <b>UBERF-8212</b></a></sub>