### PR TITLE
Freeze scroll and reading if tab not active

### DIFF
--- a/plugins/chunter-resources/src/channelDataProvider.ts
+++ b/plugins/chunter-resources/src/channelDataProvider.ts
@@ -529,7 +529,6 @@ export class ChannelDataProvider implements IChannelDataProvider {
       },
       { sort: { createdOn: SortingOrder.Ascending } }
     )
-    console.log({ firstNotification, lastViewedTimestamp })
 
     if (lastViewedTimestamp === undefined && firstNotification === undefined) {
       return -1

--- a/plugins/chunter-resources/src/channelDataProvider.ts
+++ b/plugins/chunter-resources/src/channelDataProvider.ts
@@ -119,7 +119,7 @@ export class ChannelDataProvider implements IChannelDataProvider {
   })
 
   constructor (
-    readonly context: DocNotifyContext | undefined,
+    private context: DocNotifyContext | undefined,
     readonly space: Ref<Space>,
     chatId: Ref<Doc>,
     _class: Ref<Class<ActivityMessage>>,
@@ -207,6 +207,13 @@ export class ChannelDataProvider implements IChannelDataProvider {
         sort: { createdOn: SortingOrder.Ascending }
       }
     )
+  }
+
+  async updateNewTimestamp (context?: DocNotifyContext): Promise<void> {
+    this.context = context ?? this.context
+    const firstNewMsgIndex = await this.getFirstNewMsgIndex()
+    const metadata = get(this.metadataStore)
+    this.newTimestampStore.set(firstNewMsgIndex !== undefined ? metadata[firstNewMsgIndex]?.createdOn : undefined)
   }
 
   private async loadInitialMessages (
@@ -522,6 +529,7 @@ export class ChannelDataProvider implements IChannelDataProvider {
       },
       { sort: { createdOn: SortingOrder.Ascending } }
     )
+    console.log({ firstNotification, lastViewedTimestamp })
 
     if (lastViewedTimestamp === undefined && firstNotification === undefined) {
       return -1

--- a/plugins/chunter-resources/src/components/ChannelScrollView.svelte
+++ b/plugins/chunter-resources/src/components/ChannelScrollView.svelte
@@ -135,7 +135,7 @@
   let isPageHidden = false
   let lastMsgBeforeFreeze: Ref<ActivityMessage> | undefined = undefined
 
-  document.addEventListener('visibilitychange', () => {
+  function handleVisibilityChange (): void {
     if (document.hidden) {
       isPageHidden = true
       lastMsgBeforeFreeze = shouldScrollToNew ? displayMessages[displayMessages.length - 1]?._id : undefined
@@ -145,7 +145,7 @@
         void provider.updateNewTimestamp(notifyContext)
       }
     }
-  })
+  }
 
   function isFreeze (): boolean {
     return freeze || isPageHidden
@@ -693,10 +693,12 @@
 
   onMount(() => {
     chatReadMessagesStore.update(() => new Set())
+    document.addEventListener('visibilitychange', handleVisibilityChange)
   })
 
   onDestroy(() => {
     unsubscribe()
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
   })
 
   let showScrollDownButton = false

--- a/plugins/chunter-resources/src/components/ChannelScrollView.svelte
+++ b/plugins/chunter-resources/src/components/ChannelScrollView.svelte
@@ -26,7 +26,7 @@
     messageInFocus,
     sortActivityMessages
   } from '@hcengineering/activity-resources'
-  import { Doc, getDay, Ref, Timestamp } from '@hcengineering/core'
+  import { Doc, getCurrentAccount, getDay, Ref, Timestamp } from '@hcengineering/core'
   import { DocNotifyContext } from '@hcengineering/notification'
   import { InboxNotificationsClientImpl } from '@hcengineering/notification-resources'
   import { getResource } from '@hcengineering/platform'
@@ -72,6 +72,7 @@
   const minMsgHeightRem = 2
   const loadMoreThreshold = 40
 
+  const me = getCurrentAccount()
   const client = getClient()
   const inboxClient = InboxNotificationsClientImpl.getClient()
   const contextByDocStore = inboxClient.contextByDoc
@@ -131,8 +132,23 @@
       }
     })
 
+  let isPageHidden = false
+  let lastMsgBeforeFreeze: Ref<ActivityMessage> | undefined = undefined
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      isPageHidden = true
+      lastMsgBeforeFreeze = shouldScrollToNew ? displayMessages[displayMessages.length - 1]?._id : undefined
+    } else {
+      if (isPageHidden) {
+        isPageHidden = false
+        void provider.updateNewTimestamp(notifyContext)
+      }
+    }
+  })
+
   function isFreeze (): boolean {
-    return freeze
+    return freeze || isPageHidden
   }
 
   $: displayMessages = filterChatMessages(messages, filters, filterResources, doc._class, selectedFilters)
@@ -292,6 +308,38 @@
       shouldScrollToNew = false
       isScrollAtBottom = false
       provider.addNextChunk('forward', messages[messages.length - 1]?.createdOn, limit)
+    }
+  }
+
+  function scrollToStartOfNew (): void {
+    if (!scrollElement || !lastMsgBeforeFreeze) {
+      return
+    }
+
+    const lastIndex = displayMessages.findIndex(({ _id }) => _id === lastMsgBeforeFreeze)
+    if (lastIndex === -1) return
+    const firstNewMessage = displayMessages.find(({ createdBy }, index) => index > lastIndex && createdBy !== me._id)
+
+    if (firstNewMessage === undefined) {
+      scrollToBottom()
+      return
+    }
+
+    const messagesElements = scrollContentBox?.getElementsByClassName('activityMessage')
+    const msgElement = messagesElements?.[firstNewMessage._id as any]
+
+    if (!msgElement) {
+      return
+    }
+
+    const messageRect = msgElement.getBoundingClientRect()
+
+    const topOffset = messageRect.top - 150
+
+    if (topOffset < 0) {
+      scroller?.scrollBy(topOffset)
+    } else if (topOffset > 0) {
+      scroller?.scrollBy(topOffset)
     }
   }
 
@@ -555,8 +603,12 @@
       return
     }
 
+    const prevCount = messagesCount
+    messagesCount = newCount
+
     if (isFreeze()) {
-      messagesCount = newCount
+      await wait()
+      scrollToStartOfNew()
       return
     }
 
@@ -565,15 +617,13 @@
     } else if (dateToJump !== undefined) {
       await wait()
       scrollToDate(dateToJump)
-    } else if (shouldScrollToNew && messagesCount > 0 && newCount > messagesCount) {
+    } else if (shouldScrollToNew && prevCount > 0 && newCount > prevCount) {
       await wait()
       scrollToNewMessages()
     } else {
       await wait()
       readViewportMessages()
     }
-
-    messagesCount = newCount
   }
 
   $: void handleMessagesUpdated(displayMessages.length)
@@ -610,10 +660,12 @@
 
   afterUpdate(() => {
     if (!scrollElement) return
-    const { scrollHeight } = scrollElement
+    const { offsetHeight, scrollHeight, scrollTop } = scrollElement
 
-    if (!isInitialScrolling && prevScrollHeight < scrollHeight && isScrollAtBottom) {
+    if (!isInitialScrolling && !isFreeze() && prevScrollHeight < scrollHeight && isScrollAtBottom) {
       scrollToBottom()
+    } else if (isFreeze()) {
+      isScrollAtBottom = scrollHeight <= Math.ceil(scrollTop + offsetHeight)
     }
   })
 
@@ -715,7 +767,7 @@
 
   const canLoadNextForwardStore = provider.canLoadNextForwardStore
 
-  $: if (!freeze) {
+  $: if (!freeze && !isPageHidden && isScrollInitialized) {
     readViewportMessages()
   }
 </script>


### PR DESCRIPTION
* Freeze not chat in not active tab (disable scroll to bottom and do not read messages)
* When come back to tab show start of new messages

https://github.com/user-attachments/assets/5b40675d-7dd8-4374-9a74-41cfc56029d1

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmYwZmJlYTI5ZGM1ZTdmMzI0NTU4ODUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.ZhwiXnbJLH9A_KnIE0q_YxcHIZi2GvRyusjz0TeV2OA">Huly&reg;: <b>UBERF-8229</b></a></sub>