### PR TITLE
UBERF-8210: Allow only one upgrade

### DIFF
--- a/desktop/src/main/start.ts
+++ b/desktop/src/main/start.ts
@@ -365,7 +365,12 @@ if (isMac) {
   })
 }
 
+// Note: it is reset when the app is relaunched after update
+let isUpdating = false
+
 autoUpdater.on('update-available', (info: UpdateInfo) => {
+  if (isUpdating) return
+
   void dialog
     .showMessageBox({
       type: 'info',
@@ -379,6 +384,7 @@ autoUpdater.on('update-available', (info: UpdateInfo) => {
       if (response !== 0) {
         app.quit()
       }
+      isUpdating = true
     })
 })
 
@@ -400,7 +406,7 @@ autoUpdater.on('update-downloaded', (info) => {
 ipcMain.on('start-backup', (event, token, endpoint, workspace) => {
   console.log('start backup', token, endpoint, workspace)
   if (mainWindow != null) {
-    startBackup(mainWindow, token, endpoint, workspace  , (cmd: string, ...args: any[]) => {
+    startBackup(mainWindow, token, endpoint, workspace, (cmd: string, ...args: any[]) => {
       mainWindow?.webContents.send(cmd, ...args)
     })
   }


### PR DESCRIPTION
* Allows only one upgrade dialog per app run

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-8210
Closes https://github.com/hcengineering/platform/issues/6662

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmYxMWU2MjI5ZGM1ZTdmMzI0NTU5OTQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.j6DtgouQgx-1snxSLRpVzkjuTeqBCKzTfQ4FQk387WY">Huly&reg;: <b>UBERF-8232</b></a></sub>