### PR TITLE
UBERF-8242 Fix scroll jumping in codeblock

### DIFF
--- a/plugins/text-editor-resources/src/components/extension/codeblock.ts
+++ b/plugins/text-editor-resources/src/components/extension/codeblock.ts
@@ -133,7 +133,7 @@ function createDecorations (doc: ProseMirrorNode, options: CodeBlockLowlightOpti
   doc.descendants((node, pos) => {
     if (node.type.name === CodeBlockLowlight.name) {
       decorations.push(
-        Decoration.widget(pos + node.nodeSize - 1, (view) => {
+        Decoration.widget(pos + 1, (view) => {
           const button = createLangButton(node.attrs.language)
 
           if (view.editable) {


### PR DESCRIPTION
An attempt to fix jumping scroll in codeblock. The issue seem to be caused by decoration widgets rendered in the end. Moved them to the beginning of the codeblock.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmYxYTMzNmMwYWUxNGFkY2Y2ZmJjNjAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.e0oZImEn4Zl5L11EK9HkUCrb_x_CAt0NWIMEzbNzmVg">Huly&reg;: <b>UBERF-8243</b></a></sub>