### PR TITLE
fix: report invalid content errors to analytics

### DIFF
--- a/plugins/text-editor-resources/package.json
+++ b/plugins/text-editor-resources/package.json
@@ -42,6 +42,7 @@
     "@hcengineering/platform": "^0.6.11",
     "svelte": "^4.2.12",
     "@hcengineering/ui": "^0.6.15",
+    "@hcengineering/analytics": "^0.6.0",
     "@hcengineering/presentation": "^0.6.3",
     "@hcengineering/core": "^0.6.32",
     "@hcengineering/view": "^0.6.13",

--- a/plugins/text-editor-resources/src/components/TextEditor.svelte
+++ b/plugins/text-editor-resources/src/components/TextEditor.svelte
@@ -14,6 +14,7 @@
 // limitations under the License.
 -->
 <script lang="ts">
+  import { Analytics } from '@hcengineering/analytics'
   import { Markup } from '@hcengineering/core'
   import { IntlString, translate } from '@hcengineering/platform'
   import { EmptyMarkup, getMarkup, markupToJSON } from '@hcengineering/text'
@@ -150,6 +151,7 @@
   onMount(() => {
     void ph.then(async () => {
       editor = new Editor({
+        enableContentCheck: true,
         element,
         editorProps: {
           attributes: mergeAttributes(defaultEditorAttributes, editorAttributes),
@@ -197,6 +199,9 @@
           content = getContent()
           dispatch('value', content)
           dispatch('update', content)
+        },
+        onContentError: ({ error }) => {
+          Analytics.handleError(error)
         }
       })
     })


### PR DESCRIPTION
Tiptap 2.6.6 has an event that is emitted when the editor fails to parse the content. In this PR I aded simple handler for this event to report the error and disable collaboration to avoid content corruption.

https://tiptap.dev/docs/editor/core-concepts/schema#invalid-schema-handling

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmYyNTRkYWMwYWUxNGFkY2Y2ZmJkODciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.1XmxS_pMKPUiwl9XaCcs5AesMsjvq_q5eo5BCBFGRWk">Huly&reg;: <b>UBERF-8247</b></a></sub>