### PR TITLE
fix: remove workspace id from indexeddb document name

### DIFF
--- a/plugins/text-editor-resources/src/provider/indexeddb.ts
+++ b/plugins/text-editor-resources/src/provider/indexeddb.ts
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import { getMetadata } from '@hcengineering/platform'
-import presentation from '@hcengineering/presentation'
 
 import { type Doc as YDoc } from 'yjs'
 import { IndexeddbPersistence } from 'y-indexeddb'
@@ -26,11 +24,7 @@ export class IndexeddbProvider extends IndexeddbPersistence implements Provider 
   readonly awareness: Awareness | null = null
 
   constructor (documentId: string, doc: YDoc) {
-    const workspaceId: string = getMetadata(presentation.metadata.WorkspaceId) ?? ''
-
-    const name = `${workspaceId}/${documentId}`
-
-    super(name, doc)
+    super(documentId, doc)
 
     this.loaded = new Promise((resolve) => {
       this.on('synced', resolve)


### PR DESCRIPTION
documentId already contains workspaceId, no need to duplicate

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmYyNWQ5N2MwYWUxNGFkY2Y2ZmJkYmIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.L5ZS8UXht45fBYMY2aYberyF9tPhcFMHVD2j-7HA0cc">Huly&reg;: <b>UBERF-8248</b></a></sub>