### PR TITLE
UBERF-8294: Do not upgrade stale workspaces

### DIFF
--- a/server/account/src/operations.ts
+++ b/server/account/src/operations.ts
@@ -1017,7 +1017,8 @@ export async function listWorkspacesByAccount (db: Db, email: string): Promise<W
 export async function countWorkspacesInRegion (
   db: Db,
   region: string = '',
-  upToVersion?: Data<Version>
+  upToVersion?: Data<Version>,
+  visitedSince?: number
 ): Promise<number> {
   const regionQuery = region === '' ? { $or: [{ region: { $exists: false } }, { region: '' }] } : { region }
   const query: Filter<Workspace>['$and'] = [
@@ -1037,6 +1038,10 @@ export async function countWorkspacesInRegion (
         }
       ]
     })
+  }
+
+  if (visitedSince !== undefined) {
+    query.push({ lastVisit: { $gt: visitedSince } })
   }
 
   return await db.collection<Workspace>(WORKSPACE_COLLECTION).countDocuments({
@@ -1256,7 +1261,7 @@ export async function workerHandshake (
   const workspacesCnt = await ctx.with(
     'count-workspaces-in-region',
     {},
-    async (ctx) => await countWorkspacesInRegion(db, region, version)
+    async (ctx) => await countWorkspacesInRegion(db, region, version, Date.now() - 24 * 60 * 60 * 1000)
   )
 
   await db.collection<UpgradeStatistic>(UPGRADE_COLLECTION).insertOne({
@@ -1494,7 +1499,10 @@ export async function getPendingWorkspace (
         {
           $or: [{ mode: 'active' }, { mode: { $exists: false } }]
         },
-        versionQuery
+        versionQuery,
+        {
+          lastVisit: { $gt: Date.now() - 24 * 60 * 60 * 1000 }
+        }
       ]
     },
     {


### PR DESCRIPTION
* Prevents stale workspaces from being upgraded until they are active again

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-8294
Closes https://github.com/hcengineering/platform/issues/6746

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmY1NjY4NDFjYjUwNjYzZTU5MzMxYTciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.xSP-4NXjK78M5E3FI9U9g54y3ZYFjG94MvGMoVAlqBU">Huly&reg;: <b>UBERF-8296</b></a></sub>