### PR TITLE
EZQMS-1213: replace toSorted uses with sort

### DIFF
--- a/plugins/controlled-documents-resources/src/components/document/DocumentHistory.svelte
+++ b/plugins/controlled-documents-resources/src/components/document/DocumentHistory.svelte
@@ -52,7 +52,7 @@
         (doc.major === $controlledDocument.major && doc.minor <= $controlledDocument.minor)
       )
     })
-    .toSorted(documentCompareFn)
+    .sort(documentCompareFn)
 
   function getDescription (cc: ChangeControl | undefined): string {
     if (cc === undefined) {

--- a/plugins/questions-resources/package.json
+++ b/plugins/questions-resources/package.json
@@ -7,6 +7,7 @@
     "build": "compile ui",
     "build:watch": "compile ui",
     "format": "format src",
+    "svelte-check": "do-svelte-check",
     "_phase:build": "compile ui",
     "_phase:format": "format src",
     "_phase:validate": "compile validate"

--- a/plugins/questions-resources/src/components/OrderingAnswerDataEditor.svelte
+++ b/plugins/questions-resources/src/components/OrderingAnswerDataEditor.svelte
@@ -45,12 +45,12 @@
   $: if (showDiff && assessmentData !== null) {
     indices = assessmentData.correctOrder
       .map((position, index) => [position, index])
-      .toSorted(([aPosition], [bPosition]) => (aPosition > bPosition ? 1 : aPosition < bPosition ? -1 : 0))
+      .sort(([aPosition], [bPosition]) => (aPosition > bPosition ? 1 : aPosition < bPosition ? -1 : 0))
       .map(([_, index]) => index) as [number, ...number[]]
   } else if (answerData !== null) {
     indices = answerData.order
       .map((position, index) => [position, index])
-      .toSorted(([aPosition], [bPosition]) => (aPosition > bPosition ? 1 : aPosition < bPosition ? -1 : 0))
+      .sort(([aPosition], [bPosition]) => (aPosition > bPosition ? 1 : aPosition < bPosition ? -1 : 0))
       .map(([_, index]) => index) as [number, ...number[]]
   } else {
     indices = questionData.options.map((_, index) => index) as [number, ...number[]]
@@ -67,7 +67,7 @@
     indices = moveItem(indices, from, to)
     const order = indices
       .map((initialIndex, index) => [initialIndex, index])
-      .toSorted(([aInitialIndex], [bInitialIndex]) =>
+      .sort(([aInitialIndex], [bInitialIndex]) =>
         aInitialIndex > bInitialIndex ? 1 : aInitialIndex < bInitialIndex ? -1 : 0
       )
       .map(([_, index]) => index + 1) as [OrderingPosition, ...OrderingPosition[]]

--- a/plugins/questions-resources/src/functions/MultipleChoiceAssessmentAssess.ts
+++ b/plugins/questions-resources/src/functions/MultipleChoiceAssessmentAssess.ts
@@ -16,6 +16,8 @@ MultipleChoiceAssessmentAnswer
   return {
     score:
       // eslint-disable-next-line @typescript-eslint/require-array-sort-compare
-      answerData.selectedIndices.toSorted().join('~') === assessmentData.correctIndices.toSorted().join('~') ? 100 : 0
+      answerData.selectedIndices.slice().sort().join('~') === assessmentData.correctIndices.slice().sort().join('~')
+        ? 100
+        : 0
   }
 }

--- a/plugins/recruit-resources/src/components/EditVacancy.svelte
+++ b/plugins/recruit-resources/src/components/EditVacancy.svelte
@@ -15,7 +15,7 @@
 -->
 <script lang="ts">
   import { AttachmentStyleBoxCollabEditor } from '@hcengineering/attachment-resources'
-  import core, { ClassifierKind, Data, Doc, Mixin, Ref } from '@hcengineering/core'
+  import core, { ClassifierKind, type CollaborativeDoc, Data, Doc, Mixin, Ref } from '@hcengineering/core'
   import notification from '@hcengineering/notification'
   import { Panel } from '@hcengineering/panel'
   import { getResource } from '@hcengineering/platform'
@@ -35,7 +35,7 @@
   let object: Required<Vacancy>
   let rawName: string = ''
   let rawDesc: string = ''
-  let rawFullDesc: string = ''
+  let rawFullDesc: CollaborativeDoc
   let lastId: Ref<Vacancy> | undefined = undefined
 
   let showAllMixins = false

--- a/plugins/recruit-resources/src/components/NotificationApplicantPresenter.svelte
+++ b/plugins/recruit-resources/src/components/NotificationApplicantPresenter.svelte
@@ -26,10 +26,14 @@
   let candidate: Candidate | undefined = undefined
   const client = getClient()
   const hierarchy = client.getHierarchy()
-  $: spaceQuery.query(recruit.class.Vacancy, { _id: value.space }, (res) => ([currentVacancy] = res))
+  $: spaceQuery.query(recruit.class.Vacancy, { _id: value.space }, (res) => {
+    ;[currentVacancy] = res
+  })
   const shortLabel = value && hierarchy.getClass(value._class).shortLabel
 
-  $: candidateQuery.query(recruit.mixin.Candidate, { _id: value.attachedTo }, (res) => ([candidate] = res))
+  $: candidateQuery.query(recruit.mixin.Candidate, { _id: value.attachedTo }, (res) => {
+    ;[candidate] = res
+  })
 
   $: title = `${shortLabel}-${value?.number}`
 </script>

--- a/plugins/recruit-resources/src/components/OptimizeSkills.svelte
+++ b/plugins/recruit-resources/src/components/OptimizeSkills.svelte
@@ -232,7 +232,8 @@
     goodTagMap = toIdMap(goodTags)
 
     const goodSortedTags = goodTags
-      .toSorted((a, b) => b.title.length - a.title.length)
+      .slice()
+      .sort((a, b) => b.title.length - a.title.length)
       .filter((t) => t.title.length > 2)
     const goodSortedTagsTitles = new Map<Ref<TagElement>, string>()
     processed = -1
@@ -251,7 +252,7 @@
 
     const tagElementIds = new Map<Ref<TagElement>, TagUpdatePlan['elements'][0]>()
 
-    for (const tag of tagElements.toSorted((a, b) => prepareTitle(a.title).length - prepareTitle(b.title).length)) {
+    for (const tag of tagElements.slice().sort((a, b) => prepareTitle(a.title).length - prepareTitle(b.title).length)) {
       processed++
       const refs = allRefs.filter((it) => it.tag === tag._id)
       if (goodTagMap.has(tag._id)) {

--- a/plugins/recruit-resources/src/components/icons/Vacancy.svelte
+++ b/plugins/recruit-resources/src/components/icons/Vacancy.svelte
@@ -14,7 +14,9 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  export let size: 'x-small' | 'small' | 'medium' | 'large'
+  import { IconSize } from '@hcengineering/ui'
+
+  export let size: IconSize
   const fill: string = 'currentColor'
 </script>
 

--- a/plugins/time-resources/src/components/team/calendar/TeamCalendarDay.svelte
+++ b/plugins/time-resources/src/components/team/calendar/TeamCalendarDay.svelte
@@ -143,14 +143,14 @@
         ...gitem.events,
         ...gitem.busyEvents,
         ...gitem.busy.slots
-      ].toSorted((a, b) => a.date - b.date)}
+      ].sort((a, b) => a.date - b.date)}
       <div style:overflow-x={'hidden'} style:overflow-y={'auto'} style:height="{height}rem">
         <div class="flex flex-row-center">
           <div class="flex-nowrap p-1 w-full" style:display={'inline-flex'}>
             {#each Array.from(Array(24).keys()) as hour}
               {@const _slots = slots
                 .filter((it) => new Date(it.date).getHours() === hour)
-                .toSorted((a, b) => a.date - b.date)}
+                .sort((a, b) => a.date - b.date)}
               {@const cwidth = hourWidths[hour]}
               <div class="flex-col" style:width="{cwidth}rem">
                 {#each _slots as m, i}

--- a/plugins/training-resources/package.json
+++ b/plugins/training-resources/package.json
@@ -7,6 +7,7 @@
     "build": "compile ui",
     "build:watch": "compile ui",
     "format": "format src",
+    "svelte-check": "do-svelte-check",
     "_phase:build": "compile ui",
     "_phase:format": "format src",
     "_phase:validate": "compile validate"

--- a/plugins/training-resources/src/components/SentRequestCompletionPopup.svelte
+++ b/plugins/training-resources/src/components/SentRequestCompletionPopup.svelte
@@ -43,7 +43,7 @@
           _id: employee._id as Ref<Item>,
           completion: completionMap.get(employee._id) as CompletionMapValue
         }))
-        .toSorted((item1, item2) => compareCompletionMapValueState(item1.completion.state, item2.completion.state))
+        .sort((item1, item2) => compareCompletionMapValueState(item1.completion.state, item2.completion.state))
     },
     {
       sort: {

--- a/plugins/training-resources/src/functions/trainingAttemptStateSort.ts
+++ b/plugins/training-resources/src/functions/trainingAttemptStateSort.ts
@@ -9,7 +9,7 @@ export async function trainingAttemptStateSort (
   _: TxOperations,
   states: TrainingAttemptState[]
 ): Promise<TrainingAttemptState[]> {
-  return states.toSorted(
-    (state1, state2) => trainingAttemptStateOrder.indexOf(state2) - trainingAttemptStateOrder.indexOf(state1)
-  )
+  return states
+    .slice()
+    .sort((state1, state2) => trainingAttemptStateOrder.indexOf(state2) - trainingAttemptStateOrder.indexOf(state1))
 }

--- a/plugins/training-resources/src/functions/trainingStateSort.ts
+++ b/plugins/training-resources/src/functions/trainingStateSort.ts
@@ -17,5 +17,7 @@ import type { TxOperations } from '@hcengineering/core'
 import { type TrainingState, trainingStateOrder } from '@hcengineering/training'
 
 export async function trainingStateSort (_: TxOperations, states: TrainingState[]): Promise<TrainingState[]> {
-  return states.toSorted((state1, state2) => trainingStateOrder.indexOf(state1) - trainingStateOrder.indexOf(state2))
+  return states
+    .slice()
+    .sort((state1, state2) => trainingStateOrder.indexOf(state1) - trainingStateOrder.indexOf(state2))
 }

--- a/plugins/workbench-resources/package.json
+++ b/plugins/workbench-resources/package.json
@@ -8,6 +8,7 @@
     "build": "compile ui",
     "build:docs": "api-extractor run --local",
     "format": "format src",
+    "svelte-check": "do-svelte-check",
     "build:watch": "compile ui",
     "_phase:build": "compile ui",
     "_phase:format": "format src",

--- a/plugins/workbench-resources/src/components/statistics/MetricsInfo.svelte
+++ b/plugins/workbench-resources/src/components/statistics/MetricsInfo.svelte
@@ -98,7 +98,7 @@
   {/each}
   {#each Object.entries(metrics.params) as [k, v], i}
     <div style:margin-left={`${level * 0.5}rem`}>
-      {#each Object.entries(v).toSorted((a, b) => b[1].value / (b[1].operations + 1) - a[1].value / (a[1].operations + 1)) as [kk, vv]}
+      {#each Object.entries(v).sort((a, b) => b[1].value / (b[1].operations + 1) - a[1].value / (a[1].operations + 1)) as [kk, vv]}
         {@const childExpandable =
           vv.topResult !== undefined &&
           vv.topResult.length > 0 &&


### PR DESCRIPTION
* Gets rid of toSorted
* Enables svelte-check for more resources plugins and fix some issues related to the check

Related to: https://front.hc.engineering/workbench/platform/tracker/EZQMS-1213

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmZiZGExYmRmMDI4MjgxNjJhMmZhZGQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.t0YZVImrcKSAcFXmjc3BdkBZ-FVHq8Y7WC10liNIHFw">Huly&reg;: <b>UBERF-8323</b></a></sub>