### PR TITLE
Qfix: Account db migration

### DIFF
--- a/dev/tool/src/db.ts
+++ b/dev/tool/src/db.ts
@@ -170,6 +170,13 @@ export async function moveAccountDbFromMongoToPG (
       _id: mongoWorkspace._id.toString()
     }
 
+    // delete deprecated fields
+    delete (pgWorkspace as any).createProgress
+    delete (pgWorkspace as any).creating
+    delete (pgWorkspace as any).productId
+    delete (pgWorkspace as any).organisation
+
+    // assigned separately
     delete (pgWorkspace as any).accounts
 
     const exists = await getWorkspaceById(pgDb, pgWorkspace.workspace)


### PR DESCRIPTION
* Takes deprecated fields into account when migrating account data from mongo to PG (as these fields cannot be inserted)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmZkNWRkNmRmMDI4MjgxNjJhMmZlY2YiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.i2jXKK-J809fXt36jSq3LSbUUsQ8crw7_8Pgktgp71o">Huly&reg;: <b>UBERF-8335</b></a></sub>