### PR TITLE
Qfix: Empty where clause

### DIFF
--- a/server/account/src/collections/postgres.ts
+++ b/server/account/src/collections/postgres.ts
@@ -59,6 +59,10 @@ export abstract class PostgresDbCollection<T extends Record<string, any>> implem
   }
 
   protected buildWhereClause (query: Query<T>, lastRefIdx: number = 0): [string, any[]] {
+    if (Object.keys(query).length === 0) {
+      return ['', []]
+    }
+
     const whereChunks: string[] = []
     const values: any[] = []
     let currIdx: number = lastRefIdx
@@ -131,7 +135,9 @@ export abstract class PostgresDbCollection<T extends Record<string, any>> implem
     const sqlChunks: string[] = [this.buildSelectClause()]
     const [whereClause, whereValues] = this.buildWhereClause(query)
 
-    sqlChunks.push(whereClause)
+    if (whereClause !== '') {
+      sqlChunks.push(whereClause)
+    }
 
     if (sort !== undefined) {
       sqlChunks.push(this.buildSortClause(sort))
@@ -200,7 +206,9 @@ export abstract class PostgresDbCollection<T extends Record<string, any>> implem
     const [whereClause, whereValues] = this.buildWhereClause(query, updateValues.length)
 
     sqlChunks.push(updateClause)
-    sqlChunks.push(whereClause)
+    if (whereClause !== '') {
+      sqlChunks.push(whereClause)
+    }
 
     const finalSql = sqlChunks.join(' ')
     await this.client.query(finalSql, [...updateValues, ...whereValues])
@@ -210,7 +218,9 @@ export abstract class PostgresDbCollection<T extends Record<string, any>> implem
     const sqlChunks: string[] = [`DELETE FROM ${this.name}`]
     const [whereClause, whereValues] = this.buildWhereClause(query)
 
-    sqlChunks.push(whereClause)
+    if (whereClause !== '') {
+      sqlChunks.push(whereClause)
+    }
 
     const finalSql = sqlChunks.join(' ')
     await this.client.query(finalSql, whereValues)


### PR DESCRIPTION
Fixes empty where clause case for PG account
Fixes account migration tool:

* Support missing createdOn
* Fully retriable account assignments

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmZlNWNlN2U3OTVmNWE2MjkzZjQ4ZDEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.bPPK5LIkgxMl6BQycKMg7DCW3CHyawvn7NHiX20YM0k">Huly&reg;: <b>UBERF-8341</b></a></sub>