### PR TITLE
UBERF-8357: Remove node fetch from some services

### DIFF
--- a/pods/authProviders/package.json
+++ b/pods/authProviders/package.json
@@ -33,7 +33,6 @@
     "prettier": "^3.1.0",
     "typescript": "^5.3.3",
     "@types/ws": "^8.5.11",
-    "@types/node-fetch": "~2.6.2",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "@types/jest": "^29.5.5",

--- a/server/account/package.json
+++ b/server/account/package.json
@@ -32,7 +32,6 @@
     "eslint-config-standard-with-typescript": "^40.0.0",
     "prettier": "^3.1.0",
     "typescript": "^5.3.3",
-    "@types/node-fetch": "~2.6.2",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "@types/jest": "^29.5.5",
@@ -58,7 +57,6 @@
     "@hcengineering/server-storage": "^0.6.0",
     "@hcengineering/server-core": "^0.6.1",
     "@hcengineering/server-pipeline": "^0.6.0",
-    "@hcengineering/model-all": "^0.6.0",
-    "node-fetch": "^2.6.6"
+    "@hcengineering/model-all": "^0.6.0"
   }
 }

--- a/server/account/src/operations.ts
+++ b/server/account/src/operations.ts
@@ -50,7 +50,6 @@ import { decodeToken as decodeTokenRaw, generateToken, type Token } from '@hceng
 import toolPlugin, { connect } from '@hcengineering/server-tool'
 import { randomBytes } from 'crypto'
 import { type MongoClient } from 'mongodb'
-import fetch from 'node-fetch'
 import otpGenerator from 'otp-generator'
 
 import { accountPlugin } from './plugin'

--- a/services/ai-bot/pod-ai-bot/package.json
+++ b/services/ai-bot/pod-ai-bot/package.json
@@ -36,7 +36,6 @@
     "@types/express": "^4.17.13",
     "@types/jest": "^29.5.5",
     "@types/node": "~20.11.16",
-    "@types/node-fetch": "~2.6.2",
     "@types/ws": "^8.5.11",
     "@typescript-eslint/eslint-plugin": "^6.11.0",
     "@typescript-eslint/parser": "^6.11.0",
@@ -81,7 +80,6 @@
     "form-data": "^4.0.0",
     "js-tiktoken": "^1.0.14",
     "mongodb": "^6.9.0",
-    "node-fetch": "^2.6.6",
     "openai": "^4.56.0",
     "ws": "^8.18.0"
   }

--- a/services/telegram-bot/pod-telegram-bot/package.json
+++ b/services/telegram-bot/pod-telegram-bot/package.json
@@ -35,7 +35,6 @@
     "@types/express": "^4.17.13",
     "@types/jest": "^29.5.5",
     "@types/node": "~20.11.16",
-    "@types/node-fetch": "~2.6.2",
     "@types/otp-generator": "^4.0.2",
     "@types/ws": "^8.5.11",
     "@typescript-eslint/eslint-plugin": "^6.11.0",
@@ -80,7 +79,6 @@
     "express": "^4.19.2",
     "htmlparser2": "^9.0.0",
     "mongodb": "^6.9.0",
-    "node-fetch": "^2.6.6",
     "otp-generator": "^4.0.1",
     "telegraf": "^4.16.3",
     "ws": "^8.18.0"


### PR DESCRIPTION
* Uses native nodejs fetch in some of the existing services

Note: After this PR It's still used in datalake client and it appeared not to be a trivial task to switch to the native modules there as it uses streams for uploading files and it involves using some experimental apis to support similar functions on the native modules so I felt like it's not worth it for now.

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-8357

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmZmZjQ1NjcwYjk0YzIzNzNiNmQ0NmIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.ECM3_LqEVJUfU7TPNq6cHkRijWSC3w23HqGS8pGk7lo">Huly&reg;: <b>UBERF-8360</b></a></sub>