### PR TITLE
fix: disable auto code highlight

### DIFF
--- a/packages/text/src/nodes/codeblock.ts
+++ b/packages/text/src/nodes/codeblock.ts
@@ -17,7 +17,7 @@ import { textblockTypeInputRule } from '@tiptap/core'
 import CodeBlock, { CodeBlockOptions } from '@tiptap/extension-code-block'
 
 export const codeBlockOptions: CodeBlockOptions = {
-  defaultLanguage: null,
+  defaultLanguage: 'plaintext',
   languageClassPrefix: 'language-',
   exitOnArrowDown: true,
   exitOnTripleEnter: true,

--- a/plugins/diffview-resources/src/highlight/highlight.ts
+++ b/plugins/diffview-resources/src/highlight/highlight.ts
@@ -19,16 +19,21 @@ import { hljsDefineSvelte } from './languages/svelte-hljs'
 hljs.registerLanguage('svelte', hljsDefineSvelte)
 
 export interface HighlightOptions {
+  auto?: boolean
   language: string | undefined
 }
 
 export function highlightText (text: string, options: HighlightOptions): string {
   // We should always use highlighter because it sanitizes the input
   // We have to always use highlighter to ensure that the input is sanitized
-  const { language } = options
+  const { language, auto } = options
   const validLanguage = language !== undefined && hljs.getLanguage(language) !== undefined
 
-  const { value: highlighted } = validLanguage ? hljs.highlight(text, { language }) : hljs.highlightAuto(text)
+  const { value: highlighted } = validLanguage
+    ? hljs.highlight(text, { language })
+    : auto === true
+      ? hljs.highlightAuto(text)
+      : { value: text }
 
   return normalizeHighlightTags(highlighted)
 }

--- a/tests/sanity/tests/documents/documents-content.spec.ts
+++ b/tests/sanity/tests/documents/documents-content.spec.ts
@@ -335,7 +335,7 @@ test.describe('Content in the Documents tests', () => {
     await documentContentPage.applyToolbarCommand('Line 16', 'btnBlockquote')
     await documentContentPage.applyToolbarCommand('Line 17', 'btnCode')
     await documentContentPage.applyToolbarCommand('Line 18', 'btnCodeBlock')
-    await documentContentPage.changeCodeBlockLanguage('Line 18', 'auto', 'css')
+    await documentContentPage.changeCodeBlockLanguage('Line 18', 'plaintext', 'css')
     await documentContentPage.applyNote('Line 19', 'warning', testNote)
     await documentContentPage.addImage('Line 20')
     await page.keyboard.type('Cat')


### PR DESCRIPTION
Disable auto highlight due to performance issues

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzAzNzhhZDJiYTdlN2I3MzJmNTcxMWQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.moOBjiihO8xla95EEPGzTsp7uJdh1VYkBbLdxGfDZJ4">Huly&reg;: <b>UBERF-8372</b></a></sub>