### PR TITLE
fix translate for ru.json

### DIFF
--- a/plugins/calendar-assets/lang/ru.json
+++ b/plugins/calendar-assets/lang/ru.json
@@ -80,7 +80,7 @@
     "SeeAllNumberParticipants": "{value, plural, other {Увидеть всех # участников}}",
     "SeeAllNumberReminders": "{value, plural, other {Просмотреть все # напоминаний}}",
     "Visibility": "Видимость",
-    "Private": "Видно только Вам",
+    "Private": "Видно только вам",
     "Public": "Видно всем",
     "FreeBusy": "Скрыть детали",
     "DefaultVisibility": "Видимость по умолчанию",


### PR DESCRIPTION
corrected the translation according to the language rules

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzBiZjFiMTA4YzM5MmYxMDU1OTU2OGMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.J62-5leETmiKpM1dQoldL3LZrVBJIypOyNbgsRO-D7M">Huly&reg;: <b>UBERF-8456</b></a></sub>