### PR TITLE
UBERF-8475: Capitalize Huly in GitHub issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -2,7 +2,7 @@
 A clear and concise description of the issue.
 
 ### Your environment
-* Version of huly
+* Version of Huly
 * Browser (and version)
 * Your operating system (and version)
 


### PR DESCRIPTION
Fixes #6926
Adjust the string "huly" to be capitalized in the GitHub issue template.

**Pull Request Requirements:**

- Provide a brief description of the changeset. ✅
- Include a screenshots if applicable ✅
- Ensure that the changeset adheres to the [DCO guidelines](https://github.com/apps/dco). ✅

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzBkZWM3ZDVjZTU0NjMyNTcwZDgyMTgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.qsArCvQQicKCrXGvU0Bqdp9THT58vKRRlEBMftzjL9w">Huly&reg;: <b>UBERF-8476</b></a></sub>