### PR TITLE
Feat: Filter Inline Command List With User Input

### DIFF
--- a/plugins/text-editor-resources/src/components/extensions.ts
+++ b/plugins/text-editor-resources/src/components/extensions.ts
@@ -20,7 +20,7 @@ import textEditor from '@hcengineering/text-editor'
 import { type CompletionOptions } from '../Completion'
 import MentionList from './MentionList.svelte'
 import { SvelteRenderer } from './node-view'
-import type { SuggestionKeyDownProps, SuggestionOptions, SuggestionProps } from './extension/suggestion'
+import type { SuggestionKeyDownProps, SuggestionProps } from './extension/suggestion'
 import InlineCommandsList from './InlineCommandsList.svelte'
 
 export const mInsertTable = [


### PR DESCRIPTION
### Summary

In the current version of the product, typing / within a document brings up an inline command list, but the list does not filter as you continue typing.

### What Does This PR Address?

This PR introduces functionality that allows the inline command list to filter items dynamically as you type text following the / symbol.

For more details, please refer to the video below, which demonstrates the issue that this PR resolves.

### Video Demonstration (Before)

https://github.com/user-attachments/assets/b6dafe6f-abc6-4037-9cfc-5d2ce8097e03

### Video Demonstration (After)

https://github.com/user-attachments/assets/db47bd49-e51d-4411-b9e9-7e604a27162c

Thanks!