### PR TITLE
UBERF-8480: Configurable liveness condition for upgrade

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -95,6 +95,7 @@
         "ACCOUNT_PORT": "3000",
         "FRONT_URL": "http://localhost:8080",
         "SES_URL": "",
+        // "WS_LIVENESS_DAYS": "1",
         "MINIO_ACCESS_KEY": "minioadmin",
         "MINIO_SECRET_KEY": "minioadmin",
         "MINIO_ENDPOINT": "localhost",

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -83,6 +83,7 @@ services:
       - RESERVED_DB_NAMES=telegram,gmail,github
       - MODEL_ENABLED=*
       - LAST_NAME_FIRST=true
+      # - WS_LIVENESS_DAYS=1
       - ACCOUNTS_URL=http://host.docker.internal:3000
       - BRANDING_PATH=/var/cfg/branding.json
       # - DISABLE_SIGNUP=true

--- a/server/account-service/src/index.ts
+++ b/server/account-service/src/index.ts
@@ -65,6 +65,17 @@ export function serveAccount (measureCtx: MeasureContext, brandings: BrandingMap
   const productName = process.env.PRODUCT_NAME
   const lang = process.env.LANGUAGE ?? 'en'
 
+  const wsLivenessDaysRaw = process.env.WS_LIVENESS_DAYS
+  let wsLivenessDays: number | undefined
+
+  if (wsLivenessDaysRaw !== undefined) {
+    try {
+      wsLivenessDays = parseInt(wsLivenessDaysRaw)
+    } catch (err: any) {
+      // DO NOTHING
+    }
+  }
+
   setMetadata(account.metadata.Transactors, transactorUri)
   setMetadata(platform.metadata.locale, lang)
   setMetadata(account.metadata.ProductName, productName)
@@ -72,6 +83,7 @@ export function serveAccount (measureCtx: MeasureContext, brandings: BrandingMap
   setMetadata(account.metadata.OtpRetryDelaySec, parseInt(process.env.OTP_RETRY_DELAY ?? '60'))
   setMetadata(account.metadata.SES_URL, ses)
   setMetadata(account.metadata.FrontURL, frontURL)
+  setMetadata(account.metadata.WsLivenessDays, wsLivenessDays)
 
   setMetadata(serverToken.metadata.Secret, serverSecret)
 

--- a/server/account/src/operations.ts
+++ b/server/account/src/operations.ts
@@ -1278,8 +1278,10 @@ export async function getPendingWorkspace (
   }
   // Move to config?
   const processingTimeoutMs = 30 * 1000
+  const wsLivenessDays = getMetadata(accountPlugin.metadata.WsLivenessDays)
+  const wsLivenessMs = wsLivenessDays !== undefined ? wsLivenessDays * 24 * 60 * 60 * 1000 : undefined
 
-  const result = await db.workspace.getPendingWorkspace(region, version, operation, processingTimeoutMs)
+  const result = await db.workspace.getPendingWorkspace(region, version, operation, processingTimeoutMs, wsLivenessMs)
 
   if (result != null) {
     ctx.info('getPendingWorkspace', {

--- a/server/account/src/plugin.ts
+++ b/server/account/src/plugin.ts
@@ -15,7 +15,8 @@ export const accountPlugin = plugin(accountId, {
     ProductName: '' as Metadata<string>,
     Transactors: '' as Metadata<string>,
     OtpTimeToLiveSec: '' as Metadata<number>,
-    OtpRetryDelaySec: '' as Metadata<number>
+    OtpRetryDelaySec: '' as Metadata<number>,
+    WsLivenessDays: '' as Metadata<number>
   },
   string: {
     ConfirmationText: '' as IntlString,

--- a/server/account/src/types.ts
+++ b/server/account/src/types.ts
@@ -195,6 +195,7 @@ export interface WorkspaceDbCollection extends DbCollection<Workspace> {
     region: string,
     version: Data<Version>,
     operation: WorkspaceOperation,
-    processingTimeoutMs: number
+    processingTimeoutMs: number,
+    wsLivenessMs?: number
   ) => Promise<WorkspaceInfo | undefined>
 }


### PR DESCRIPTION
* Adds configurable liveness condition for upgrade: `account` service env var `WS_LIVENESS_DAYS`

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-8480
Closes https://github.com/hcengineering/platform/issues/6931

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzBlNTk5ZGRjN2M3OWMyMDMzYTI1YTkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.LFEIR_tFiohk68O5ouY8wdI73kXDwa8zwSkwqooJ7UE">Huly&reg;: <b>UBERF-8492</b></a></sub>