### PR TITLE
qfix: disable applicant preview

### DIFF
--- a/models/recruit/src/index.ts
+++ b/models/recruit/src/index.ts
@@ -846,9 +846,9 @@ export function createModel (builder: Builder): void {
     card: recruit.component.KanbanCard
   })
 
-  builder.mixin(recruit.class.Applicant, core.class.Class, view.mixin.PreviewPresenter, {
-    presenter: recruit.component.KanbanCard
-  })
+  // builder.mixin(recruit.class.Applicant, core.class.Class, view.mixin.PreviewPresenter, {
+  //   presenter: recruit.component.KanbanCard
+  // })
 
   builder.mixin(recruit.class.Applicant, core.class.Class, view.mixin.ObjectEditor, {
     editor: recruit.component.EditApplication


### PR DESCRIPTION
Disable as a quick fix because we use incompatible component as preview

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU1M2MyMzUzNmNiMTQyNWExMTViYTEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.98AdqYBRerb1fuXANLlmLvtL4Nqi2g27YvWTtmqlrZA">Huly&reg;: <b>UBERF-8645</b></a></sub>