### PR TITLE
Attempt to fix false user multiplication in analytics

### DIFF
--- a/dev/prod/src/analytics/posthog.ts
+++ b/dev/prod/src/analytics/posthog.ts
@@ -2,7 +2,7 @@ import { AnalyticProvider } from "@hcengineering/analytics"
 import posthog from 'posthog-js'
 
 export class PosthogAnalyticProvider implements AnalyticProvider {
-  init (config: Record<string, any>): boolean {
+  init(config: Record<string, any>): boolean {
     if (config.POSTHOG_API_KEY !== undefined && config.POSTHOG_API_KEY !== '' && config.POSTHOG_HOST !== null) {
       posthog.init(config.POSTHOG_API_KEY, { api_host: config.POSTHOG_HOST })
       return true
@@ -11,15 +11,17 @@ export class PosthogAnalyticProvider implements AnalyticProvider {
   }
 
   setUser(email: string): void {
-    posthog.identify(email, { email: email })
+    if (!posthog._isIdentified()) {
+      posthog.identify(email, { email: email })
+    }
   }
   setTag(key: string, value: string): void {
     posthog.setPersonProperties({ [key]: value })
   }
   setWorkspace(ws: string): void {
     this.setTag('workspace', ws)
-    posthog.group('workspace', ws, { 
-      name: `${ws}` 
+    posthog.group('workspace', ws, {
+      name: `${ws}`
     })
   }
   logout(): void {


### PR DESCRIPTION
Added a check if user is already identified, to avoid extra identification