### PR TITLE
Qfix: Fix setting UI metadata from config

### DIFF
--- a/desktop/src/ui/platform.ts
+++ b/desktop/src/ui/platform.ts
@@ -201,6 +201,7 @@ export async function configurePlatform (): Promise<void> {
   ipcMain.setTitle(title)
 
   setMetadata(login.metadata.AccountsUrl, config.ACCOUNTS_URL)
+  setMetadata(login.metadata.DisableSignUp, config.DISABLE_SIGNUP === 'true')
   setMetadata(presentation.metadata.UploadURL, config.UPLOAD_URL)
   setMetadata(presentation.metadata.FilesURL, config.FILES_URL)
   setMetadata(presentation.metadata.CollaboratorUrl, config.COLLABORATOR_URL)

--- a/desktop/src/ui/types.ts
+++ b/desktop/src/ui/types.ts
@@ -28,6 +28,7 @@ export interface Config {
   PUSH_PUBLIC_KEY: string
   ANALYTICS_COLLECTOR_URL?: string
   AI_URL?:string
+  DISABLE_SIGNUP?: string
   BRANDING_URL?: string
   PREVIEW_CONFIG: string
   UPLOAD_CONFIG: string

--- a/dev/prod/src/platform.ts
+++ b/dev/prod/src/platform.ts
@@ -151,7 +151,7 @@ export interface Config {
   BRANDING_URL?: string
   TELEGRAM_BOT_URL?: string
   AI_URL?:string
-
+  DISABLE_SIGNUP?: string
   // Could be defined for dev environment
   FRONT_URL?: string
   PREVIEW_CONFIG?: string
@@ -292,6 +292,7 @@ export async function configurePlatform() {
   // tryOpenInDesktopApp(config.APP_PROTOCOL ?? 'huly://')
 
   setMetadata(login.metadata.AccountsUrl, config.ACCOUNTS_URL)
+  setMetadata(login.metadata.DisableSignUp, config.DISABLE_SIGNUP === 'true')
   setMetadata(presentation.metadata.FilesURL, config.FILES_URL)
   setMetadata(presentation.metadata.UploadURL, config.UPLOAD_URL)
   setMetadata(presentation.metadata.CollaboratorUrl, config.COLLABORATOR_URL)


### PR DESCRIPTION
* Fixes setting UI metadata related to disabled sign-up from config

These changes were somehow missing in the original PR for this feature.