### PR TITLE
Mobile layout fixes

### DIFF
--- a/packages/theme/styles/_layouts.scss
+++ b/packages/theme/styles/_layouts.scss
@@ -1053,6 +1053,7 @@ a.no-line {
 .bottom-divider { border-bottom: 1px solid var(--theme-divider-color); }
 .left-divider { border-left: 1px solid var(--theme-divider-color); }
 .right-divider { border-right: 1px solid var(--theme-divider-color); }
+.right-navpanel-border { border-right: 1px solid var(--theme-navpanel-border); }
 .bottom-highlight-select { border-bottom: 1px solid var(--highlight-select); }
 
 

--- a/packages/ui/src/components/Separator.svelte
+++ b/packages/ui/src/components/Separator.svelte
@@ -456,7 +456,6 @@
   }
 
   function pointerDown (event: PointerEvent): void {
-    console.log('[!!!] pointerDown ', checkFullWidth())
     if (checkFullWidth()) return
     prepareSeparation(event)
     document.addEventListener('pointermove', pointerMove)

--- a/packages/ui/src/resize.ts
+++ b/packages/ui/src/resize.ts
@@ -148,7 +148,7 @@ export function saveSeparator (
 }
 
 export const panelSeparators: DefSeparators = [
-  { minSize: 30, size: 'auto', maxSize: 'auto' },
+  { minSize: 20, size: 'auto', maxSize: 'auto' },
   { minSize: 17, size: 25, maxSize: 35, float: 'aside' }
 ]
 

--- a/plugins/love-resources/src/components/Room.svelte
+++ b/plugins/love-resources/src/components/Room.svelte
@@ -17,7 +17,7 @@
   import { personByIdStore } from '@hcengineering/contact-resources'
   import { Room as TypeRoom } from '@hcengineering/love'
   import { getMetadata } from '@hcengineering/platform'
-  import { Label, Loading, resizeObserver } from '@hcengineering/ui'
+  import { Label, Loading, resizeObserver, deviceOptionsStore as deviceInfo } from '@hcengineering/ui'
   import {
     LocalParticipant,
     LocalTrackPublication,
@@ -333,7 +333,7 @@
   $: if (((document.fullscreenElement && !$isFullScreen) || $isFullScreen) && roomEl) toggleFullscreen()
 </script>
 
-<div bind:this={roomEl} class="flex-col-center w-full h-full" class:theme-dark={$isFullScreen}>
+<div bind:this={roomEl} class="flex-col-center w-full h-full right-navpanel-border" class:theme-dark={$isFullScreen}>
   {#if $isConnected && !$isCurrentInstanceConnected}
     <div class="flex justify-center error h-full w-full clear-mins">
       <Label label={love.string.AnotherWindowError} />
@@ -345,7 +345,13 @@
   {:else if loading}
     <Loading />
   {/if}
-  <div class="room-container" class:sharing={$screenSharing} class:many={columns > 3} class:hidden={loading}>
+  <div
+    class="room-container"
+    class:sharing={$screenSharing}
+    class:many={columns > 3}
+    class:hidden={loading}
+    class:mobile={$deviceInfo.isMobile}
+  >
     <div class="screenContainer">
       <video class="screen" bind:this={screen}></video>
     </div>
@@ -450,6 +456,15 @@
       &:not(.sharing) .videoGrid,
       &.sharing {
         gap: 0.5rem;
+      }
+    }
+
+    &.mobile {
+      padding: var(--spacing-0_5);
+
+      &:not(.sharing) .videoGrid,
+      &.sharing {
+        gap: var(--spacing-0_5);
       }
     }
   }

--- a/plugins/workbench-resources/src/components/Workbench.svelte
+++ b/plugins/workbench-resources/src/components/Workbench.svelte
@@ -647,6 +647,18 @@
   const checkOnHide = (): void => {
     if ($deviceInfo.navigator.visible && $deviceInfo.docWidth <= 1024) $deviceInfo.navigator.visible = false
   }
+  let oldNavVisible: boolean = $deviceInfo.navigator.visible
+  let oldASideVisible: boolean = $deviceInfo.aside.visible
+  $: if (oldNavVisible !== $deviceInfo.navigator.visible || oldASideVisible !== $deviceInfo.aside.visible) {
+    if ($deviceInfo.isMobile && $deviceInfo.isPortrait && $deviceInfo.navigator.float) {
+      if ($deviceInfo.navigator.visible && $deviceInfo.aside.visible) {
+        if (oldNavVisible) $deviceInfo.navigator.visible = false
+        else $deviceInfo.aside.visible = false
+      }
+    }
+    oldNavVisible = $deviceInfo.navigator.visible
+    oldASideVisible = $deviceInfo.aside.visible
+  }
   $: $deviceInfo.navigator.direction = $deviceInfo.isMobile && $deviceInfo.isPortrait ? 'horizontal' : 'vertical'
   let appsMini: boolean
   $: appsMini =

--- a/plugins/workbench-resources/src/components/WorkbenchTabs.svelte
+++ b/plugins/workbench-resources/src/components/WorkbenchTabs.svelte
@@ -57,23 +57,25 @@
       </div>
     </div>
   {:else if !mini}
-    <ScrollerBar bind:scroller padding={'.25rem 0'}>
+    <div class="flex-row-center gap-1 py-1 overflow-x-auto">
       {#each $tabsStore as tab (tab._id)}
         <WorkbenchTabPresenter {tab} />
       {/each}
-    </ScrollerBar>
+    </div>
   {:else if selectedTab !== undefined}
     <WorkbenchTabPresenter tab={selectedTab} />
-    <ButtonIcon
-      bind:element
-      icon={IconMoreH}
-      iconProps={{ fill: 'var(--theme-dark-color)' }}
-      size={'extra-small'}
-      kind={'tertiary'}
-      hasMenu
-      {pressed}
-      on:click={showTabs}
-    />
+    {#if $tabsStore.length > 1}
+      <ButtonIcon
+        bind:element
+        icon={IconMoreH}
+        iconProps={{ fill: 'var(--theme-dark-color)' }}
+        size={'extra-small'}
+        kind={'tertiary'}
+        hasMenu
+        {pressed}
+        on:click={showTabs}
+      />
+    {/if}
   {/if}
   {#if !popup}
     <ButtonIcon


### PR DESCRIPTION
1. Fixed Room layout

<img width="301" alt="screen-1" src="https://github.com/user-attachments/assets/4a430336-0881-4d19-8849-75e4896eef91">

2. In the mobile portrait mode:
 - the floating panel in the width of the screen
 - navigator and aside cannot be opened at the same time

<img width="215" alt="screen-2" src="https://github.com/user-attachments/assets/411953e4-900c-4343-8165-63fe1df21df6"> <img width="215" alt="screen-3" src="https://github.com/user-attachments/assets/8be3f507-770c-4c92-b19c-114f628fb08b"> <img width="215" alt="screen-4" src="https://github.com/user-attachments/assets/e6f3052b-1c7d-46ff-8104-a7bfe2dd66ef"> <img width="215" alt="screen-5" src="https://github.com/user-attachments/assets/3b2b80c2-9acb-4ba3-9c7e-b4a5958e103d">

3. Fixed WorkbenchTabs