### PR TITLE
Fix mentions to handle non-latin names during import

### DIFF
--- a/dev/import-tool/src/clickup/clickup.ts
+++ b/dev/import-tool/src/clickup/clickup.ts
@@ -62,7 +62,7 @@ interface ImportIssueEx extends ImportIssue {
 }
 
 class ClickupMarkdownPreprocessor implements MarkdownPreprocessor {
-  private readonly MENTION_REGEX = /@([A-Za-z]+ [A-Za-z]+)/g
+  private readonly MENTION_REGEX = /@([\p{L}\p{M}]+ [\p{L}\p{M}]+)/gu
   constructor (private readonly personsByName: Map<string, Ref<Person>>) {}
 
   process (json: MarkupNode): MarkupNode {


### PR DESCRIPTION
Fix mentions to handle non-latin names during import:
```
- @Иван Петров
- @José García
- @François Dubois
- @張 偉
```