### PR TITLE
DEFAULT_LOGIN_METHOD env for when mail otp isn't available (self-hosted)

### DIFF
--- a/desktop/src/ui/platform.ts
+++ b/desktop/src/ui/platform.ts
@@ -112,7 +112,7 @@ import github, { githubId } from '@hcengineering/github'
 import { uiId } from '@hcengineering/ui/src/plugin'
 import { preferenceId } from '@hcengineering/preference'
 
-function configureI18n (): void {
+function configureI18n(): void {
   // Add localization
   addStringsLoader(platformId, async (lang: string) => await import(`@hcengineering/platform/lang/${lang}.json`))
   addStringsLoader(coreId, async (lang: string) => await import(`@hcengineering/core/lang/${lang}.json`))
@@ -187,7 +187,7 @@ function configureI18n (): void {
   addStringsLoader(analyticsCollectorId, async (lang: string) => await import(`@hcengineering/analytics-collector-assets/lang/${lang}.json`))
 }
 
-export async function configurePlatform (): Promise<void> {
+export async function configurePlatform(): Promise<void> {
   configureI18n()
 
   const ipcMain = (window as any).electron as IPCMainExposed
@@ -202,6 +202,7 @@ export async function configurePlatform (): Promise<void> {
 
   setMetadata(login.metadata.AccountsUrl, config.ACCOUNTS_URL)
   setMetadata(login.metadata.DisableSignUp, config.DISABLE_SIGNUP === 'true')
+  setMetadata(login.metadata.DefaultLoginMethod, config.DEFAULT_LOGIN_METHOD)
   setMetadata(presentation.metadata.UploadURL, config.UPLOAD_URL)
   setMetadata(presentation.metadata.FilesURL, config.FILES_URL)
   setMetadata(presentation.metadata.CollaboratorUrl, config.COLLABORATOR_URL)

--- a/desktop/src/ui/types.ts
+++ b/desktop/src/ui/types.ts
@@ -29,7 +29,7 @@ export interface Config {
   ANALYTICS_COLLECTOR_URL?: string
   AI_URL?: string
   DISABLE_SIGNUP?: string
-  DEFAULT_LOGIN_METHOD?: string
+  DEFAULT_LOGIN_METHOD?: 'otp' | 'password'
   BRANDING_URL?: string
   PREVIEW_CONFIG: string
   UPLOAD_CONFIG: string

--- a/desktop/src/ui/types.ts
+++ b/desktop/src/ui/types.ts
@@ -27,8 +27,9 @@ export interface Config {
   PRINT_URL?: string
   PUSH_PUBLIC_KEY: string
   ANALYTICS_COLLECTOR_URL?: string
-  AI_URL?:string
+  AI_URL?: string
   DISABLE_SIGNUP?: string
+  DEFAULT_LOGIN_METHOD?: string
   BRANDING_URL?: string
   PREVIEW_CONFIG: string
   UPLOAD_CONFIG: string

--- a/dev/prod/src/platform.ts
+++ b/dev/prod/src/platform.ts
@@ -294,6 +294,7 @@ export async function configurePlatform() {
 
   setMetadata(login.metadata.AccountsUrl, config.ACCOUNTS_URL)
   setMetadata(login.metadata.DisableSignUp, config.DISABLE_SIGNUP === 'true')
+  setMetadata(login.metadata.DefaultLoginMethod, config.DEFAULT_LOGIN_METHOD)
   setMetadata(presentation.metadata.FilesURL, config.FILES_URL)
   setMetadata(presentation.metadata.UploadURL, config.UPLOAD_URL)
   setMetadata(presentation.metadata.CollaboratorUrl, config.COLLABORATOR_URL)

--- a/dev/prod/src/platform.ts
+++ b/dev/prod/src/platform.ts
@@ -152,6 +152,7 @@ export interface Config {
   TELEGRAM_BOT_URL?: string
   AI_URL?:string
   DISABLE_SIGNUP?: string
+  DEFAULT_LOGIN_METHOD?: 'otp'|'password'
   // Could be defined for dev environment
   FRONT_URL?: string
   PREVIEW_CONFIG?: string

--- a/plugins/login-resources/src/components/LoginApp.svelte
+++ b/plugins/login-resources/src/components/LoginApp.svelte
@@ -59,7 +59,7 @@
 
   onDestroy(location.subscribe(updatePageLoc))
 
-  function updatePageLoc (loc: Location): void {
+  function updatePageLoc(loc: Location): void {
     const token = getMetadata(presentation.metadata.Token)
     page = (loc.path[1] as Pages) ?? (token != null ? 'selectWorkspace' : 'login')
     const allowedUnauthPages: Pages[] = [
@@ -80,7 +80,7 @@
     navigateUrl = loc.query?.navigateUrl ?? undefined
   }
 
-  async function chooseToken (): Promise<void> {
+  async function chooseToken(): Promise<void> {
     if (page === 'auth') {
       // token handled by auth page
       return

--- a/plugins/login-resources/src/components/LoginForm.svelte
+++ b/plugins/login-resources/src/components/LoginForm.svelte
@@ -18,14 +18,20 @@
   import LoginPasswordForm from './LoginPasswordForm.svelte'
   import LoginOtpForm from './LoginOtpForm.svelte'
   import BottomActionComponent from './BottomAction.svelte'
+  import { getMetadata } from '@hcengineering/platform'
   import login from '../plugin'
 
   export let navigateUrl: string | undefined = undefined
   export let signUpDisabled = false
+  const defaultLoginMethod = getMetadata(login.metadata.DefaultLoginMethod) ?? 'otp'
 
   let method: LoginMethods = LoginMethods.Otp
 
-  function changeMethod (event: CustomEvent<LoginMethods>): void {
+  if (defaultLoginMethod === 'password') {
+    method = LoginMethods.Password
+  }
+
+  function changeMethod(event: CustomEvent<LoginMethods>): void {
     method = event.detail
   }
 

--- a/plugins/login/src/index.ts
+++ b/plugins/login/src/index.ts
@@ -73,7 +73,7 @@ export default plugin(loginId, {
     LastToken: '' as Metadata<string>,
     LoginEndpoint: '' as Metadata<string>,
     LoginEmail: '' as Metadata<string>,
-    DefaultLoginMethod: '' as Metadata<string>,
+    DefaultLoginMethod: '' as Metadata<'otp' | 'password'>,
     DisableSignUp: '' as Metadata<boolean>
   },
   component: {

--- a/plugins/login/src/index.ts
+++ b/plugins/login/src/index.ts
@@ -73,6 +73,7 @@ export default plugin(loginId, {
     LastToken: '' as Metadata<string>,
     LoginEndpoint: '' as Metadata<string>,
     LoginEmail: '' as Metadata<string>,
+    DefaultLoginMethod: '' as Metadata<string>,
     DisableSignUp: '' as Metadata<boolean>
   },
   component: {

--- a/server/front/src/starter.ts
+++ b/server/front/src/starter.ts
@@ -119,6 +119,8 @@ export function startFront (ctx: MeasureContext, extraConfig?: Record<string, st
 
   const disableSignUp = process.env.DISABLE_SIGNUP
 
+  const defaultLoginMethod = process.env.DEFAULT_LOGIN_METHOD
+
   const config = {
     elasticUrl,
     storageAdapter,
@@ -137,7 +139,8 @@ export function startFront (ctx: MeasureContext, extraConfig?: Record<string, st
     previewConfig,
     uploadConfig,
     pushPublicKey,
-    disableSignUp
+    disableSignUp,
+    defaultLoginMethod
   }
   console.log('Starting Front service with', config)
   const shutdown = start(ctx, config, SERVER_PORT, extraConfig)


### PR DESCRIPTION
When self hosting, SMTP isn't supported yet. The default email based login doesn't work. Login by email is just a click away but it would be easier if that could just be made default.

This change makes it such that we can simply add

```bash
LOGIN_PASSWORD_ONLY=true
```

to the environment to switch the defaults around.