### PR TITLE
Fix love metadata update

### DIFF
--- a/plugins/love-resources/src/utils.ts
+++ b/plugins/love-resources/src/utils.ts
@@ -26,7 +26,8 @@ import {
   type Room,
   RoomAccess,
   RoomType,
-  TranscriptionStatus
+  TranscriptionStatus,
+  type RoomMetadata
 } from '@hcengineering/love'
 import { getEmbeddedLabel, getMetadata, getResource, type IntlString } from '@hcengineering/platform'
 import presentation, {
@@ -351,7 +352,7 @@ lk.on(RoomEvent.RecordingStatusChanged, (evt) => {
 })
 lk.on(RoomEvent.RoomMetadataChanged, (metadata) => {
   try {
-    const data = JSON.parse(metadata)
+    const data = JSON.parse(metadata) as RoomMetadata
     if (data.recording !== undefined) {
       isRecording.set(data.recording)
     }
@@ -379,10 +380,9 @@ lk.on(RoomEvent.Disconnected, () => {
 })
 
 function initRoomMetadata (metadata: string | undefined): void {
-  if (metadata === undefined) return
-  let data: { transcription?: TranscriptionStatus } = {}
+  let data: RoomMetadata
   try {
-    data = metadata === '' ? {} : JSON.parse(metadata)
+    data = metadata == null || metadata === '' ? {} : JSON.parse(metadata)
   } catch (err: any) {
     data = {}
     Analytics.handleError(err)

--- a/plugins/love/src/index.ts
+++ b/plugins/love/src/index.ts
@@ -85,6 +85,12 @@ export type RoomLanguage =
   | 'uk'
   | 'vi'
 
+export interface RoomMetadata {
+  recording?: boolean
+  transcription?: TranscriptionStatus
+  language?: RoomLanguage
+}
+
 export interface Room extends Doc {
   name: string
   type: RoomType


### PR DESCRIPTION
Save current metadata values so as not to lose when updating

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU1M2ZjNDUzNmNiMTQyNWExMTY2NGMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.OvdAW73gYuNeSlynxQwjsQwMXyjOR8UEzvv5JJEXHzg">Huly&reg;: <b>UBERF-8684</b></a></sub>