### PR TITLE
Fix hideAdd does not prevent adding by keyboard on TagsPopup

### DIFF
--- a/plugins/tags-resources/src/components/TagsPopup.svelte
+++ b/plugins/tags-resources/src/components/TagsPopup.svelte
@@ -126,7 +126,7 @@
 
   async function onSearchKeydown (ev: KeyboardEvent): Promise<void> {
     if (ev.code !== 'Enter') return
-    if (!inProcess && objects.length < 1) {
+    if (!inProcess && !hideAdd && objects.length < 1) {
       inProcess = true
       await createTagElementQuick()
       ev.preventDefault()


### PR DESCRIPTION
While looking to the code of `TagsPopup`, to make it work with keyboard only, I noticed that the `hideAdd` prop does not prevent the creating of a new tag via the keyboard.