### PR TITLE
Fixes for mobile

### DIFF
--- a/packages/theme/styles/_layouts.scss
+++ b/packages/theme/styles/_layouts.scss
@@ -84,6 +84,14 @@ select:-webkit-autofill:focus {
   background: transparent;
 }
 
+// Fix for iOS (disable zooming on input fields)
+@media screen and (-webkit-min-device-pixel-ratio: 0) and (max-width: 480px) { 
+  select,
+  textarea,
+  input,
+  div.ref-container div.select-text > div[contenteditable="true"] { font-size: 16px; }
+}
+
 table, caption, tbody, tfoot, thead, tr, th, td {
   margin: 0;
   padding: 0;

--- a/plugins/text-editor-resources/src/components/MentionList.svelte
+++ b/plugins/text-editor-resources/src/components/MentionList.svelte
@@ -139,5 +139,12 @@
     min-width: 0;
     min-height: 0;
     z-index: 10001;
+
+    @media screen and (max-width: 480px) {
+      position: fixed;
+      left: var(--spacing-1);
+      width: calc(100vw - var(--spacing-1) * 2);
+      height: 10rem;
+    }
   }
 </style>


### PR DESCRIPTION
1. Fix for iOS (disable zooming on input fields)
2. Fixed size for MentionPopup
   <img width="195" src="https://github.com/user-attachments/assets/c590bab7-db5a-44fd-b84b-36eb53e28fdc" alt="screen-mention">