### PR TITLE
Informative icons for the LOVE sidebar

### DIFF
--- a/plugins/love-resources/src/components/widget/WidgetSwitcher.svelte
+++ b/plugins/love-resources/src/components/widget/WidgetSwitcher.svelte
@@ -16,17 +16,30 @@
   import type { Asset, IntlString } from '@hcengineering/platform'
   import type { AnySvelteComponent } from '@hcengineering/ui'
   import { AppItem } from '@hcengineering/workbench-resources'
+  import { RoomType } from '@hcengineering/love'
+  import { currentRoom } from '../../stores'
   import { isConnected, isSharingEnabled, isCameraEnabled, isMicEnabled } from '../../utils'
+  import love from '../../plugin'
 
   export let label: IntlString
   export let icon: Asset | AnySvelteComponent
   export let selected: boolean = false
   export let size: 'small' | 'medium' | 'large' = 'small'
+
+  $: allowCam = $currentRoom?.type === RoomType.Video
 </script>
 
 <AppItem
   {label}
-  {icon}
+  icon={$isSharingEnabled
+    ? love.icon.SharingDisabled
+    : $isConnected && allowCam && !$isCameraEnabled && !$isMicEnabled
+      ? love.icon.CamDisabled
+      : $isConnected && !allowCam && !$isMicEnabled
+        ? love.icon.MicDisabled
+        : !allowCam || (!$isCameraEnabled && $isMicEnabled)
+            ? love.icon.Mic
+            : icon}
   {selected}
   {size}
   kind={$isSharingEnabled

--- a/plugins/workbench-resources/src/components/AppItem.svelte
+++ b/plugins/workbench-resources/src/components/AppItem.svelte
@@ -119,7 +119,7 @@
     }
     &.accented,
     &.accented.selected {
-      background-color: var(--global-disabled-PriorityColor);
+      background-color: var(--button-secondary-active-BackgroundColor);
     }
     &.positive .icon-container,
     &.negative .icon-container,


### PR DESCRIPTION
When sharing:
<img width="251" src="https://github.com/user-attachments/assets/90a6531d-1150-4dd0-a49e-6b73014b528b" alt="screen-share-d"> <img width="251" src="https://github.com/user-attachments/assets/28b4f7f8-4a4c-4ef3-b2e2-92018e3189f7" alt="screen-share-l">
When camera on:
<img width="251" src="https://github.com/user-attachments/assets/c0cfd5bb-e9f9-49de-a47f-84f89fbfbb72" alt="screen-video-d"> <img width="251" src="https://github.com/user-attachments/assets/53709234-4a57-45ae-a615-c722ce9c93f1" alt="screen-video-l">
When camera off:
<img width="251" src="https://github.com/user-attachments/assets/73b50714-60a6-4b71-b687-96a7eb853b8e" alt="screen-videoOff-d"> <img width="251" src="https://github.com/user-attachments/assets/8a510da5-d493-4366-b7e6-a4c3ed8a6d67" alt="screen-videoOff-l">
When meeting muted:
<img width="251" src="https://github.com/user-attachments/assets/db2124a9-20d4-4201-ab17-96550b7573e2" alt="screen-meetOff-d"> <img width="251" src="https://github.com/user-attachments/assets/fa9591d1-5747-454f-ae13-d5ae6a05784d" alt="screen-meetOff-l">
When audio meeting:
<img width="251" src="https://github.com/user-attachments/assets/86556b27-4f70-4fd8-9406-ef8deae9a743" alt="screen-audioOn-d"> <img width="251" src="https://github.com/user-attachments/assets/8bd59704-de78-4b51-9d63-abc66b6c2236" alt="screen-audioOn-l">
When audio meeting muted:
<img width="251" src="https://github.com/user-attachments/assets/a48cad46-264d-4adf-ad20-efb2701d8036" alt="screen-audioOff-d"> <img width="251" src="https://github.com/user-attachments/assets/fa951033-19ef-4630-bd21-8dbd16c1eb49" alt="screen-audioOff-l">