### PR TITLE
style(drive): fix pdf appears small 

### DIFF
--- a/plugins/drive-resources/src/components/EditFile.svelte
+++ b/plugins/drive-resources/src/components/EditFile.svelte
@@ -42,7 +42,7 @@
 </script>
 
 {#if object !== undefined && version !== undefined && blob !== undefined && contentType !== undefined}
-  <FilePreview file={blob} {contentType} name={version.title} metadata={version.metadata} fit />
+  <FilePreview file={blob} {contentType} name={version.title} metadata={version.metadata} fit={contentType !== 'application/pdf'} />
 
   {#if object.versions > 1}
     <div class="w-full mt-6">

--- a/plugins/drive-resources/src/components/EditFile.svelte
+++ b/plugins/drive-resources/src/components/EditFile.svelte
@@ -42,7 +42,13 @@
 </script>
 
 {#if object !== undefined && version !== undefined && blob !== undefined && contentType !== undefined}
-  <FilePreview file={blob} {contentType} name={version.title} metadata={version.metadata} fit={contentType !== 'application/pdf'} />
+  <FilePreview
+    file={blob}
+    {contentType}
+    name={version.title}
+    metadata={version.metadata}
+    fit={contentType !== 'application/pdf'}
+  />
 
   {#if object.versions > 1}
     <div class="w-full mt-6">


### PR DESCRIPTION
**Pull Request Requirements:**

- Fix an issue where pdf appears small in the drive module. Ref: #7129

Before:
![pdf-before](https://github.com/user-attachments/assets/244be319-df0e-4127-90ab-fa356755b503)

After:
![pdf-after](https://github.com/user-attachments/assets/d6a92b11-cae9-4425-ab96-de077aae9640)