### PR TITLE
fix: fallback to defaultIcon when value is undefined

### DIFF
--- a/plugins/document-resources/src/components/DocumentIcon.svelte
+++ b/plugins/document-resources/src/components/DocumentIcon.svelte
@@ -20,7 +20,7 @@
 
   import { ComponentType } from 'svelte'
 
-  export let value: IconProps
+  export let value: IconProps | undefined
   export let size: IconSize
   export let iconWithEmoji: AnySvelteComponent | Asset | ComponentType | undefined = view.ids.IconWithEmoji
   export let defaultIcon: AnySvelteComponent | Asset | ComponentType = document.icon.Document
@@ -28,10 +28,10 @@
 
 <Icon
   {size}
-  icon={value.icon === iconWithEmoji && iconWithEmoji ? IconWithEmoji : value.icon ?? defaultIcon}
-  iconProps={value.icon === iconWithEmoji && iconWithEmoji
-    ? { icon: value.color }
+  icon={value?.icon === iconWithEmoji && iconWithEmoji ? IconWithEmoji : value?.icon ?? defaultIcon}
+  iconProps={value?.icon === iconWithEmoji && iconWithEmoji
+    ? { icon: value?.color }
     : {
-        fill: value.color !== undefined ? getPlatformColorDef(value.color, $themeStore.dark).icon : 'currentColor'
+        fill: value?.color !== undefined ? getPlatformColorDef(value?.color, $themeStore.dark).icon : 'currentColor'
       }}
 />


### PR DESCRIPTION
**Fix:**

- Fallback to default icon when value is undefined
- This change can avoid errors like #6914

Before:

[before-document-sidebar.webm](https://github.com/user-attachments/assets/d813442e-b670-4c07-97da-b4a6f9e3dc89)

After:

[after-document-sidebar.webm](https://github.com/user-attachments/assets/2dc07ed2-ba94-4aef-aff2-487fbe8c6783)