### PR TITLE
fix: prevent content shift on select workspace page during loading

### DIFF
--- a/plugins/login-assets/lang/cs.json
+++ b/plugins/login-assets/lang/cs.json
@@ -19,6 +19,7 @@
     "DoNotHaveAnAccount": "Nemáte účet?",
     "PasswordRepeat": "Zopakujte heslo",
     "HaveAccount": "Již máte účet?",
+    "LoadingAccount": "Načítání...",
     "SelectWorkspace": "Vyberte pracovní prostor",
     "Copy": "Kopírovat",
     "Copied": "Zkopírováno",

--- a/plugins/login-assets/lang/en.json
+++ b/plugins/login-assets/lang/en.json
@@ -19,6 +19,7 @@
     "DoNotHaveAnAccount": "Do not have an account?",
     "PasswordRepeat": "Repeat password",
     "HaveAccount": "Already have an account?",
+    "LoadingAccount": "Loading...",
     "SelectWorkspace": "Select workspace",
     "Copy": "Copy",
     "Copied": "Copied",

--- a/plugins/login-assets/lang/es.json
+++ b/plugins/login-assets/lang/es.json
@@ -19,6 +19,7 @@
     "DoNotHaveAnAccount": "¿No tienes una cuenta?",
     "PasswordRepeat": "Repetir contraseña",
     "HaveAccount": "¿Ya tienes una cuenta?",
+    "LoadingAccount": "Cargando...",
     "SelectWorkspace": "Seleccionar espacio de trabajo",
     "Copy": "Copiar",
     "Copied": "Copiado",

--- a/plugins/login-assets/lang/fr.json
+++ b/plugins/login-assets/lang/fr.json
@@ -19,6 +19,7 @@
     "DoNotHaveAnAccount": "Vous n'avez pas de compte ?",
     "PasswordRepeat": "Répétez le mot de passe",
     "HaveAccount": "Vous avez déjà un compte ?",
+    "LoadingAccount": "Chargement...",
     "SelectWorkspace": "Sélectionner un espace de travail",
     "Copy": "Copier",
     "Copied": "Copié",

--- a/plugins/login-assets/lang/it.json
+++ b/plugins/login-assets/lang/it.json
@@ -19,6 +19,7 @@
     "DoNotHaveAnAccount": "Non hai un account?",
     "PasswordRepeat": "Ripeti password",
     "HaveAccount": "Hai già un account?",
+    "LoadingAccount": "Caricamento...",
     "SelectWorkspace": "Seleziona spazio di lavoro",
     "Copy": "Copia",
     "Copied": "Copiato",

--- a/plugins/login-assets/lang/pt.json
+++ b/plugins/login-assets/lang/pt.json
@@ -19,6 +19,7 @@
     "DoNotHaveAnAccount": "Não tem uma conta?",
     "PasswordRepeat": "Repetir palavra-passe",
     "HaveAccount": "Já tem uma conta?",
+    "LoadingAccount": "Carregando...",
     "SelectWorkspace": "Selecionar espaço de trabalho",
     "Copy": "Copiar",
     "Copied": "Copiado",

--- a/plugins/login-assets/lang/ru.json
+++ b/plugins/login-assets/lang/ru.json
@@ -19,6 +19,7 @@
     "DoNotHaveAnAccount": "Нет учетной записи?",
     "PasswordRepeat": "Повторите пароль",
     "HaveAccount": "Уже есть учетная запись?",
+    "LoadingAccount": "Загрузка...",
     "SelectWorkspace": "Выбрать рабочее пространство",
     "Copy": "Копировать",
     "Copied": "Скопировано",

--- a/plugins/login-assets/lang/zh.json
+++ b/plugins/login-assets/lang/zh.json
@@ -19,6 +19,7 @@
     "DoNotHaveAnAccount": "还没有账户？",
     "PasswordRepeat": "重复密码",
     "HaveAccount": "已经有账户了？",
+    "LoadingAccount": "加载中...",
     "SelectWorkspace": "选择工作区",
     "Copy": "复制",
     "Copied": "已复制",

--- a/plugins/login-resources/src/components/SelectWorkspace.svelte
+++ b/plugins/login-resources/src/components/SelectWorkspace.svelte
@@ -20,6 +20,7 @@
   import {
     Button,
     Label,
+    Spinner,
     Scroller,
     SearchEdit,
     deviceOptionsStore as deviceInfo,
@@ -95,7 +96,11 @@
 <form class="container" style:padding={$deviceInfo.docWidth <= 480 ? '1.25rem' : '5rem'}>
   <div class="grow-separator" />
   <div class="fs-title">
-    {account?.email}
+    {#if account?.email}
+      {account.email}
+    {:else}
+      <Label label={login.string.LoadingAccount} />
+    {/if}
   </div>
   <div class="title"><Label label={login.string.SelectWorkspace} /></div>
   <div class="status">
@@ -106,7 +111,11 @@
       <SearchEdit bind:value={search} width={'100%'} />
     </div>
   {/if}
-  {#await _getWorkspaces() then}
+  {#await _getWorkspaces()}
+    <div class="workspace-loader">
+      <Spinner />
+    </div>
+  {:then}
     <Scroller padding={'.125rem 0'} maxHeight={35}>
       <div class="form">
         {#each workspaces
@@ -206,6 +215,13 @@
     justify-content: space-between;
     flex-grow: 1;
     overflow: hidden;
+
+    .workspace-loader {
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
 
     .title {
       font-weight: 600;

--- a/plugins/login-resources/src/plugin.ts
+++ b/plugins/login-resources/src/plugin.ts
@@ -32,6 +32,7 @@ export default mergeIds(loginId, login, {
     LastName: '' as IntlString,
     FirstName: '' as IntlString,
     HaveAccount: '' as IntlString,
+    LoadingAccount: '' as IntlString,
     Join: '' as IntlString,
     Email: '' as IntlString,
     Password: '' as IntlString,


### PR DESCRIPTION
**Fix:**

- Added a loading state to the select workspace and username on the select workspace page.
- This change prevents content shift during data loading, improving user experience.

Before(delay added for demonstration):

[before-content-shift.webm](https://github.com/user-attachments/assets/6c527231-98a8-42cd-89fc-6635f612e50d)

After(delay added for demonstration):

[after-content-shift.webm](https://github.com/user-attachments/assets/2014c5c2-668d-4e18-80be-0d4fd96e3dc1)