### PR TITLE
Improved editor indent plugin related behaviour, added x-scroll to code blocks

### DIFF
--- a/packages/theme/styles/prose.scss
+++ b/packages/theme/styles/prose.scss
@@ -386,6 +386,7 @@ table.proseTable {
   background-color: var(--theme-button-default);
   border: 1px solid var(--theme-button-border);
   border-radius: .25rem;
+  font-size: 0.875rem;
 }
 
 .proseCodeBlock {
@@ -397,13 +398,19 @@ table.proseTable {
   padding: .5rem;
   user-select: text;
   cursor: auto;
+
+  code {
+    display: block;
+    overflow-x: auto;
+    white-space: pre;
+    word-wrap: nowrap;
+    scrollbar-width: auto;
+    font-size: 0.875rem;
+  }
 }
 
 pre.proseCodeBlock {
   position: relative;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  word-break: normal;
 }
 
 pre.proseCodeBlock {
@@ -496,6 +503,11 @@ pre.proseCodeBlock>pre.proseCode {
 
     font-size: 0.875rem;
     line-height: 1.5em;
+
+    overflow-x: auto;
+    white-space: pre;
+    word-wrap: nowrap;
+    scrollbar-width: auto;
   }
 
   .mermaidPreviewContainer {


### PR DESCRIPTION
Improved editor indent plugin related behaviour, added x-scroll to code blocks

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY1NTc1OWMyOWE3OGFmZmY2NmU5Y2MiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.lpb72Ev3agK4urh9NA_pw1RB7ETbD8WHkZkQGFZLKYE">Huly&reg;: <b>UBERF-8988</b></a></sub>