### PR TITLE
fix(github): broken images in issue description

### DIFF
--- a/packages/text/src/markdown/serializer.ts
+++ b/packages/text/src/markdown/serializer.ts
@@ -140,7 +140,22 @@ export const storeNodes: Record<string, NodeProcessor> = {
 
   image: (state, node) => {
     const attrs = nodeAttrs(node)
-    if (attrs['file-id'] != null) {
+    if (attrs.token != null && attrs['file-id'] != null) {
+      // Convert image to token format
+      state.write(
+        '![' +
+          state.esc(`${attrs.alt ?? ''}`) +
+          '](' +
+          (state.imageUrl +
+            `${attrs['file-id']}` +
+            `?file=${attrs['file-id']}` +
+            (attrs.width != null ? '&width=' + state.esc(`${attrs.width}`) : '') +
+            (attrs.height != null ? '&height=' + state.esc(`${attrs.height}`) : '') +
+            (attrs.token != null ? '&token=' + state.esc(`${attrs.token}`) : '')) +
+          (attrs.title != null ? ' ' + state.quote(`${attrs.title}`) : '') +
+          ')'
+      )
+    } else if (attrs['file-id'] != null) {
       // Convert image to fileid format
       state.write(
         '![' +

--- a/services/github/pod-github/src/sync/guest.ts
+++ b/services/github/pod-github/src/sync/guest.ts
@@ -89,10 +89,7 @@ function findImageTags (node: MarkupNode): MarkupNode[] {
   return []
 }
 
-export function appendGuestLinkToImage (
-  markdown: MarkupNode,
-  workspace: WorkspaceIdWithUrl
-): void {
+export function appendGuestLinkToImage (markdown: MarkupNode, workspace: WorkspaceIdWithUrl): void {
   const imageTags: MarkupNode[] = markdown.content?.flatMap(findImageTags) ?? []
 
   if (imageTags.length === 0) {

--- a/services/github/pod-github/src/worker.ts
+++ b/services/github/pod-github/src/worker.ts
@@ -191,7 +191,7 @@ export class GithubWorker implements IntegrationManager {
       text ?? '',
       concatLink(this.getBranding()?.front ?? config.FrontURL, `/browse/?workspace=${this.workspace.name}`),
       // TODO storage URL
-      concatLink(this.getBranding()?.front ?? config.FrontURL, `/files?workspace=${this.workspace.name}&file=`),
+      concatLink(this.getBranding()?.front ?? config.FrontURL, `/files/${this.workspace.name}/`),
       preprocessor
     )
   }


### PR DESCRIPTION
**Fix:**

- This PR addresses the issue of broken image previews in GitHub issues by appending an access token to the image source.

Before:
![before-gh-image-preview](https://github.com/user-attachments/assets/88d4075b-3e39-4bd1-a9c2-c22b12ce37b6)

After (Simulated Change in Production):
Simulated changes as setting up object storage for local testing is time-intensive.
![after-gh-image-preview](https://github.com/user-attachments/assets/a35898b8-a1a1-46ce-857a-b6f43533652d)

The following example shows that this change does not affect image rendering on the platform:
![after-gh-image-preview-platform](https://github.com/user-attachments/assets/3db07340-5b65-4f24-b207-6bf777a5cd41)

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY5YWVjY2MyOWE3OGFmZmY2NmVjYjMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.fzW6MPSZpiGIHXGhwnmxDeGjntPXUW0Bxok3EsqyLfA">Huly&reg;: <b>UBERF-9003</b></a></sub>