### PR TITLE
Support Controlled Documents import

### DIFF
--- a/dev/import-tool/docs/huly/README.md
+++ b/dev/import-tool/docs/huly/README.md
@@ -31,12 +31,24 @@ workspace/
 │   └── files/
 │       └── diagram.png          # Can be referenced in markdown content
 └── Project Alpha.yaml           # Project configuration
+├── QMS Documents/              # QMS documentation
+│   ├── [SOP-001] Document Control.md           # Document template
+│   ├── [SOP-001] Document Control/             # Template implementations
+│   │   └── [SOP-002] Document Review.md        # Controlled document
+│   └── [WI-001] Document Template Usage.md     # Standalone controlled document
+└── QMS Documents.yaml         # QMS space configuration
 ```
 
 ### File Format Requirements
+* All spaces files must be in YAML format
+* All document/issue files must include YAML frontmatter followed by Markdown content
+* Children documents/issues are located in the folder with the same name as the parent document/issue
 
-#### Space Configuration (*.yaml)
-Project space (`Project Alpha.yaml`):
+
+#### Tracker Issues
+
+##### 1. Project Configuration (*.yaml)
+Example: `Project Alpha.yaml`:
 ```yaml
 class: tracker:class:Project       # Required
 title: Project Alpha               # Required
@@ -51,32 +63,8 @@ description: string                # Optional
 defaultIssueStatus: Todo           # Optional
 ```
 
-Teamspace (`Documentation.yaml`):
-```yaml
-class: document:class:Teamspace   # Required
-title: Documentation              # Required
-private: false                    # Optional, default: false
-autoJoin: true                    # Optional, default: true
-owners:                           # Optional, list of email addresses
-  - john.doe@example.com
-members:                          # Optional, list of email addresses
-  - joe.shmoe@example.com
-description: string               # Optional
-```
-
-#### Documents and Issues (*.md)
-All files must include YAML frontmatter followed by Markdown content:
-
-Document (`Getting Started.md`):
-```yaml
----
-class: document:class:Document    # Required
-title: Getting Started Guide      # Required
----
-# Content in Markdown format
-```
-
-Issue (`1.Project Setup.md`):
+##### 2. Issue (*.md)
+Example: `1.Project Setup.md`:
 ```yaml
 ---
 class: tracker:class:Issue        # Required
@@ -90,11 +78,11 @@ remainingTime: 4                  # Optional, in hours
 Task description in Markdown...
 ```
 
-### Task Identification
-* Human-readable task ID is formed by combining project's identifier and task number from filename
-* Example: For project with identifier "ALPHA" and task "1.Setup Project.md", the task ID will be "ALPHA-1"
+##### Issue Identification
+* Human-readable issue ID is formed by combining project's identifier and issue number from filename
+* Example: For project with identifier `ALPHA` and issue `1.Setup Project.md`, the issue ID will be `ALPHA-1`
 
-### Allowed Values
+##### Allowed Values
 
 Issue status values:
 * `Backlog`
@@ -108,6 +96,99 @@ Issue priority values:
 * `Medium`
 * `High`
 * `Urgent`
+
+#### Documents
+
+##### 1. Teamspace Configuration (*.yaml)
+Example: `Documentation.yaml`:
+```yaml
+class: document:class:Teamspace   # Required
+title: Documentation              # Required
+private: false                    # Optional, default: false
+autoJoin: true                    # Optional, default: true
+owners:                           # Optional, list of email addresses
+  - john.doe@example.com
+members:                          # Optional, list of email addresses
+  - joe.shmoe@example.com
+description: string               # Optional
+```
+
+##### 2. Document (*.md)
+Example: `Getting Started.md`:
+```yaml
+---
+class: document:class:Document    # Required
+title: Getting Started Guide      # Required
+---
+# Content in Markdown format
+```
+
+#### Controlled Documents
+##### 1. Space Configuration (*.yaml)
+QMS Document Space: `QMS Documents.yaml`:
+```yaml
+class: documents:class:OrgSpace   # Required
+title: QMS Documents              # Required
+private: false                    # Optional, default: false
+owners:                           # Optional, list of email addresses
+  - john.doe@example.com
+members:                          # Optional, list of email addresses
+  - joe.shmoe@example.com
+description: string               # Optional
+qualified: john.doe@example.com   # Optional, qualified user
+manager: jane.doe@example.com     # Optional, QMS manager
+qara: bob.smith@example.com       # Optional, QA/RA specialist
+```
+
+##### 2. Document Template (*.md)
+Example: `[SOP-001] Document Control.md`:
+```yaml
+---
+class: documents:mixin:DocumentTemplate  # Required
+title: SOP Template                      # Required
+docPrefix: SOP                           # Required, document code prefix
+category: documents:category:Procedures  # Required
+author: John Smith                       # Required
+owner: Jane Wilson                       # Required
+abstract: Template description           # Optional
+reviewers:                               # Optional
+  - alice.cooper@example.com
+approvers:                               # Optional
+  - david.brown@example.com
+coAuthors:                               # Optional
+  - bob.dylan@example.com
+---
+Template content in Markdown...
+```
+
+##### 3. Controlled Document (*.md)
+Example: `[SOP-002] Document Review.md`:
+```yaml
+---
+class: documents:class:ControlledDocument # Required
+title: Document Review Procedure          # Required
+template: [SOP-001] Document Control.md   # Required, path to template
+author: John Smith                        # Required
+owner: Jane Wilson                        # Required
+abstract: Document description            # Optional
+reviewers:                                # Optional
+  - alice.cooper@example.com
+approvers:                                # Optional
+  - david.brown@example.com
+coAuthors:                                # Optional
+  - bob.dylan@example.com
+changeControl:                            # Optional
+  description: Initial document creation
+  reason: Need for standardized process
+  impact: Improved document control
+---
+Document content in Markdown...
+```
+##### Controlled Document Code Format
+* Document code must be specified in file name: `[CODE] Any File Name.md`
+* If code is not specified for controlled document, it will be generated automatically using template's docPrefix and sequential number (e.g. `SOP-99`)
+* If code is not specified for template, it will be generated automatically as `TMPL-seqNumber`, where `seqNumber` is the sequence number of the template in the space
+
 
 ### Run Import Tool
 ```bash
@@ -125,3 +206,6 @@ docker run \
 * All users must exist in the system before import
 * Assignees are mapped by full name
 * Files in space directories can be used as attachments when referenced in markdown content
+* Document codes (in square brackets) must be unique across all document spaces
+* Controlled documents must be created in the same space as their templates
+* Controlled documents can be imported only with `Draft` status

--- a/dev/import-tool/docs/huly/example-workspace/QMS Documents.yaml
+++ b/dev/import-tool/docs/huly/example-workspace/QMS Documents.yaml
@@ -1,0 +1,11 @@
+class: documents:class:OrgSpace
+title: QMS Documents
+description: Quality Management System Documentation
+private: false
+owners:
+  - user1
+members:
+  - user1
+qualified: user1
+manager: user1
+qara: user1

--- a/dev/import-tool/docs/huly/example-workspace/QMS Documents/[SOP-001] Document Control.md
+++ b/dev/import-tool/docs/huly/example-workspace/QMS Documents/[SOP-001] Document Control.md
@@ -1,0 +1,32 @@
+---
+class: documents:mixin:DocumentTemplate
+title: 'Standard Operating Procedure Template'
+docPrefix: SOP
+category: DOC
+author: John Appleseed
+owner: John Appleseed
+abstract: Template for Standard Operating Procedures
+reviewers:
+  - John Appleseed
+approvers:
+  - John Appleseed
+---
+# Standard Operating Procedure
+
+## 1. Purpose
+[Describe the purpose of the procedure]
+
+## 2. Scope
+[Define the scope and applicability]
+
+## 3. Responsibilities
+[List key roles and responsibilities]
+
+## 4. Procedure
+[Detail the step-by-step procedure]
+
+## 5. References
+[List related documents]
+
+## 6. Revision History
+[Document revision history]

--- a/dev/import-tool/docs/huly/example-workspace/QMS Documents/[SOP-001] Document Control/[SOP-002] Document Review.md
+++ b/dev/import-tool/docs/huly/example-workspace/QMS Documents/[SOP-001] Document Control/[SOP-002] Document Review.md
@@ -1,0 +1,42 @@
+---
+class: documents:class:ControlledDocument
+title: Document Review Procedure
+template: '../[SOP-001] Document Control.md'
+author: John Appleseed
+owner: John Appleseed
+abstract: Procedure for document review and approval process
+reviewers:
+  - John Appleseed
+approvers:
+  - John Appleseed
+changeControl:
+  description: Initial document creation
+  reason: Need for standardized review process
+  impact: Improved document quality control
+---
+# Document Review Procedure
+
+## 1. Purpose
+This procedure defines the process for reviewing quality management system documents.
+
+## 2. Scope
+Applies to all controlled documents within the QMS.
+
+## 3. Responsibilities
+- Document Owner: Responsible for content
+- Reviewers: Technical review
+- QA Manager: Final approval
+
+## 4. Procedure
+1. Author prepares document
+2. Technical review
+3. QA review
+4. Final approval
+5. Document release
+
+## 5. References
+- Quality Manual
+- Document Control Procedure
+
+## 6. Revision History
+Rev 0.1 - Initial draft 

--- a/dev/import-tool/docs/huly/example-workspace/QMS Documents/[WI-001] Document Template Usage.md
+++ b/dev/import-tool/docs/huly/example-workspace/QMS Documents/[WI-001] Document Template Usage.md
@@ -1,0 +1,28 @@
+---
+class: documents:class:ControlledDocument
+title: Document Template Usage Guide
+template: '[SOP-001] Document Control.md'
+author: John Appleseed
+owner: John Appleseed
+abstract: Work instruction for using document templates
+reviewers:
+  - John Appleseed
+approvers:
+  - John Appleseed
+---
+# Document Template Usage Guide
+
+## 1. Purpose
+Guide users in proper usage of QMS document templates.
+
+## 2. Scope
+All personnel creating QMS documentation.
+
+## 3. Procedure
+1. Select appropriate template
+2. Fill in required sections
+3. Submit for review
+
+## 4. References
+- [Document Control SOP](./[SOP-001]%20Document%20Control.md)
+- [Document Review Procedure](./[SOP-001]%20Document%20Control/[SOP-002]%20Document%20Review.md)

--- a/dev/import-tool/docs/huly/example-workspace/QMS Documents/[WI-001] Document Template Usage.md
+++ b/dev/import-tool/docs/huly/example-workspace/QMS Documents/[WI-001] Document Template Usage.md
@@ -23,6 +23,15 @@ All personnel creating QMS documentation.
 2. Fill in required sections
 3. Submit for review
 
-## 4. References
+## 4. Document Review Changes
+
+| Step | Current Text | Updated Text | Comments |
+| --- | --- | --- | --- |
+| Initial Review | Select a template from library | Select a template that matches your document type | Clarified selection criteria |
+| Metadata | Fill in required fields | Complete all required metadata and content fields | Added metadata specification |
+| Review Process | Submit for review | Submit document for review according to procedure | Added reference to procedure |
+| Approval | Wait for approval | Submit for approval after receiving all reviews | Process detail added |
+
+## 5. References
 - [Document Control SOP](./[SOP-001]%20Document%20Control.md)
 - [Document Review Procedure](./[SOP-001]%20Document%20Control/[SOP-002]%20Document%20Review.md)

--- a/models/controlled-documents/src/plugin.ts
+++ b/models/controlled-documents/src/plugin.ts
@@ -15,7 +15,7 @@
 
 import { documentsId } from '@hcengineering/controlled-documents'
 import documents from '@hcengineering/controlled-documents-resources/src/plugin'
-import type { Client, Doc, Ref, Role } from '@hcengineering/core'
+import type { Client, Doc, Ref } from '@hcengineering/core'
 import { type ObjectSearchCategory, type ObjectSearchFactory } from '@hcengineering/model-presentation'
 import { mergeIds, type Resource } from '@hcengineering/platform'
 import { type TagCategory } from '@hcengineering/tags'
@@ -70,11 +70,6 @@ export default mergeIds(documentsId, documents, {
     ListDocument: '' as Ref<Doc>,
     TableDocumentTemplate: '' as Ref<Doc>,
     TableDocumentDomain: '' as Ref<Doc>
-  },
-  role: {
-    QARA: '' as Ref<Role>,
-    Manager: '' as Ref<Role>,
-    QualifiedUser: '' as Ref<Role>
   },
   notification: {
     DocumentsNotificationGroup: '' as Ref<NotificationGroup>,

--- a/packages/importer/package.json
+++ b/packages/importer/package.json
@@ -45,6 +45,7 @@
     "@hcengineering/chunter": "^0.6.20",
     "@hcengineering/collaboration": "^0.6.0",
     "@hcengineering/contact": "^0.6.24",
+    "@hcengineering/controlled-documents": "^0.1.0",
     "@hcengineering/core": "^0.6.32",
     "@hcengineering/document": "^0.6.0",
     "@hcengineering/model-attachment": "^0.6.0",

--- a/packages/importer/src/importer/importer.ts
+++ b/packages/importer/src/importer/importer.ts
@@ -14,12 +14,25 @@
 //
 import attachment, { Drawing, type Attachment } from '@hcengineering/attachment'
 import chunter, { type ChatMessage } from '@hcengineering/chunter'
-import { type Person } from '@hcengineering/contact'
+import { Employee, type Person } from '@hcengineering/contact'
+import documents, {
+  ChangeControl,
+  type ControlledDocument,
+  createControlledDocMetadata,
+  createDocumentTemplateMetadata,
+  DocumentCategory,
+  DocumentMeta,
+  type DocumentSpace,
+  DocumentState,
+  DocumentTemplate,
+  OrgSpace,
+  ProjectDocument,
+  useDocumentTemplate
+} from '@hcengineering/controlled-documents'
 import core, {
   type Account,
   type AttachedData,
   type Class,
-  type Blob as PlatformBlob,
   type CollaborativeDoc,
   type Data,
   type Doc,
@@ -27,7 +40,9 @@ import core, {
   generateId,
   makeCollabId,
   type Mixin,
+  type Blob as PlatformBlob,
   type Ref,
+  RolesAssignment,
   SortingOrder,
   type Space,
   type Status,
@@ -157,6 +172,57 @@ export interface ImportDrawing {
   contentProvider: () => Promise<string>
 }
 
+export type ImportControlledDoc = ImportControlledDocument | ImportControlledDocumentTemplate // todo: rename
+export interface ImportOrgSpace extends ImportSpace<ImportControlledDoc> {
+  class: Ref<Class<DocumentSpace>>
+  qualified?: Ref<Account>
+  manager?: Ref<Account>
+  qara?: Ref<Account>
+}
+
+export interface ImportControlledDocumentTemplate extends ImportDoc {
+  id: Ref<ControlledDocument>
+  metaId: Ref<DocumentMeta>
+  class: Ref<Class<Document>>
+  docPrefix: string
+  code?: string
+  major: number
+  minor: number
+  state: DocumentState
+  category?: Ref<DocumentCategory>
+  author?: Ref<Employee>
+  owner?: Ref<Employee>
+  abstract?: string
+  reviewers?: Ref<Employee>[]
+  approvers?: Ref<Employee>[]
+  coAuthors?: Ref<Employee>[]
+  ccReason?: string
+  ccImpact?: string
+  ccDescription?: string
+  subdocs: ImportControlledDoc[]
+}
+
+export interface ImportControlledDocument extends ImportDoc {
+  id: Ref<ControlledDocument>
+  metaId: Ref<DocumentMeta>
+  class: Ref<Class<ControlledDocument>>
+  template: Ref<ControlledDocument> // todo: test (it was Ref<DocumentTemplate>)
+  code?: string
+  major: number
+  minor: number
+  state: DocumentState
+  reviewers?: Ref<Employee>[]
+  approvers?: Ref<Employee>[]
+  coAuthors?: Ref<Employee>[]
+  author?: Ref<Employee>
+  owner?: Ref<Employee>
+  abstract?: string
+  ccReason?: string
+  ccImpact?: string
+  ccDescription?: string
+  subdocs: ImportControlledDoc[]
+}
+
 export class WorkspaceImporter {
   private readonly issueStatusByName = new Map<string, Ref<IssueStatus>>()
   private readonly projectTypeByName = new Map<string, Ref<ProjectType>>()
@@ -192,6 +258,8 @@ export class WorkspaceImporter {
         await this.importTeamspace(space as ImportTeamspace)
       } else if (space.class === tracker.class.Project) {
         await this.importProject(space as ImportProject)
+      } else if (space.class === documents.class.OrgSpace) {
+        await this.importOrgSpace(space as ImportOrgSpace)
       }
     }
   }
@@ -723,5 +791,334 @@ export class WorkspaceImporter {
       i++
     }
     return identifier
+  }
+
+  async importOrgSpace (space: ImportOrgSpace): Promise<Ref<DocumentSpace>> {
+    this.logger.log('Creating document space: ' + space.title)
+    const spaceId = await this.createOrgSpace(space)
+    this.logger.log('Document space created: ' + spaceId)
+
+    // Create hierarchy meta
+    const templateMetaMap = new Map<Ref<ControlledDocument>, { seqNumber: number, code: string }>()
+    for (const doc of space.docs) {
+      if (this.isDocumentTemplate(doc)) {
+        await this.createDocTemplateMetaHierarhy(doc as ImportControlledDocumentTemplate, templateMetaMap, spaceId)
+      } else {
+        await this.createControlledDocMetaHierarhy(doc as ImportControlledDocument, templateMetaMap, spaceId)
+      }
+    }
+
+    // Partition templates and documents
+    const templateMap = new Map<Ref<ControlledDocument>, ImportControlledDocumentTemplate>()
+    const documentMap = new Map<Ref<ControlledDocument>, ImportControlledDocument>()
+    for (const doc of space.docs) {
+      this.partitionTemplatesFromDocuments(doc, documentMap, templateMap)
+    }
+
+    // Create attached docs for templates
+    for (const template of templateMap.values()) {
+      const meta = templateMetaMap.get(template.id)
+      if (meta === undefined) {
+        throw new Error('Template meta not found: ' + template.id)
+      }
+      await this.createDocTemplateAttachedDoc(template, meta.seqNumber, meta.code, spaceId)
+    }
+
+    // Create attached docs for documents
+    for (const document of documentMap.values()) {
+      await this.createControlledDocAttachedDoc(document, spaceId)
+    }
+
+    return spaceId
+  }
+
+  private partitionTemplatesFromDocuments (
+    doc: ImportControlledDoc,
+    documentMap: Map<Ref<ControlledDocument>, ImportControlledDocument>,
+    templateMap: Map<Ref<ControlledDocument>, ImportControlledDocumentTemplate>
+  ): void {
+    if (this.isDocumentTemplate(doc)) {
+      templateMap.set(doc.id, doc as ImportControlledDocumentTemplate)
+    } else {
+      documentMap.set(doc.id, doc as ImportControlledDocument)
+    }
+
+    for (const subdoc of doc.subdocs) {
+      this.partitionTemplatesFromDocuments(subdoc, documentMap, templateMap)
+    }
+  }
+
+  private isDocumentTemplate (doc: ImportDoc): boolean {
+    return doc.class === documents.mixin.DocumentTemplate
+  }
+
+  private async createOrgSpace (space: ImportOrgSpace): Promise<Ref<DocumentSpace>> {
+    const spaceId = generateId<DocumentSpace>()
+    const data: Data<OrgSpace> = {
+      type: documents.spaceType.DocumentSpaceType,
+      description: space.description ?? '',
+      name: space.title,
+      private: space.private,
+      owners: space.owners ?? [],
+      members: space.members ?? [],
+      archived: space.archived ?? false
+    }
+    await this.client.createDoc(documents.class.OrgSpace, core.space.Space, data, spaceId)
+
+    const rolesAssignment: RolesAssignment = {}
+    if (space.qualified !== undefined) {
+      rolesAssignment[documents.role.QualifiedUser] = [space.qualified]
+    }
+    if (space.manager !== undefined) {
+      rolesAssignment[documents.role.Manager] = [space.manager]
+    }
+    if (space.qara !== undefined) {
+      rolesAssignment[documents.role.QARA] = [space.qara]
+    }
+    if (Object.keys(rolesAssignment).length > 0) {
+      await this.client.createMixin(
+        spaceId,
+        documents.class.OrgSpace,
+        core.space.Space,
+        documents.mixin.DocumentSpaceTypeData,
+        rolesAssignment
+      )
+    }
+    return spaceId
+  }
+
+  private async createDocTemplateMetaHierarhy (
+    template: ImportControlledDocumentTemplate,
+    templateMetaMap: Map<Ref<ControlledDocument>, { seqNumber: number, code: string }>,
+    spaceId: Ref<DocumentSpace>,
+    parentProjectDocumentId?: Ref<ProjectDocument>
+  ): Promise<Ref<ControlledDocument>> {
+    this.logger.log('Creating document template: ' + template.title)
+    const templateId = template.id ?? generateId<ControlledDocument>()
+
+    const { seqNumber, code, projectDocumentId } = await createDocumentTemplateMetadata(
+      this.client,
+      documents.class.Document,
+      spaceId,
+      documents.mixin.DocumentTemplate,
+      undefined,
+      parentProjectDocumentId,
+      templateId as unknown as Ref<ControlledDocument>, // todo: suspisios place
+      template.docPrefix,
+      template.code ?? '',
+      template.title,
+      template.metaId
+    )
+
+    templateMetaMap.set(templateId, { seqNumber, code })
+
+    for (const subdoc of template.subdocs) {
+      if (this.isDocumentTemplate(subdoc)) {
+        await this.createDocTemplateMetaHierarhy(
+          subdoc as ImportControlledDocumentTemplate,
+          templateMetaMap,
+          spaceId,
+          projectDocumentId
+        )
+      } else {
+        await this.createControlledDocMetaHierarhy(
+          subdoc as ImportControlledDocument,
+          templateMetaMap,
+          spaceId,
+          projectDocumentId
+        )
+      }
+    }
+
+    return templateId
+  }
+
+  private async createDocTemplateAttachedDoc (
+    template: ImportControlledDocumentTemplate,
+    seqNumber: number,
+    code: string,
+    spaceId: Ref<DocumentSpace>
+  ): Promise<Ref<ControlledDocument>> {
+    const content = await template.descrProvider()
+
+    this.logger.log('Creating document template attached doc: ' + template.title)
+
+    const collabId = makeCollabId(documents.class.Document, template.id, 'content')
+    const contentId = await this.createCollaborativeContent(template.id, collabId, content, spaceId)
+
+    const changeControlId =
+      template.ccReason !== undefined || template.ccImpact !== undefined || template.ccDescription !== undefined
+        ? await this.createChangeControl(spaceId, template.ccDescription, template.ccReason, template.ccImpact)
+        : ('' as Ref<ChangeControl>)
+
+    const ops = this.client.apply()
+    const result = await ops.addCollection(
+      documents.class.ControlledDocument,
+      spaceId,
+      template.metaId,
+      documents.class.DocumentMeta,
+      'documents',
+      {
+        title: template.title,
+        major: template.major,
+        minor: template.minor,
+        state: template.state,
+        author: template.author,
+        owner: template.owner,
+        abstract: template.abstract,
+        reviewers: template.reviewers ?? [],
+        approvers: template.approvers ?? [],
+        coAuthors: template.coAuthors ?? [],
+        code,
+        seqNumber,
+        prefix: template.docPrefix, // todo: or TEMPLATE_PREFIX?s
+        content: contentId,
+        changeControl: changeControlId,
+        commentSequence: 0,
+        requests: 0,
+        labels: 0
+      },
+      template.id as unknown as Ref<ControlledDocument> // todo: make sure it's not used anywhere as mixin id
+    )
+
+    await ops.createMixin(template.id, documents.class.Document, spaceId, documents.mixin.DocumentTemplate, {
+      sequence: 0,
+      docPrefix: template.docPrefix
+    })
+
+    const commit = await ops.commit()
+    if (!commit.result) {
+      throw new Error('Failed to create document template attached doc: ' + template.title)
+    }
+
+    this.logger.log('Document template attached doc created: ' + result)
+    return result
+  }
+
+  private async createControlledDocMetaHierarhy (
+    doc: ImportControlledDocument,
+    templateMetaMap: Map<Ref<ControlledDocument>, { seqNumber: number, code: string }>,
+    spaceId: Ref<DocumentSpace>,
+    parentProjectDocumentId?: Ref<ProjectDocument>
+  ): Promise<Ref<ControlledDocument>> {
+    this.logger.log('Creating controlled document: ' + doc.title)
+    const documentId = doc.id ?? generateId<ControlledDocument>()
+
+    // const { seqNumber, prefix, category } = await useDocumentTemplate(this.client, doc.template as unknown as Ref<DocumentTemplate>)
+    const result = await createControlledDocMetadata(
+      this.client,
+      documents.template.ProductChangeControl, // todo: make it dynamic - wtf, commit missed?
+      documentId,
+      spaceId,
+      undefined, // project
+      parentProjectDocumentId, // parent
+      'prefix',
+      0,
+      doc.code ?? '',
+      doc.title,
+      doc.metaId
+    )
+
+    // Process subdocs recursively
+    for (const subdoc of doc.subdocs) {
+      if (this.isDocumentTemplate(subdoc)) {
+        await this.createDocTemplateMetaHierarhy(
+          subdoc as ImportControlledDocumentTemplate,
+          templateMetaMap,
+          spaceId,
+          result.projectDocumentId
+        )
+      } else {
+        await this.createControlledDocMetaHierarhy(
+          subdoc as ImportControlledDocument,
+          templateMetaMap,
+          spaceId,
+          result.projectDocumentId
+        )
+      }
+    }
+
+    return documentId
+  }
+
+  private async createControlledDocAttachedDoc (
+    document: ImportControlledDocument,
+    spaceId: Ref<DocumentSpace>
+  ): Promise<Ref<ControlledDocument>> {
+    this.logger.log('Creating controlled document attached doc: ' + document.title)
+
+    const content = await document.descrProvider()
+    const collabId = makeCollabId(documents.class.Document, document.id, 'content')
+    const contentId = await this.createCollaborativeContent(document.id, collabId, content, spaceId)
+
+    const templateId = document.template
+    const { seqNumber, prefix, category } = await useDocumentTemplate(
+      this.client,
+      templateId as unknown as Ref<DocumentTemplate>
+    )
+
+    const ops = this.client.apply()
+
+    const changeControlId =
+      document.ccReason !== undefined || document.ccImpact !== undefined
+        ? await this.createChangeControl(spaceId, document.ccDescription, document.ccReason, document.ccImpact)
+        : ('' as Ref<ChangeControl>)
+
+    const result = await ops.addCollection(
+      documents.class.ControlledDocument,
+      spaceId,
+      document.metaId,
+      documents.class.DocumentMeta,
+      'documents',
+      {
+        title: document.title,
+        major: document.major,
+        minor: document.minor,
+        state: document.state,
+        author: document.author,
+        owner: document.owner,
+        abstract: document.abstract,
+        reviewers: document.reviewers ?? [],
+        approvers: document.approvers ?? [],
+        coAuthors: document.coAuthors ?? [],
+        changeControl: changeControlId,
+        code: document.code ?? `${prefix}-${seqNumber}`,
+        prefix,
+        category,
+        seqNumber,
+        content: contentId,
+        template: templateId as unknown as Ref<DocumentTemplate>,
+        commentSequence: 0,
+        requests: 0
+      },
+      document.id
+    )
+
+    await ops.updateDoc(documents.class.DocumentMeta, spaceId, document.metaId, {
+      documents: 0,
+      title: `${prefix}-${seqNumber} ${document.title}`
+    })
+
+    await ops.commit()
+
+    this.logger.log('Controlled document attached doc created: ' + result)
+
+    return result
+  }
+
+  private async createChangeControl (
+    spaceId: Ref<DocumentSpace>,
+    description?: string,
+    reason?: string,
+    impact?: string
+  ): Promise<Ref<ChangeControl>> {
+    const changeControlData: Data<ChangeControl> = {
+      reason: reason ?? '',
+      impact: impact ?? '',
+      description: description ?? '',
+      impactedDocuments: []
+    }
+
+    return await this.client.createDoc(documents.class.ChangeControl, spaceId, changeControlData)
   }
 }

--- a/plugins/controlled-documents/src/docutils.ts
+++ b/plugins/controlled-documents/src/docutils.ts
@@ -16,16 +16,16 @@
 import { type Employee } from '@hcengineering/contact'
 import { type AttachedData, type Class, type Ref, type TxOperations, Blob, Mixin } from '@hcengineering/core'
 import {
-  type Document,
-  type DocumentTemplate,
   type ControlledDocument,
+  type Document,
   type DocumentCategory,
-  type DocumentSpace,
   type DocumentMeta,
+  type DocumentSpace,
+  type DocumentTemplate,
+  type HierarchyDocument,
   type Project,
-  DocumentState,
-  HierarchyDocument,
-  ProjectDocument
+  type ProjectDocument,
+  DocumentState
 } from './types'
 
 import documents from './plugin'
@@ -67,18 +67,55 @@ export async function createControlledDocFromTemplate (
     return { seqNumber: -1, success: false }
   }
 
+  const { seqNumber, prefix, content, category } = await useDocumentTemplate(client, templateId)
+  const { success, documentMetaId } = await createControlledDocMetadata(
+    client,
+    templateId,
+    documentId,
+    space,
+    project,
+    parent,
+    prefix,
+    seqNumber,
+    spec.code,
+    spec.title
+  )
+
+  if (!success) {
+    return { seqNumber: -1, success: false }
+  }
+
+  await client.addCollection(
+    docClass,
+    space,
+    documentMetaId,
+    documents.class.DocumentMeta,
+    'documents',
+    {
+      ...spec,
+      category,
+      template: templateId,
+      seqNumber,
+      prefix,
+      state: DocumentState.Draft,
+      content
+    },
+    documentId
+  )
+
+  return { seqNumber, success: true }
+}
+
+export async function useDocumentTemplate (
+  client: TxOperations,
+  templateId: Ref<DocumentTemplate>
+): Promise<{ seqNumber: number, prefix: string, content: Ref<Blob> | null, category: Ref<DocumentCategory> }> {
   const template = await client.findOne(documents.mixin.DocumentTemplate, {
     _id: templateId
   })
 
   if (template === undefined) {
-    return { seqNumber: -1, success: false }
-  }
-
-  let path: Array<Ref<DocumentMeta>> = []
-
-  if (parent !== undefined) {
-    path = await getParentPath(client, parent)
+    return { seqNumber: -1, prefix: '', content: null, category: '' as Ref<DocumentCategory> }
   }
 
   await client.updateMixin(templateId, documents.class.Document, template.space, documents.mixin.DocumentTemplate, {
@@ -89,34 +126,27 @@ export async function createControlledDocFromTemplate (
   const seqNumber = template.sequence + 1
   const prefix = template.docPrefix
 
-  return await createControlledDoc(
-    client,
-    templateId,
-    documentId,
-    { ...spec, category: template.category },
-    space,
-    project,
-    prefix,
-    seqNumber,
-    path,
-    docClass,
-    template.content
-  )
+  return { seqNumber, prefix, content: template.content, category: template.category as Ref<DocumentCategory> }
 }
 
-async function createControlledDoc (
+export async function createControlledDocMetadata (
   client: TxOperations,
   templateId: Ref<DocumentTemplate>,
   documentId: Ref<ControlledDocument>,
-  spec: AttachedData<ControlledDocument>,
   space: Ref<DocumentSpace>,
   project: Ref<Project> | undefined,
+  parent: Ref<ProjectDocument> | undefined,
   prefix: string,
   seqNumber: number,
-  path: Ref<DocumentMeta>[] = [],
-  docClass: Ref<Class<ControlledDocument>> = documents.class.ControlledDocument,
-  content: Ref<Blob> | null
-): Promise<{ seqNumber: number, success: boolean }> {
+  specCode: string,
+  specTitle: string,
+  metaId?: Ref<DocumentMeta>
+): Promise<{
+    success: boolean
+    seqNumber: number
+    documentMetaId: Ref<DocumentMeta>
+    projectDocumentId: Ref<ProjectDocument>
+  }> {
   const projectId = project ?? documents.ids.NoProject
 
   const ops = client.apply()
@@ -127,23 +157,33 @@ async function createControlledDoc (
   })
 
   ops.notMatch(documents.class.Document, {
-    code: spec.code
+    code: specCode
   })
 
-  const metaId = await ops.createDoc(documents.class.DocumentMeta, space, {
-    documents: 0,
-    title: `${prefix}-${seqNumber} ${spec.title}`
-  })
+  const documentMetaId = await ops.createDoc(
+    documents.class.DocumentMeta,
+    space,
+    {
+      documents: 0,
+      title: `${prefix}-${seqNumber} ${specTitle}`
+    },
+    metaId
+  )
+
+  let path: Array<Ref<DocumentMeta>> = []
+  if (parent !== undefined) {
+    path = await getParentPath(client, parent)
+  }
 
   const projectMetaId = await ops.createDoc(documents.class.ProjectMeta, space, {
     project: projectId,
-    meta: metaId,
+    meta: documentMetaId,
     path,
     parent: path[0] ?? documents.ids.NoParent,
     documents: 0
   })
 
-  await client.addCollection(
+  const projectDocumentId = await client.addCollection(
     documents.class.ProjectDocument,
     space,
     projectMetaId,
@@ -156,25 +196,9 @@ async function createControlledDoc (
     }
   )
 
-  await ops.addCollection(
-    docClass,
-    space,
-    metaId,
-    documents.class.DocumentMeta,
-    'documents',
-    {
-      ...spec,
-      template: templateId,
-      seqNumber,
-      prefix,
-      state: DocumentState.Draft,
-      content
-    },
-    documentId
-  )
-
   const success = await ops.commit()
-  return { seqNumber, success: success.result }
+
+  return { success: success.result, seqNumber, documentMetaId, projectDocumentId }
 }
 
 export async function createDocumentTemplate (
@@ -190,6 +214,70 @@ export async function createDocumentTemplate (
   category: Ref<DocumentCategory>,
   author?: Ref<Employee>
 ): Promise<{ seqNumber: number, success: boolean }> {
+  const { success, seqNumber, code, documentMetaId } = await createDocumentTemplateMetadata(
+    client,
+    _class,
+    space,
+    _mixin,
+    project,
+    parent,
+    templateId,
+    prefix,
+    spec.code ?? '',
+    spec.title
+  )
+
+  if (!success) {
+    return { seqNumber: -1, success: false }
+  }
+
+  const ops = client.apply()
+  await ops.addCollection<DocumentMeta, HierarchyDocument>(
+    _class,
+    space,
+    documentMetaId,
+    documents.class.DocumentMeta,
+    'documents',
+    {
+      ...spec,
+      code,
+      seqNumber,
+      category,
+      prefix: TEMPLATE_PREFIX,
+      author,
+      owner: author,
+      content: spec.content ?? null
+    },
+    templateId
+  )
+  await ops.createMixin(templateId, documents.class.Document, space, _mixin, {
+    sequence: 0,
+    docPrefix: prefix
+  })
+  const commit = await ops.commit()
+
+  return { seqNumber, success: commit.result }
+}
+
+export async function createDocumentTemplateMetadata (
+  client: TxOperations,
+  _class: Ref<Class<Document>>,
+  space: Ref<DocumentSpace>,
+  _mixin: Ref<Mixin<DocumentTemplate>>,
+  project: Ref<Project> | undefined,
+  parent: Ref<ProjectDocument> | undefined,
+  templateId: Ref<ControlledDocument>,
+  prefix: string,
+  specCode: string,
+  specTitle: string,
+  metaId?: Ref<DocumentMeta>
+): Promise<{
+    success: boolean
+    seqNumber: number
+    code: string
+    documentMetaId: Ref<DocumentMeta>
+    projectDocumentId: Ref<ProjectDocument>
+  }> {
   const projectId = project ?? documents.ids.NoProject
 
   const incResult = await client.updateDoc(
@@ -202,7 +290,7 @@ export async function createDocumentTemplate (
     true
   )
   const seqNumber = (incResult as any).object.sequence as number
-  const code = spec.code === '' ? `${TEMPLATE_PREFIX}-${seqNumber}` : spec.code
+  const code = specCode === '' ? `${TEMPLATE_PREFIX}-${seqNumber}` : specCode
 
   let path: Array<Ref<DocumentMeta>> = []
 
@@ -225,20 +313,25 @@ export async function createDocumentTemplate (
     docPrefix: prefix
   })
 
-  const metaId = await ops.createDoc(documents.class.DocumentMeta, space, {
-    documents: 0,
-    title: `${TEMPLATE_PREFIX}-${seqNumber} ${spec.title}`
-  })
+  const documentMetaId = await ops.createDoc(
+    documents.class.DocumentMeta,
+    space,
+    {
+      documents: 0,
+      title: `${TEMPLATE_PREFIX}-${seqNumber} ${specTitle}`
+    },
+    metaId
+  )
 
   const projectMetaId = await ops.createDoc(documents.class.ProjectMeta, space, {
     project: projectId,
-    meta: metaId,
+    meta: documentMetaId,
     path,
     parent: path[0] ?? documents.ids.NoParent,
     documents: 0
   })
 
-  await client.addCollection(
+  const projectDocumentId = await client.addCollection(
     documents.class.ProjectDocument,
     space,
     projectMetaId,
@@ -251,31 +344,7 @@ export async function createDocumentTemplate (
     }
   )
 
-  await ops.addCollection<DocumentMeta, HierarchyDocument>(
-    _class,
-    space,
-    metaId,
-    documents.class.DocumentMeta,
-    'documents',
-    {
-      ...spec,
-      code,
-      seqNumber,
-      category,
-      prefix: TEMPLATE_PREFIX,
-      author,
-      owner: author,
-      content: null
-    },
-    templateId
-  )
-
-  await ops.createMixin(templateId, documents.class.Document, space, _mixin, {
-    sequence: 0,
-    docPrefix: prefix
-  })
-
   const success = await ops.commit()
 
-  return { seqNumber, success: success.result }
+  return { success: success.result, seqNumber, code, documentMetaId, projectDocumentId }
 }

--- a/plugins/controlled-documents/src/plugin.ts
+++ b/plugins/controlled-documents/src/plugin.ts
@@ -6,7 +6,8 @@ import {
   type Type,
   type Space,
   type SpaceTypeDescriptor,
-  type Permission
+  type Permission,
+  Role
 } from '@hcengineering/core'
 import type { Asset, Plugin, Resource } from '@hcengineering/platform'
 import { IntlString, plugin } from '@hcengineering/platform'
@@ -275,6 +276,11 @@ export const documentsPlugin = plugin(documentsId, {
     CM: '' as Ref<DocumentCategory>,
     CA: '' as Ref<DocumentCategory>,
     CC: '' as Ref<DocumentCategory>
+  },
+  role: {
+    QARA: '' as Ref<Role>,
+    Manager: '' as Ref<Role>,
+    QualifiedUser: '' as Ref<Role>
   },
   resolver: {
     Location: '' as Resource<(loc: Location) => Promise<ResolvedLocation | undefined>>


### PR DESCRIPTION
## Features

* Added new document types:
  * QMS Document Spaces (OrgSpace)
  * Controlled Document Templates
  * Controlled Documents based on templates
* Added support for QMS-specific roles and permissions
* Added validation for QMS document hierarchy and references
* Document Code is parsed out from the file name
* If the code is not specified, it will be generated automativally from template docPrefix

## Limitations

* Controlled documents must be created in the same space as their templates
* Controlled documents can be imported only with `Draft` status
* All users must exist in the system before import
* Versioning is not supported

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzZhYjMwMmMyOWE3OGFmZmY2NmYyZmYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.lwlMVL4FnzxEsyQVbY7iY3Dnj6ez411qFQZBgHp7opY">Huly&reg;: <b>UBERF-9009</b></a></sub>