### PR TITLE
Fixed indent behaviour with a single empty line

### DIFF
--- a/plugins/text-editor-resources/src/components/extension/indent.ts
+++ b/plugins/text-editor-resources/src/components/extension/indent.ts
@@ -125,7 +125,7 @@ export function adjustSelectionIndent (
   let insertionOffset = 0
 
   for (const range of ranges) {
-    if (direction > 0 ? range.text === '' : range.indent === 0) {
+    if (direction > 0 ? (range.text === '' && ranges.length > 1) : range.indent === 0) {
       continue
     }
     const indentOffset = indentLevelOffset(range.indent, direction)

--- a/plugins/text-editor-resources/src/components/extension/indent.ts
+++ b/plugins/text-editor-resources/src/components/extension/indent.ts
@@ -125,7 +125,7 @@ export function adjustSelectionIndent (
   let insertionOffset = 0
 
   for (const range of ranges) {
-    if (direction > 0 ? (range.text === '' && ranges.length > 1) : range.indent === 0) {
+    if (direction > 0 ? range.text === '' && ranges.length > 1 : range.indent === 0) {
       continue
     }
     const indentOffset = indentLevelOffset(range.indent, direction)


### PR DESCRIPTION
Fixed indent behaviour with a single empty line

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzZiZmExMTUzZGExNmZlYjk2NWI1ZGMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.Ly8X7Yjgv26LIJk_x3JAIny058RxBEWaQLEmXcC3WPo">Huly&reg;: <b>UBERF-9022</b></a></sub>