### PR TITLE
Use the second day to protect the date popup against the effects of time  zone changes

### DIFF
--- a/packages/ui/src/components/calendar/DatePopup.svelte
+++ b/packages/ui/src/components/calendar/DatePopup.svelte
@@ -86,7 +86,9 @@
     }
   }
   const changeMonth = (date: Date): Date => {
-    return new Date(date.getFullYear(), date.getMonth() + 1, 1)
+    // We should use the second day to protect the result of the month-shifted against the effects of time zone changes.
+    const secondDay = 2
+    return new Date(date.getFullYear(), date.getMonth() + 1, secondDay)
   }
 
   $: if (viewDate) viewDateSec = changeMonth(viewDate)


### PR DESCRIPTION
Test case:

1. open tracker
2. change the time zone with a negative offset.
3. as a result all calendars with two months show the same months.

It can happen with travelers.

<img width="562" src="https://github.com/user-attachments/assets/2864d460-cb78-4132-bd70-7192f3d6c1c4" alt="Screenshot 2024-12-26 at 9 33 09 PM">

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzZkZGRjNTRlMGExYTljMzdlZmRhYTkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.0Bj8aI-H-1lC7-bkELuFcHcoJFOqwzcJDttLNzDYh3Y">Huly&reg;: <b>UBERF-9038</b></a></sub>