### PR TITLE
Ability to move task statuses between categories

### DIFF
--- a/packages/importer/src/importer/importer.ts
+++ b/packages/importer/src/importer/importer.ts
@@ -229,7 +229,13 @@ export class WorkspaceImporter {
           kind: 'both',
           name: taskType.name,
           ofClass: tracker.class.Issue,
-          statusCategories: [task.statusCategory.Active],
+          statusCategories: [
+            task.statusCategory.UnStarted,
+            task.statusCategory.ToDo,
+            task.statusCategory.Active,
+            task.statusCategory.Won,
+            task.statusCategory.Lost
+          ],
           statusClass: tracker.class.IssueStatus,
           icon: tracker.icon.Issue,
           color: 0,

--- a/plugins/task-resources/src/components/taskTypes/TaskTypeEditor.svelte
+++ b/plugins/task-resources/src/components/taskTypes/TaskTypeEditor.svelte
@@ -237,6 +237,15 @@
                 const index = taskType.statuses.findIndex((p) => p === evt.detail.stateID)
                 const state = taskType.statuses.splice(index, 1)[0]
 
+                if (evt.detail.newCategory !== undefined) {
+                  const stateDoc = $statusStore.byId.get(evt.detail.stateID)
+                  if (stateDoc !== undefined) {
+                    await client.update(stateDoc, {
+                      category: evt.detail.newCategory
+                    })
+                  }
+                }
+
                 const statuses = [
                   ...taskType.statuses.slice(0, evt.detail.position),
                   state,


### PR DESCRIPTION
* Add default task status categories for tasks imported from ClickUp
* Ability to move task statuses between categories

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzZlNmFkZjRlMGExYTljMzdlZmRjNTciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.wlBumyP1QD_5LqB_gkVmwHjsz_zmprkivBn9TPWgXZg">Huly&reg;: <b>UBERF-9040</b></a></sub>