### PR TITLE
UBERF-8899: Fix Reconnect performance

### DIFF
--- a/packages/core/src/tx.ts
+++ b/packages/core/src/tx.ts
@@ -51,7 +51,8 @@ export enum WorkspaceEvent {
   IndexingUpdate,
   SecurityChange,
   MaintenanceNotification,
-  BulkUpdate
+  BulkUpdate,
+  LastTx
 }
 
 /**

--- a/packages/ui/src/components/DropdownLabels.svelte
+++ b/packages/ui/src/components/DropdownLabels.svelte
@@ -50,9 +50,11 @@
   let container: HTMLElement
   let opened: boolean = false
 
-  $: selectedItem = multiselect ? items.filter((p) => selected?.includes(p.id)) : items.find((x) => x.id === selected)
-  $: if (autoSelect && selected === undefined && items[0] !== undefined) {
-    selected = multiselect ? [items[0].id] : items[0].id
+  $: selectedItem = multiselect
+    ? (items ?? []).filter((p) => selected?.includes(p.id))
+    : (items ?? []).find((x) => x.id === selected)
+  $: if (autoSelect && selected === undefined && items?.[0] !== undefined) {
+    selected = multiselect ? [items?.[0]?.id] : items?.[0]?.id
   }
 
   const dispatch = createEventDispatcher()
@@ -111,7 +113,7 @@
         <slot name="content" />
       {:else if Array.isArray(selectedItem)}
         {#if selectedItem.length > 0}
-          {#each selectedItem as seleceted, i}
+          {#each selectedItem as seleceted}
             <span class="step-row">{seleceted.label}</span>
           {/each}
         {:else}

--- a/plugins/client-resources/src/index.ts
+++ b/plugins/client-resources/src/index.ts
@@ -118,10 +118,10 @@ export default async () => {
                   reject(new Error(`Connection timeout, and no connection established to ${endpoint}`))
                 }
               }, connectTimeout)
-              newOpt.onConnect = async (event, data) => {
+              newOpt.onConnect = async (event, lastTx, data) => {
                 // Any event is fine, it means server is alive.
                 clearTimeout(connectTO)
-                await opt?.onConnect?.(event, data)
+                await opt?.onConnect?.(event, lastTx, data)
                 resolve()
               }
             })

--- a/plugins/client/src/index.ts
+++ b/plugins/client/src/index.ts
@@ -62,7 +62,7 @@ export interface ClientFactoryOptions {
   onUpgrade?: () => void
   onUnauthorized?: () => void
   onArchived?: () => void
-  onConnect?: (event: ClientConnectEvent, data: any) => Promise<void>
+  onConnect?: (event: ClientConnectEvent, lastTx: string | undefined, data: any) => Promise<void>
   ctx?: MeasureContext
   onDialTimeout?: () => void | Promise<void>
 }

--- a/plugins/recruit-resources/src/components/VacancyPresenter.svelte
+++ b/plugins/recruit-resources/src/components/VacancyPresenter.svelte
@@ -31,7 +31,7 @@
   export let type: ObjectPresenterType = 'link'
 
   const dispatch = createEventDispatcher()
-  $: accentColor = getPlatformAvatarColorForTextDef(value.name, $themeStore.dark)
+  $: accentColor = getPlatformAvatarColorForTextDef(value?.name ?? '', $themeStore.dark)
 
   $: dispatch('accent-color', accentColor)
   onMount(() => {

--- a/server/core/src/types.ts
+++ b/server/core/src/types.ts
@@ -162,6 +162,11 @@ export interface DBAdapterManager {
 
 export interface PipelineContext {
   workspace: WorkspaceIdWithUrl
+
+  lastTx?: string
+
+  lastHash?: string
+
   hierarchy: Hierarchy
   modelDb: ModelDb
   branding: Branding | null

--- a/server/middleware/src/model.ts
+++ b/server/middleware/src/model.ts
@@ -115,6 +115,7 @@ export class ModelMiddleware extends BaseMiddleware implements Middleware {
 
   private setLastHash (hash: string): void {
     this.lastHash = hash
+    this.context.lastHash = this.lastHash
     this.lastHashResponse = Promise.resolve({
       full: false,
       hash,

--- a/server/middleware/src/txPush.ts
+++ b/server/middleware/src/txPush.ts
@@ -16,12 +16,16 @@
 import core, {
   DOMAIN_TRANSIENT,
   DOMAIN_TX,
+  generateId,
   TxProcessor,
+  WorkspaceEvent,
   type Doc,
   type MeasureContext,
+  type SessionData,
   type Tx,
   type TxCUD,
-  type TxResult
+  type TxResult,
+  type TxWorkspaceEvent
 } from '@hcengineering/core'
 import { PlatformError, unknownError } from '@hcengineering/platform'
 import type { DBAdapterManager, Middleware, PipelineContext, TxMiddlewareResult } from '@hcengineering/server-core'
@@ -68,6 +72,22 @@ export class TxMiddleware extends BaseMiddleware implements Middleware {
           txes: Array.from(new Set(txToStore.map((it) => it._class)))
         }
       )
+      // We need to remember last Tx Id in context, so it will be used during reconnect to track a requirement for refresh.
+      this.context.lastTx = txToStore[txToStore.length - 1]._id
+      // We need to deliver information to all clients so far.
+      const evt: TxWorkspaceEvent = {
+        _class: core.class.TxWorkspaceEvent,
+        _id: generateId(),
+        event: WorkspaceEvent.LastTx,
+        modifiedBy: core.account.System,
+        modifiedOn: Date.now(),
+        objectSpace: core.space.DerivedTx,
+        space: core.space.DerivedTx,
+        params: {
+          lastTx: this.context.lastTx
+        }
+      }
+      ;(ctx.contextData as SessionData).broadcast.txes.push(evt)
     }
     if (txPromise !== undefined) {
       await txPromise

--- a/server/rpc/src/rpc.ts
+++ b/server/rpc/src/rpc.ts
@@ -46,6 +46,8 @@ export interface HelloResponse extends Response<any> {
   binary: boolean
   reconnect?: boolean
   serverVersion: string
+  lastTx?: string
+  lastHash?: string // Last model hash
 }
 
 function replacer (key: string, value: any): any {


### PR DESCRIPTION
UBERF-8899: Fix Reconnect performance

1. Remember last essential txId as lastTx and resend it to any connected client,
2. On reconnect receive lastTx and refresh only if have some changes.

<sub><a href="https://front.hc.engineering/guest/platform?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzdkMmEyNjVkMWU2NjljYmJjMzVhZDEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InBsYXRmb3JtIn0.MGkoFWChZvYi3U2H3U0roQvrOY2l7m8Fc1FYUJ8S_fQ">Huly&reg;: <b>UBERF-9067</b></a></sub>