### PR TITLE
qfix: UI/UX do not use intalic for blockquotes

### DIFF
--- a/packages/theme/styles/prose.scss
+++ b/packages/theme/styles/prose.scss
@@ -1,5 +1,5 @@
 //
-// Copyright © 2022, 2023 Hardcore Engineering Inc.
+// Copyright © 2022, 2023, 2025 Hardcore Engineering Inc.
 //
 // Licensed under the Eclipse Public License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License. You may
@@ -372,9 +372,7 @@ table.proseTable {
   margin-inline: 1px 0;
   padding-left: 1.5em;
   padding-right: 1.5em;
-  font-style: italic;
   position: relative;
-
   border-left: 3px solid var(--theme-text-primary-color);
 }
 


### PR DESCRIPTION
## Motvation

Italics should not be used in blockquotes because we lose the original style of blockquoted text. Other chat services also don't do it on block quoting.