### PR TITLE
qfiX:  correctly handle edge case with Link extension

### DIFF
--- a/packages/text/src/kits/default-kit.ts
+++ b/packages/text/src/kits/default-kit.ts
@@ -55,7 +55,7 @@ export const DefaultKit = Extension.create<DefaultKitOptions>({
         multicolor: false
       }),
       Typography.configure({}),
-      Link.configure({
+      Link.extend({ inclusive: false }).configure({
         openOnClick: true,
         HTMLAttributes: { class: 'cursor-pointer', rel: 'noopener noreferrer', target: '_blank' }
       })

--- a/plugins/text-editor-resources/src/kits/default-kit.ts
+++ b/plugins/text-editor-resources/src/kits/default-kit.ts
@@ -1,5 +1,5 @@
 //
-// Copyright © 2023, 2024 Hardcore Engineering Inc.
+// Copyright © 2023, 2024, 2025 Hardcore Engineering Inc.
 //
 // Licensed under the Eclipse Public License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License. You may
@@ -61,7 +61,7 @@ export const DefaultKit = Extension.create<DefaultKitOptions>({
         multicolor: false
       }),
       Typography.configure({}),
-      Link.configure({
+      Link.extend({ inclusive: false }).configure({
         openOnClick: true,
         HTMLAttributes: { class: 'cursor-pointer', rel: 'noopener noreferrer', target: '_blank' }
       }),


### PR DESCRIPTION
## Motivation

Steps:

1. type a link in the editor, eg youtube.com
2. delete all text
3. add a new text

Actual: text has a link from the step1

This pr fixes the issue

See more details https://github.com/ueberdosis/tiptap/issues/2571