### PR TITLE
EZQMS-1400: Forbid creation of templates in technical documentation

### DIFF
--- a/plugins/controlled-documents-resources/src/utils.ts
+++ b/plugins/controlled-documents-resources/src/utils.ts
@@ -423,10 +423,16 @@ export async function canCreateChildTemplate (
   }
 
   const client = getClient()
-  const spaceId: Ref<DocumentSpace> = isSpace(client.getHierarchy(), doc) ? doc._id : doc.space
-  const orgSpace = await client.findOne(documents.class.OrgSpace, { _id: spaceId })
+  const hierarchy = client.getHierarchy()
+  const spaceId: Ref<DocumentSpace> = isSpace(hierarchy, doc) ? doc._id : doc.space
+  const orgSpace = await client.findOne(documents.class.DocumentSpace, { _id: spaceId })
 
-  return orgSpace !== undefined && (await checkPermission(client, documents.permission.CreateDocument, spaceId))
+  if (orgSpace === undefined) return false
+
+  const isExternalSpace = hierarchy.isDerived(orgSpace._class, documents.class.ExternalSpace)
+  const canCreateDocuments = await checkPermission(client, documents.permission.CreateDocument, spaceId)
+
+  return !isExternalSpace && canCreateDocuments
 }
 
 export async function canCreateChildDocument (


### PR DESCRIPTION
The source of the problem is in a bug in query execution, so it has to be bypassed for now.