### PR TITLE
Fixed validation of class inheritance in queries

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -156,7 +156,8 @@ export function matchQuery<T extends Doc> (
   hierarchy: Hierarchy,
   skipLookup: boolean = false
 ): Doc[] {
-  let result = docs
+  const baseClass = hierarchy.getBaseClass(clazz)
+  let result = docs.filter((r) => hierarchy.isDerived(r._class, baseClass))
   for (const key in query) {
     if (skipLookup && key.startsWith('$lookup.')) {
       continue

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -158,6 +158,9 @@ export function matchQuery<T extends Doc> (
 ): Doc[] {
   const baseClass = hierarchy.getBaseClass(clazz)
   let result = docs.filter((r) => hierarchy.isDerived(r._class, baseClass))
+  if (baseClass !== clazz) {
+    result = docs.filter((r) => hierarchy.hasMixin(r, clazz))
+  }
   for (const key in query) {
     if (skipLookup && key.startsWith('$lookup.')) {
       continue


### PR DESCRIPTION
The original source of the problem is [here](https://github.com/hcengineering/platform/blob/0958c241cdbc43a2972b3f3c84dac7ab3fb4c6fb/server/mongo/src/storage.ts#L930), but we should probably do the check in the matchQuery itself