### PR TITLE
UBERF-9263: Make reactions tooltip reactive

### DIFF
--- a/packages/ui/src/tooltips.ts
+++ b/packages/ui/src/tooltips.ts
@@ -20,7 +20,7 @@ export const tooltipstore = derived(modalStore, (modals) => {
     return emptyTooltip
   }
   const tooltip = modals.filter((m) => m?.type === 'tooltip')
-  return tooltip.length > 0 ? (tooltip[0] as LabelAndProps) : emptyTooltip
+  return tooltip.length > 0 ? (tooltip[tooltip.length - 1] as LabelAndProps) : emptyTooltip
 })
 
 let toHandler: any
@@ -94,6 +94,7 @@ export function tooltip (node: HTMLElement, options?: LabelAndProps): any {
     destroy () {
       node.removeEventListener('mousemove', show)
       node.removeEventListener('mouseleave', hide)
+      closeTooltip()
     }
   }
 }

--- a/packages/ui/src/tooltips.ts
+++ b/packages/ui/src/tooltips.ts
@@ -1,5 +1,5 @@
 import { type IntlString } from '@hcengineering/platform'
-import { derived } from 'svelte/store'
+import { derived, get } from 'svelte/store'
 import type { AnyComponent, AnySvelteComponent, LabelAndProps, TooltipAlignment } from './types'
 import { modalStore } from './modals'
 
@@ -92,9 +92,12 @@ export function tooltip (node: HTMLElement, options?: LabelAndProps): any {
     },
 
     destroy () {
+      const currentTooltip = get(tooltipstore)
+      if (currentTooltip?.element != null && currentTooltip.element === node) {
+        closeTooltip()
+      }
       node.removeEventListener('mousemove', show)
       node.removeEventListener('mouseleave', hide)
-      closeTooltip()
     }
   }
 }
@@ -118,7 +121,7 @@ export function showTooltip (
     props,
     anchor,
     onUpdate,
-    kind: kind ?? 'tooltip',
+    kind,
     keys,
     type: 'tooltip'
   }
@@ -128,10 +131,12 @@ export function showTooltip (
       if (tooltip.kind !== undefined && storedValue.kind === undefined) {
         storedValue.kind = tooltip.kind
       }
-      if (storedValue.kind === undefined) {
-        storedValue.kind = 'tooltip'
-      }
     }
+
+    if (storedValue.kind == null) {
+      storedValue.kind = 'tooltip'
+    }
+
     old.push(storedValue)
     return old
   })


### PR DESCRIPTION
- Update users tooltip immediately when click on reaction
- Close tooltip when parent element destriyed

https://github.com/user-attachments/assets/1efa335f-93d5-402c-b471-f42240c75363