### PR TITLE
UBERF-9353 Fix markup to ydoc conversion

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -257,6 +257,7 @@
         "MINIO_SECRET_KEY": "minioadmin",
         "MINIO_ENDPOINT": "localhost"
       },
+      "runtimeVersion": "20",
       "runtimeArgs": ["--nolazy", "-r", "ts-node/register"],
       "sourceMaps": true,
       "cwd": "${workspaceRoot}/pods/collaborator",

--- a/packages/text-ydoc/src/__tests__/ydoc.test.ts
+++ b/packages/text-ydoc/src/__tests__/ydoc.test.ts
@@ -14,7 +14,8 @@
 //
 
 import { Markup } from '@hcengineering/core'
-import { markupToYDoc, markupToYDocNoSchema, yDocToMarkup } from '../ydoc'
+import { markupToJSON } from '@hcengineering/text'
+import { jsonToYDocNoSchema, markupToYDoc, markupToYDocNoSchema, yDocToMarkup } from '../ydoc'
 
 describe('ydoc', () => {
   const markups: Markup[] = [
@@ -58,6 +59,16 @@ describe('ydoc', () => {
       const back = yDocToMarkup(ydoc, 'test')
 
       expect(JSON.parse(back)).toEqual(JSON.parse(markup))
+    })
+  })
+
+  describe.each(markups)('jsonToYDocNoSchema', (markup) => {
+    it('converts json to ydoc', () => {
+      const json = markupToJSON(markup)
+      const ydoc1 = jsonToYDocNoSchema(json, 'test')
+      const ydoc2 = markupToYDoc(markup, 'test')
+
+      expect(ydoc1.getXmlFragment('test').toJSON()).toEqual(ydoc2.getXmlFragment('test').toJSON())
     })
   })
 })


### PR DESCRIPTION
This PR fixes the following warning that is printed to console when converting markup to ydoc:

```
Invalid access: Add Yjs type to a document before reading data.
```

Warning happens when attempting access methods of elements that have not been attached to an ydoc:
https://github.com/yjs/yjs/blob/4b865764b850669732a790c605d6178ee6b21e22/src/types/YXmlFragment.js#L182