### PR TITLE
UBERF-9362 Improve collaborator error handling when saving doc

### DIFF
--- a/server/client/src/account.ts
+++ b/server/client/src/account.ts
@@ -109,6 +109,9 @@ export async function getTransactorEndpoint (
           })
         })
       ).json()
+      if (workspaceInfo.result === undefined) {
+        throw new Error('Workspace not found')
+      }
       return workspaceInfo.result.endpoint
     } catch (err: any) {
       if (timeout > 0 && st + timeout < Date.now()) {


### PR DESCRIPTION
1. Explicitly indicate that workspace was not found when fetching endpoint info
2. Create platform client only after ydoc is saved to ensure we do not lost changes