### PR TITLE
Fix workspace creation after fresh start

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,10 @@ Before you can begin, you need to create a workspace and an account and associat
 
 ```bash
 cd ./tool # dev/tool in the repository root
-rushx run-local create-workspace ws1 -w DevWorkspace # Create workspace
 rushx run-local create-account user1 -p 1234 -f John -l Appleseed # Create account
+rushx run-local create-workspace ws1 email:user1 -b DevWorkspace # Create workspace
 rushx run-local configure ws1 --list --enable '*' # Enable all modules, even if they are not yet intended to be used by a wide audience.
 rushx run-local assign-workspace user1 ws1 # Assign workspace to user.
-rushx run-local confirm-email user1 # To allow the creation of additional test workspaces.
-
 ```
 
 Alternatively, you can just execute:

--- a/scripts/create-workspace.sh
+++ b/scripts/create-workspace.sh
@@ -1,6 +1,5 @@
 cd ./dev/tool
-rushx run-local create-workspace ws1 -w DevWorkspace # Create workspace
 rushx run-local create-account user1 -p 1234 -f John -l Appleseed # Create account
+rushx run-local create-workspace ws1 -b DevWorkspace # Create workspace
 rushx run-local configure ws1 --list --enable '*' # Enable all modules, even if they are not yet intended to be used by a wide audience.
 rushx run-local assign-workspace user1 ws1 # Assign workspace to user.
-rushx run-local confirm-email user1 # To allow the creation of additional test workspaces.


### PR DESCRIPTION
Can't start project after fresh start.

Steps to reproduce:

```sh
cd ./dev
docker compose down --volumes
cd ../
./scripts/fast-start.sh
```

Error 1 - cmd `create-workspace` fails:

```
$ rushx run-local create-workspace ws1 -w DevWorkspace
Found configuration in /Users/agalitsyn/src/github.com/hcengineering/platform/rush.json

Rush Multi-Project Build Tool 5.148.0 - Node.js 20.18.2 (LTS)
> "rush bundle --to @hcengineering/tool >/dev/null && cross-env SERVER_SECRET=secret FULLTEXT_URL=http://localhost:4700 ACCOUNTS_URL=http://localhost:3000 TRANSACTOR_URL=ws://localhost:3333 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin MINIO_ENDPOINT=localhost ACCOUNT_DB_URL=mongodb://localhost:27017 DB_URL=mongodb://localhost:27017 TELEGRAM_DATABASE=telegram-service REKONI_URL=http://localhost:4004 MODEL_VERSION=$(node ../../common/scripts/show_version.js) GIT_REVISION=$(git describe --all --long) node --expose-gc --max-old-space-size=18000 ./bundle/bundle.js create-workspace ws1 -w DevWorkspace"

error: unknown option '-w'
Error: Failed calling rush bundle --to @hcengineering/tool >/dev/null && cross-env SERVER_SECRET=secret FULLTEXT_URL=http://localhost:4700 ACCOUNTS_URL=http://localhost:3000 TRANSACTOR_URL=ws://localhost:3333 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin MINIO_ENDPOINT=localhost ACCOUNT_DB_URL=mongodb://localhost:27017 DB_URL=mongodb://localhost:27017 TELEGRAM_DATABASE=telegram-service REKONI_URL=http://localhost:4004 MODEL_VERSION=$(node ../../common/scripts/show_version.js) GIT_REVISION=$(git describe --all --long) node --expose-gc --max-old-space-size=18000 ./bundle/bundle.js create-workspace ws1 -w DevWorkspace.  Exit code: 1
```

Error 2 - cmd `confirm-email` not found

```
$ rushx run-local confirm-email user1 
Found configuration in /Users/agalitsyn/src/github.com/hcengineering/platform/rush.json

Rush Multi-Project Build Tool 5.148.0 - Node.js 20.18.2 (LTS)
> "rush bundle --to @hcengineering/tool >/dev/null && cross-env SERVER_SECRET=secret FULLTEXT_URL=http://localhost:4700 ACCOUNTS_URL=http://localhost:3000 TRANSACTOR_URL=ws://localhost:3333 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin MINIO_ENDPOINT=localhost ACCOUNT_DB_URL=mongodb://localhost:27017 DB_URL=mongodb://localhost:27017 TELEGRAM_DATABASE=telegram-service REKONI_URL=http://localhost:4004 MODEL_VERSION=$(node ../../common/scripts/show_version.js) GIT_REVISION=$(git describe --all --long) node --expose-gc --max-old-space-size=18000 ./bundle/bundle.js confirm-email user1"

error: unknown command 'confirm-email'
Error: Failed calling rush bundle --to @hcengineering/tool >/dev/null && cross-env SERVER_SECRET=secret FULLTEXT_URL=http://localhost:4700 ACCOUNTS_URL=http://localhost:3000 TRANSACTOR_URL=ws://localhost:3333 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin MINIO_ENDPOINT=localhost ACCOUNT_DB_URL=mongodb://localhost:27017 DB_URL=mongodb://localhost:27017 TELEGRAM_DATABASE=telegram-service REKONI_URL=http://localhost:4004 MODEL_VERSION=$(node ../../common/scripts/show_version.js) GIT_REVISION=$(git describe --all --long) node --expose-gc --max-old-space-size=18000 ./bundle/bundle.js confirm-email user1.  Exit code: 1
```

Seems that it was broken in https://github.com/hcengineering/platform/pull/7573