### PR TITLE
qfix: Correctly display long strings

### DIFF
--- a/plugins/attachment-resources/src/components/LinkPreviewPresenter.svelte
+++ b/plugins/attachment-resources/src/components/LinkPreviewPresenter.svelte
@@ -155,6 +155,7 @@
   }
   .description {
     color: var(--theme-link-preview-description-color);
+    overflow: hidden;
   }
   .content span {
     display: none;


### PR DESCRIPTION
## Motivation

Fixes:
![image](https://github.com/user-attachments/assets/68044262-3e84-42da-8d6b-e6fb36c11a60)