### PR TITLE
EQMS-1430: Fixed infinite loop in Channellnput

### DIFF
--- a/plugins/activity-resources/src/components/Activity.svelte
+++ b/plugins/activity-resources/src/components/Activity.svelte
@@ -181,7 +181,7 @@
         if (res.length > 0) {
           return res
         }
-        clazz = hierarchy.getClass(_class).extends
+        clazz = hierarchy.getClass(clazz).extends
       }
     } catch (e) {
       console.error(e)

--- a/plugins/chunter-resources/src/components/ChannelInput.svelte
+++ b/plugins/chunter-resources/src/components/ChannelInput.svelte
@@ -45,7 +45,7 @@
         if (res.length > 0) {
           return res
         }
-        clazz = hierarchy.getClass(_class).extends
+        clazz = hierarchy.getClass(clazz).extends
       }
     } catch (e) {
       console.error(e)


### PR DESCRIPTION
At the moment, an attempt to open the Controlled Document channel in Chunter causes the page to freeze. And since the website always tries to load the earlier location, it's impossible to get back into the workspace without clearing the cache.