### PR TITLE
fix: handle token decode errors

### DIFF
--- a/server/account/src/utils.ts
+++ b/server/account/src/utils.ts
@@ -56,7 +56,7 @@ import {
   AccountEventType
 } from './types'
 import { Analytics } from '@hcengineering/analytics'
-import { decodeTokenVerbose, generateToken } from '@hcengineering/server-token'
+import { TokenError, decodeTokenVerbose, generateToken } from '@hcengineering/server-token'
 
 export const GUEST_ACCOUNT = 'b6996120-416f-49cd-841e-e4a5d2e49c9b'
 
@@ -127,7 +127,7 @@ export function wrap (
             ? err.status
             : new Status(Severity.ERROR, platform.status.InternalServerError, {})
 
-        if (((err.message as string) ?? '') === 'Signature verification failed') {
+        if (err instanceof TokenError) {
           // Let's send un authorized
           return {
             error: new Status(Severity.ERROR, platform.status.Unauthorized, {})

--- a/server/front/src/index.ts
+++ b/server/front/src/index.ts
@@ -23,7 +23,7 @@ import {
   metricsAggregate,
   type Ref
 } from '@hcengineering/core'
-import { decodeToken } from '@hcengineering/server-token'
+import { TokenError, decodeToken } from '@hcengineering/server-token'
 import { StorageAdapter } from '@hcengineering/storage'
 import bp from 'body-parser'
 import cors from 'cors'
@@ -376,10 +376,13 @@ export function start (
       })
       res.end(json)
     } catch (err: any) {
+      if (err instanceof TokenError) {
+        res.status(401).send()
+        return
+      }
       ctx.error('statistics error', { err })
       Analytics.handleError(err)
-      res.writeHead(404, {})
-      res.end()
+      res.status(404).send()
     }
   })
 

--- a/server/token/src/token.ts
+++ b/server/token/src/token.ts
@@ -12,6 +12,16 @@ export interface Token {
   extra?: Record<string, any>
 }
 
+/**
+ * @public
+ */
+export class TokenError extends Error {
+  constructor (message: string) {
+    super(message)
+    this.name = 'TokenError'
+  }
+}
+
 const getSecret = (): string => {
   return getMetadata(serverPlugin.metadata.Secret) ?? 'secret'
 }
@@ -50,6 +60,6 @@ export function decodeTokenVerbose (ctx: MeasureContext, token: string): Token {
     } catch (err2: any) {
       // Nothing to do
     }
-    throw err
+    throw new TokenError(err.message)
   }
 }


### PR DESCRIPTION
Handle token errors to prevent them from appearing in sentry logs