### PR TITLE
fix: do not display empty link preview in case of file error

### DIFF
--- a/packages/presentation/src/file.ts
+++ b/packages/presentation/src/file.ts
@@ -289,12 +289,12 @@ async function uploadFileWithSignedUrl (file: File, uuid: string, uploadUrl: str
   }
 }
 
-export async function getJsonOrEmpty (file: string, name: string): Promise<any> {
+export async function getJsonOrEmpty<T> (file: string, name: string): Promise<T | undefined> {
   try {
     const fileUrl = getFileUrl(file, name)
     const resp = await fetch(fileUrl)
-    return await resp.json()
+    return await resp.json() as T
   } catch {
-    return {}
+    return undefined
   }
 }

--- a/packages/presentation/src/file.ts
+++ b/packages/presentation/src/file.ts
@@ -289,11 +289,11 @@ async function uploadFileWithSignedUrl (file: File, uuid: string, uploadUrl: str
   }
 }
 
-export async function getJsonOrEmpty<T> (file: string, name: string): Promise<T | undefined> {
+export async function getJsonOrEmpty<T = any> (file: string, name: string): Promise<T | undefined> {
   try {
     const fileUrl = getFileUrl(file, name)
     const resp = await fetch(fileUrl)
-    return await resp.json() as T
+    return (await resp.json()) as T
   } catch {
     return undefined
   }

--- a/plugins/attachment-resources/src/components/AttachmentPresenter.svelte
+++ b/plugins/attachment-resources/src/components/AttachmentPresenter.svelte
@@ -123,45 +123,49 @@
         {#await getJsonOrEmpty(value.file, value.name)}
           <Spinner size="small" />
         {:then linkPreviewDetails}
-          <div class="flex-center icon image">
-            {#if linkPreviewDetails.icon !== undefined && !useDefaultIcon}
-              <img
-                src={linkPreviewDetails.icon}
-                class="link-preview-icon"
-                alt="link-preview"
-                on:error={() => {
-                  useDefaultIcon = true
-                }}
-              />
-            {:else}
-              <WebIcon size="medium" />
-            {/if}
-          </div>
-          <div class="flex-col info-container">
-            <div class="name">
-              <a target="_blank" class="no-line" style:flex-shrink={0} href={linkPreviewDetails.url}
-                >{trimFilename(linkPreviewDetails?.title ?? value.name)}</a
-              >
-            </div>
-            <div class="info-content flex-row-center">
-              <span class="actions inline-flex clear-mins gap-1">
-                {#if linkPreviewDetails.description}
-                  {trimFilename(linkPreviewDetails.description)}
-                  <span>•</span>
-                {/if}
-                <span
-                  class="remove-link"
-                  on:click={(ev) => {
-                    ev.stopPropagation()
-                    ev.preventDefault()
-                    dispatch('remove', value)
+          {#if linkPreviewDetails !== undefined}
+            <div class="flex-center icon image">
+              {#if linkPreviewDetails.icon !== undefined && !useDefaultIcon}
+                <img
+                  src={linkPreviewDetails.icon}
+                  class="link-preview-icon"
+                  alt="link-preview"
+                  on:error={() => {
+                    useDefaultIcon = true
                   }}
-                >
-                  <Label label={presentation.string.Delete} />
-                </span>
-              </span>
+                />
+              {:else}
+                <WebIcon size="medium" />
+              {/if}
             </div>
-          </div>
+            <div class="flex-col info-container">
+              <div class="name">
+                <a target="_blank" class="no-line" style:flex-shrink={0} href={linkPreviewDetails.url}
+                  >{trimFilename(linkPreviewDetails?.title ?? value.name)}</a
+                >
+              </div>
+              <div class="info-content flex-row-center">
+                <span class="actions inline-flex clear-mins gap-1">
+                  {#if linkPreviewDetails.description}
+                    {trimFilename(linkPreviewDetails.description)}
+                    <span>•</span>
+                  {/if}
+                  <!-- svelte-ignore a11y-click-events-have-key-events -->
+                  <!-- svelte-ignore a11y-no-static-element-interactions -->
+                  <span
+                    class="remove-link"
+                    on:click={(ev) => {
+                      ev.stopPropagation()
+                      ev.preventDefault()
+                      dispatch('remove', value)
+                    }}
+                  >
+                    <Label label={presentation.string.Delete} />
+                  </span>
+                </span>
+              </div>
+            </div>
+          {/if}
         {/await}
       {:else}
         {#await getBlobRef(value.file, value.name, sizeToWidth('large')) then valueRef}

--- a/plugins/attachment-resources/src/components/LinkPreviewPresenter.svelte
+++ b/plugins/attachment-resources/src/components/LinkPreviewPresenter.svelte
@@ -26,7 +26,7 @@
 
   let useDefaultIcon = false
   let retryCount = 0
-  let viewModel: LinkPreviewDetails
+  let viewModel: LinkPreviewDetails | undefined
   let previewImageSrc: string | undefined
 
   function refreshPreviewImage (): void {
@@ -53,12 +53,13 @@
     )
   }
   onMount(() => {
-    void getJsonOrEmpty(attachment.file, attachment.name)
+    void getJsonOrEmpty<LinkPreviewDetails>(attachment.file, attachment.name)
       .then((res) => {
-        viewModel = res as LinkPreviewDetails
+        viewModel = res
         refreshPreviewImage()
       })
       .catch((err) => {
+        viewModel = undefined
         console.error(err)
       })
   })


### PR DESCRIPTION
Currently in case of file access error the link preview shows "undefined" text. This fix hides the preview at all.