### PR TITLE
UBERF-9451: Drop old tokens from local storage

### DIFF
--- a/desktop/src/ui/index.ts
+++ b/desktop/src/ui/index.ts
@@ -58,12 +58,12 @@ window.addEventListener('DOMContentLoaded', () => {
   })
 
   ipcMain.on('logout', () => {
-    const tokens = fetchMetadataLocalStorage(login.metadata.LoginTokens)
+    const tokens = fetchMetadataLocalStorage(login.metadata.LoginTokensV2)
     if (tokens !== null) {
       const loc = getCurrentLocation()
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete tokens[loc.path[1]]
-      setMetadataLocalStorage(login.metadata.LoginTokens, tokens)
+      setMetadataLocalStorage(login.metadata.LoginTokensV2, tokens)
     }
     setMetadata(presentation.metadata.Token, null)
     setMetadataLocalStorage(login.metadata.LastToken, null)

--- a/plugins/guest-resources/src/connect.ts
+++ b/plugins/guest-resources/src/connect.ts
@@ -242,12 +242,12 @@ export async function connect (title: string): Promise<Client | undefined> {
 }
 
 function clearMetadata (ws: string): void {
-  const tokens = fetchMetadataLocalStorage(login.metadata.LoginTokens)
+  const tokens = fetchMetadataLocalStorage(login.metadata.LoginTokensV2)
   if (tokens !== null) {
     const loc = getCurrentLocation()
     // eslint-disable-next-line
     delete tokens[loc.path[1]]
-    setMetadataLocalStorage(login.metadata.LoginTokens, tokens)
+    setMetadataLocalStorage(login.metadata.LoginTokensV2, tokens)
   }
   const currentWorkspace = getMetadata(presentation.metadata.WorkspaceUuid)
   if (currentWorkspace !== undefined) {

--- a/plugins/guest-resources/src/utils.ts
+++ b/plugins/guest-resources/src/utils.ts
@@ -11,7 +11,7 @@ import { workbenchId } from '@hcengineering/workbench'
 export async function checkAccess (doc: Doc): Promise<void> {
   const loc = getCurrentLocation()
   const ws = loc.path[1]
-  const tokens: Record<string, string> = fetchMetadataLocalStorage(login.metadata.LoginTokens) ?? {}
+  const tokens: Record<string, string> = fetchMetadataLocalStorage(login.metadata.LoginTokensV2) ?? {}
   const token = tokens[ws]
   const endpoint = getMetadata(presentation.metadata.Endpoint)
   if (token === undefined || endpoint === undefined) return

--- a/plugins/login-resources/src/components/LoginApp.svelte
+++ b/plugins/login-resources/src/components/LoginApp.svelte
@@ -72,7 +72,7 @@
       'auth'
     ]
     if (token === undefined ? !allowedUnauthPages.includes(page) : !pages.includes(page)) {
-      const tokens = fetchMetadataLocalStorage(login.metadata.LoginTokens)
+      const tokens = fetchMetadataLocalStorage(login.metadata.LoginTokensV2)
       page = tokens != null ? 'login' : 'signup'
     }
 

--- a/plugins/login-resources/src/utils.ts
+++ b/plugins/login-resources/src/utils.ts
@@ -425,12 +425,12 @@ export async function getPerson (): Promise<[Status, Person | null]> {
 }
 
 export function setLoginInfo (loginInfo: WorkspaceLoginInfo): void {
-  const tokens: Record<string, string> = fetchMetadataLocalStorage(login.metadata.LoginTokens) ?? {}
+  const tokens: Record<string, string> = fetchMetadataLocalStorage(login.metadata.LoginTokensV2) ?? {}
   tokens[loginInfo.workspaceUrl] = loginInfo.token
 
   setMetadata(presentation.metadata.Token, loginInfo.token)
   setMetadataLocalStorage(login.metadata.LastToken, loginInfo.token)
-  setMetadataLocalStorage(login.metadata.LoginTokens, tokens)
+  setMetadataLocalStorage(login.metadata.LoginTokensV2, tokens)
   setMetadataLocalStorage(login.metadata.LoginEndpoint, loginInfo.endpoint)
   setMetadataLocalStorage(login.metadata.LoginAccount, loginInfo.account)
 }
@@ -473,7 +473,7 @@ export async function checkJoined (inviteId: string): Promise<[Status, Workspace
   let token = getMetadata(presentation.metadata.Token)
 
   if (token == null) {
-    const tokens: Record<string, string> = fetchMetadataLocalStorage(login.metadata.LoginTokens) ?? {}
+    const tokens: Record<string, string> = fetchMetadataLocalStorage(login.metadata.LoginTokensV2) ?? {}
     token = Object.values(tokens)[0]
     if (token == null) {
       return [unknownStatus('Please login'), null]

--- a/plugins/login/src/index.ts
+++ b/plugins/login/src/index.ts
@@ -29,7 +29,7 @@ export const loginId = 'login' as Plugin
 export default plugin(loginId, {
   metadata: {
     AccountsUrl: '' as Asset,
-    LoginTokens: '' as Metadata<Record<string, string>>,
+    LoginTokensV2: '' as Metadata<Record<string, string>>,
     LastToken: '' as Metadata<string>,
     LoginEndpoint: '' as Metadata<string>,
     LoginAccount: '' as Metadata<string>,

--- a/plugins/setting-resources/src/components/Settings.svelte
+++ b/plugins/setting-resources/src/components/Settings.svelte
@@ -99,12 +99,12 @@
     navigate(loc)
   }
   function signOut (): void {
-    const tokens = fetchMetadataLocalStorage(login.metadata.LoginTokens)
+    const tokens = fetchMetadataLocalStorage(login.metadata.LoginTokensV2)
     if (tokens !== null) {
       const loc = getCurrentResolvedLocation()
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete tokens[loc.path[1]]
-      setMetadataLocalStorage(login.metadata.LoginTokens, tokens)
+      setMetadataLocalStorage(login.metadata.LoginTokensV2, tokens)
     }
     setMetadata(presentation.metadata.Token, null)
     setMetadataLocalStorage(login.metadata.LastToken, null)

--- a/plugins/workbench-resources/src/connect.ts
+++ b/plugins/workbench-resources/src/connect.ts
@@ -77,7 +77,7 @@ export async function connect (title: string): Promise<Client | undefined> {
       return
     }
   }
-  const tokens: Record<string, string> = fetchMetadataLocalStorage(login.metadata.LoginTokens) ?? {}
+  const tokens: Record<string, string> = fetchMetadataLocalStorage(login.metadata.LoginTokensV2) ?? {}
   let token = tokens[wsUrl]
 
   const selectWorkspace = await getResource(login.function.SelectWorkspace)
@@ -101,7 +101,7 @@ export async function connect (title: string): Promise<Client | undefined> {
 
   tokens[wsUrl] = workspaceLoginInfo.token
   token = workspaceLoginInfo.token
-  setMetadataLocalStorage(login.metadata.LoginTokens, tokens)
+  setMetadataLocalStorage(login.metadata.LoginTokensV2, tokens)
   setMetadata(presentation.metadata.WorkspaceUuid, workspaceLoginInfo.workspace)
   setMetadata(presentation.metadata.WorkspaceDataId, workspaceLoginInfo.workspaceDataId)
   setMetadata(presentation.metadata.Endpoint, workspaceLoginInfo.endpoint)
@@ -434,12 +434,12 @@ async function getGlobalPerson (): Promise<GlobalPerson | undefined> {
 }
 
 export function clearMetadata (ws: string): void {
-  const tokens = fetchMetadataLocalStorage(login.metadata.LoginTokens)
+  const tokens = fetchMetadataLocalStorage(login.metadata.LoginTokensV2)
   if (tokens !== null) {
     const loc = getCurrentLocation()
     // eslint-disable-next-line
     delete tokens[loc.path[1]]
-    setMetadataLocalStorage(login.metadata.LoginTokens, tokens)
+    setMetadataLocalStorage(login.metadata.LoginTokensV2, tokens)
   }
   const currentWorkspace = getMetadata(presentation.metadata.WorkspaceUuid)
   if (currentWorkspace !== undefined) {

--- a/plugins/workbench-resources/src/utils.ts
+++ b/plugins/workbench-resources/src/utils.ts
@@ -207,13 +207,13 @@ export async function buildNavModel (
 }
 
 export function signOut (): void {
-  const tokens = fetchMetadataLocalStorage(login.metadata.LoginTokens)
+  const tokens = fetchMetadataLocalStorage(login.metadata.LoginTokensV2)
   if (tokens !== null) {
     const loc = getCurrentLocation()
     const l = loc.path[1]
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
     delete tokens[l]
-    setMetadataLocalStorage(login.metadata.LoginTokens, tokens)
+    setMetadataLocalStorage(login.metadata.LoginTokensV2, tokens)
   }
   setMetadata(presentation.metadata.Token, null)
   setMetadataLocalStorage(login.metadata.LastToken, null)


### PR DESCRIPTION
* Fixes switching to another workspace scenario when old format tokens are saved in the local storage

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-9451