### PR TITLE
Drop the meeting minutes cache when the AI disconnects.

### DIFF
--- a/services/ai-bot/pod-ai-bot/src/workspace/love.ts
+++ b/services/ai-bot/pod-ai-bot/src/workspace/love.ts
@@ -48,7 +48,7 @@ export class LoveController {
   private participantsInfo: ParticipantInfo[] = []
   private rooms: Room[] = []
   private readonly socialIdByPerson = new Map<Ref<Person>, PersonId>()
-  private readonly meetingMinutes: MeetingMinutes[] = []
+  private meetingMinutes: MeetingMinutes[] = []
 
   constructor (
     private readonly workspace: WorkspaceUuid,
@@ -169,6 +169,7 @@ export class LoveController {
       await stopTranscription(this.token, getTokenRoomName(this.workspace, room.name, room._id), room.name)
     }
 
+    this.meetingMinutes = this.meetingMinutes.filter((m) => m.attachedTo !== roomId)
     this.connectedRooms.delete(roomId)
   }
 


### PR DESCRIPTION
At the moment, it is very common that because of the MM cache, the transcription starts being written to the previous document. The fix simply resets it when disconnected.