### PR TITLE
qfix: correctly use datalake files scheme for recorder

### DIFF
--- a/plugins/recorder-resources/src/recording.ts
+++ b/plugins/recorder-resources/src/recording.ts
@@ -50,9 +50,8 @@ export async function record (options: FileUploadOptions): Promise<void> {
 }
 
 async function uploadRecording (recordingName: string, onUploaded: FileUploadCallback): Promise<void> {
-  const u = new URL(getFileUrl(recordingName))
   await onUploaded({
-    uuid: getFileUrl(u.toString()) as Ref<Blob>,
+    uuid: getBlobUrl(recordingName) as Ref<Blob>,
     name: 'Recording-' + now(),
     file: { ...new Blob(), type: 'video/x-mpegURL' },
     path: undefined,
@@ -64,4 +63,13 @@ async function uploadRecording (recordingName: string, onUploaded: FileUploadCal
 function now (): string {
   const date = new Date()
   return date.toLocaleDateString() + ' ' + date.toLocaleTimeString()
+}
+
+function getBlobUrl (file: string): string {
+  const fileUrl = getFileUrl(file)
+  const u = new URL(fileUrl)
+  if (u.searchParams.has('file')) {
+    return u.toString()
+  }
+  return fileUrl.split('/').slice(0, -1).join('/')
 }


### PR DESCRIPTION
## Motivation

Fixes issue with playing videos by HLS player if front is using datalake files scheme.

The current front is using the next scheme for files.

```
/blob/:workspace/:name/:filename
```

where in most cases name == filename

And default file url makes the HLS player mad because it will try to permutate wrong combinations:

```
blob/workspace/master/master_1080
blob/workspace/master/master_720
```

when expected

```
/blob/workspace/master_1080
/ blob/workspace/master_720
```

This PR fixes the issue.