### PR TITLE
Update max-width/max-height for attachment video preview

### DIFF
--- a/plugins/attachment-resources/src/components/AttachmentVideoPreview.svelte
+++ b/plugins/attachment-resources/src/components/AttachmentVideoPreview.svelte
@@ -74,8 +74,8 @@
 
 <style lang="scss">
   .container {
-    max-width: 20rem;
-    max-height: 20rem;
+    max-width: 25rem;
+    max-height: 25rem;
     min-width: 4rem;
     min-height: 4rem;
     border-radius: 0.75rem;


### PR DESCRIPTION
Fixes:
<img width="408" alt="Screenshot 2025-03-10 at 6 04 50 PM" src="https://github.com/user-attachments/assets/4a08acec-a467-4692-b3cd-f1ebbb07001d" />
