### PR TITLE
UBERF-9633: Use proper split of create/upgrade in migrations

### DIFF
--- a/models/activity/src/migration.ts
+++ b/models/activity/src/migration.ts
@@ -38,7 +38,6 @@ import {
   type MigrationDocumentQuery,
   type MigrationIterator,
   type MigrationUpgradeClient,
-  type MigrateMode,
   tryMigrate
 } from '@hcengineering/model'
 import { htmlToMarkup } from '@hcengineering/text'
@@ -457,8 +456,8 @@ async function migrateSocialIdsInDocUpdates (client: MigrationClient): Promise<v
 }
 
 export const activityOperation: MigrateOperation = {
-  async migrate (client: MigrationClient, mode: MigrateMode): Promise<void> {
-    await tryMigrate(client, activityId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, activityId, [
       {
         state: 'reactions',
         mode: 'upgrade',
@@ -507,6 +506,7 @@ export const activityOperation: MigrateOperation = {
       },
       {
         state: 'migrate-employee-space-v1',
+        mode: 'upgrade',
         func: async () => {
           await client.update<ActivityMessage>(
             DOMAIN_ACTIVITY,
@@ -517,10 +517,12 @@ export const activityOperation: MigrateOperation = {
       },
       {
         state: 'migrate-activity-markup',
+        mode: 'upgrade',
         func: migrateActivityMarkup
       },
       {
         state: 'move-reactions',
+        mode: 'upgrade',
         func: async (client: MigrationClient): Promise<void> => {
           await client.move(DOMAIN_ACTIVITY, { _class: activity.class.Reaction }, DOMAIN_REACTION)
           await client.move(DOMAIN_ACTIVITY, { _class: activity.class.UserMentionInfo }, DOMAIN_USER_MENTION)
@@ -528,15 +530,18 @@ export const activityOperation: MigrateOperation = {
       },
       {
         state: 'accounts-to-social-ids-v2',
+        mode: 'upgrade',
         func: migrateAccountsToSocialIds
       },
       {
         state: 'accounts-in-doc-updates-v2',
+        mode: 'upgrade',
         func: migrateAccountsInDocUpdates
       },
       // ONLY FOR STAGING. REMOVE IT BEFORE MERGING TO PRODUCTION
       {
         state: 'social-ids-in-doc-updates',
+        mode: 'upgrade',
         func: migrateSocialIdsInDocUpdates
       }
     ])

--- a/models/ai-bot/src/migration.ts
+++ b/models/ai-bot/src/migration.ts
@@ -22,8 +22,8 @@ import {
 import { aiBotId } from '@hcengineering/ai-bot'
 
 export const aiBotOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, aiBotId, [])
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, aiBotId, [])
   },
   async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {}
 }

--- a/models/analytics-collector/src/migration.ts
+++ b/models/analytics-collector/src/migration.ts
@@ -13,15 +13,15 @@
 // limitations under the License.
 //
 
+import analyticsCollector, { analyticsCollectorId } from '@hcengineering/analytics-collector'
 import {
+  tryMigrate,
   type MigrateOperation,
   type MigrateUpdate,
   type MigrationClient,
   type MigrationDocumentQuery,
-  type MigrationUpgradeClient,
-  tryMigrate
+  type MigrationUpgradeClient
 } from '@hcengineering/model'
-import analyticsCollector, { analyticsCollectorId } from '@hcengineering/analytics-collector'
 import { DOMAIN_SPACE, getSocialKeyByOldEmail } from '@hcengineering/model-core'
 import { DOMAIN_DOC_NOTIFY, DOMAIN_NOTIFICATION } from '@hcengineering/model-notification'
 import { DOMAIN_ACTIVITY } from '@hcengineering/model-activity'
@@ -87,10 +87,11 @@ async function migrateAccountsToSocialIds (client: MigrationClient): Promise<voi
 }
 
 export const analyticsCollectorOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, analyticsCollectorId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, analyticsCollectorId, [
       {
         state: 'remove-analytics-channels-v3',
+        mode: 'upgrade',
         func: removeOnboardingChannels
       },
       {

--- a/models/attachment/src/migration.ts
+++ b/models/attachment/src/migration.ts
@@ -22,10 +22,11 @@ import {
 import attachment, { attachmentId, DOMAIN_ATTACHMENT } from '.'
 
 export const attachmentOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, attachmentId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, attachmentId, [
       {
         state: 'fix-attachedTo',
+        mode: 'upgrade',
         func: async (client: MigrationClient): Promise<void> => {
           await client.update(
             DOMAIN_ATTACHMENT,

--- a/models/bitrix/src/migration.ts
+++ b/models/bitrix/src/migration.ts
@@ -25,8 +25,8 @@ import { bitrixId } from '@hcengineering/bitrix'
 
 export const bitrixOperation: MigrateOperation = {
   async migrate (client: MigrationClient): Promise<void> {},
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, bitrixId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, bitrixId, [
       {
         state: 'create-defaults-v2',
         func: async (client) => {

--- a/models/board/src/migration.ts
+++ b/models/board/src/migration.ts
@@ -82,16 +82,17 @@ async function migrateIdentifiers (client: MigrationClient): Promise<void> {
 }
 
 export const boardOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, boardId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, boardId, [
       {
         state: 'identifier',
+        mode: 'upgrade',
         func: migrateIdentifiers
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, boardId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, boardId, [
       {
         state: 'board0001',
         func: async (client) => {

--- a/models/calendar/src/migration.ts
+++ b/models/calendar/src/migration.ts
@@ -207,10 +207,11 @@ async function migrateTimezone (client: MigrationClient): Promise<void> {
 }
 
 export const calendarOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, calendarId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, calendarId, [
       {
         state: 'calendar001',
+        mode: 'upgrade',
         func: async (client) => {
           await fixEventDueDate(client)
           await migrateReminders(client)
@@ -220,14 +221,17 @@ export const calendarOperation: MigrateOperation = {
       },
       {
         state: 'timezone',
+        mode: 'upgrade',
         func: migrateTimezone
       },
       {
         state: 'migrate_calendars',
+        mode: 'upgrade',
         func: migrateCalendars
       },
       {
         state: 'move-events',
+        mode: 'upgrade',
         func: async (client) => {
           await client.move(
             DOMAIN_CALENDAR,
@@ -242,8 +246,8 @@ export const calendarOperation: MigrateOperation = {
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, calendarId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, calendarId, [
       {
         state: 'default-space',
         func: (client) =>

--- a/models/card/src/migration.ts
+++ b/models/card/src/migration.ts
@@ -27,16 +27,17 @@ import view from '@hcengineering/view'
 import card from '.'
 
 export const cardOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, chunterId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, chunterId, [
       {
         state: 'set-parent-info',
+        mode: 'upgrade',
         func: setParentInfo
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, chunterId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, chunterId, [
       {
         state: 'migrateViewlets',
         func: migrateViewlets

--- a/models/chunter/src/migration.ts
+++ b/models/chunter/src/migration.ts
@@ -37,8 +37,8 @@ import contact, { getAllAccounts } from '@hcengineering/contact'
 import { DOMAIN_DOC_NOTIFY, DOMAIN_NOTIFICATION } from '@hcengineering/model-notification'
 import { type DocUpdateMessage } from '@hcengineering/activity'
 
-import chunter from './plugin'
 import { DOMAIN_CHUNTER } from './index'
+import chunter from './plugin'
 
 export const DOMAIN_COMMENT = 'comment' as Domain
 
@@ -232,8 +232,8 @@ async function removeWrongActivity (client: MigrationClient): Promise<void> {
 }
 
 export const chunterOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, chunterId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, chunterId, [
       {
         state: 'create-chat-messages',
         mode: 'upgrade',
@@ -308,8 +308,8 @@ export const chunterOperation: MigrateOperation = {
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, chunterId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, chunterId, [
       {
         state: 'create-defaults-v2',
         func: async (client) => {

--- a/models/contact/src/migration.ts
+++ b/models/contact/src/migration.ts
@@ -263,10 +263,11 @@ async function createSocialIdentities (client: MigrationClient): Promise<void> {
 }
 
 export const contactOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, contactId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, contactId, [
       {
         state: 'employees',
+        mode: 'upgrade',
         func: async (client) => {
           await client.update(
             DOMAIN_TX,
@@ -373,6 +374,7 @@ export const contactOperation: MigrateOperation = {
       },
       {
         state: 'removeEmployeeSpace',
+        mode: 'upgrade',
         func: async (client) => {
           await client.update(
             DOMAIN_CONTACT,
@@ -387,12 +389,14 @@ export const contactOperation: MigrateOperation = {
       },
       {
         state: 'avatars',
+        mode: 'upgrade',
         func: async (client) => {
           await migrateAvatars(client)
         }
       },
       {
         state: 'avatarsKind',
+        mode: 'upgrade',
         func: async (client) => {
           await client.update(
             DOMAIN_CONTACT,
@@ -419,8 +423,8 @@ export const contactOperation: MigrateOperation = {
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, contactId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, contactId, [
       {
         state: 'createSpace-v2',
         func: async (client) => {

--- a/models/controlled-documents/src/migration.ts
+++ b/models/controlled-documents/src/migration.ts
@@ -457,8 +457,8 @@ async function migrateDocumentMetaInternalCode (client: MigrationClient): Promis
 }
 
 export const documentsOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, documentsId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, documentsId, [
       {
         state: 'migrateSpaceTypes',
         func: migrateSpaceTypes
@@ -488,8 +488,8 @@ export const documentsOperation: MigrateOperation = {
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, documentsId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, documentsId, [
       {
         state: 'init-documents',
         func: async (client) => {

--- a/models/core/src/migration.ts
+++ b/models/core/src/migration.ts
@@ -884,8 +884,8 @@ async function processMigrateJsonForDoc (
 }
 
 export const coreOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, coreId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, coreId, [
       {
         state: 'statuses-to-model',
         mode: 'upgrade',
@@ -996,8 +996,8 @@ export const coreOperation: MigrateOperation = {
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, coreId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, coreId, [
       {
         state: 'create-defaults-v2',
         func: async (client) => {

--- a/models/document/src/migration.ts
+++ b/models/document/src/migration.ts
@@ -353,8 +353,8 @@ async function removeOldClasses (client: MigrationClient): Promise<void> {
   }
 }
 export const documentOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, documentId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, documentId, [
       {
         state: 'updateDocumentIcons',
         mode: 'upgrade',

--- a/models/drive/src/migration.ts
+++ b/models/drive/src/migration.ts
@@ -121,8 +121,8 @@ async function renameFields (client: MigrationClient): Promise<void> {
 }
 
 export const driveOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, driveId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, driveId, [
       {
         state: 'file-versions',
         func: migrateFileVersions
@@ -134,7 +134,7 @@ export const driveOperation: MigrateOperation = {
     ])
   },
 
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, driveId, [])
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, driveId, [])
   }
 }

--- a/models/gmail/src/migration.ts
+++ b/models/gmail/src/migration.ts
@@ -43,8 +43,8 @@ async function migrateSettings (client: MigrationClient): Promise<void> {
 }
 
 export const gmailOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, gmailId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, gmailId, [
       {
         state: 'removeDeprecatedSpace',
         func: async (client: MigrationClient) => {

--- a/models/guest/src/migration.ts
+++ b/models/guest/src/migration.ts
@@ -7,8 +7,8 @@ import {
 } from '@hcengineering/model'
 
 export const guestOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, guestId, [])
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, guestId, [])
   },
   async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {}
 }

--- a/models/hr/src/migration.ts
+++ b/models/hr/src/migration.ts
@@ -104,10 +104,11 @@ async function migrateDepartmentMembersToEmployee (client: MigrationClient): Pro
 }
 
 export const hrOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, hrId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, hrId, [
       {
         state: 'migrateDepartments',
+        mode: 'upgrade',
         func: migrateDepartments
       },
       {
@@ -122,8 +123,8 @@ export const hrOperation: MigrateOperation = {
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, hrId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, hrId, [
       {
         state: 'create-defaults-v2',
         func: async (client) => {

--- a/models/inventory/src/migration.ts
+++ b/models/inventory/src/migration.ts
@@ -25,8 +25,8 @@ import {
 import { DOMAIN_INVENTORY } from '.'
 
 export const inventoryOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, inventoryId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, inventoryId, [
       {
         state: 'removeDeprecatedSpace',
         func: async (client: MigrationClient) => {

--- a/models/lead/src/migration.ts
+++ b/models/lead/src/migration.ts
@@ -148,18 +148,19 @@ async function migrateDefaultTypeMixins (client: MigrationClient): Promise<void>
 }
 
 export const leadOperation: MigrateOperation = {
-  async preMigrate (client: MigrationClient, logger: ModelLogger): Promise<void> {
-    await tryMigrate(client, leadId, [
+  async preMigrate (client: MigrationClient, logger: ModelLogger, mode): Promise<void> {
+    await tryMigrate(mode, client, leadId, [
       {
         state: 'migrate-default-statuses',
         func: (client) => migrateDefaultStatuses(client, logger)
       }
     ])
   },
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, leadId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, leadId, [
       {
         state: 'identifier',
+        mode: 'upgrade',
         func: migrateIdentifiers
       },
       {
@@ -170,6 +171,7 @@ export const leadOperation: MigrateOperation = {
       },
       {
         state: 'migrate-customer-description',
+        mode: 'upgrade',
         func: async (client) => {
           await client.update(
             DOMAIN_CONTACT,
@@ -186,8 +188,8 @@ export const leadOperation: MigrateOperation = {
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, leadId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, leadId, [
       {
         state: 'u-default-funnel',
         func: async (client) => {

--- a/models/notification/src/migration.ts
+++ b/models/notification/src/migration.ts
@@ -670,22 +670,25 @@ export async function migrateNotificationsObject (client: MigrationClient): Prom
 }
 
 export const notificationOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, notificationId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, notificationId, [
       {
         state: 'delete-hidden-notifications',
+        mode: 'upgrade',
         func: async (client) => {
           await removeNotifications(client, { hidden: true })
         }
       },
       {
         state: 'delete-invalid-notifications',
+        mode: 'upgrade',
         func: async (client) => {
           await removeNotifications(client, { attachedToClass: 'chunter:class:Comment' as Ref<Class<Doc>> })
         }
       },
       {
         state: 'remove-old-classes',
+        mode: 'upgrade',
         func: async (client) => {
           await client.deleteMany(DOMAIN_NOTIFICATION, { _class: 'notification:class:DocUpdates' as Ref<Class<Doc>> })
           await client.deleteMany(DOMAIN_TX, { objectClass: 'notification:class:DocUpdates' as Ref<Class<Doc>> })
@@ -693,6 +696,7 @@ export const notificationOperation: MigrateOperation = {
       },
       {
         state: 'removeDeprecatedSpace',
+        mode: 'upgrade',
         func: async (client: MigrationClient) => {
           await migrateSpace(client, 'notification:space:Notifications' as Ref<Space>, core.space.Workspace, [
             DOMAIN_NOTIFICATION
@@ -701,34 +705,40 @@ export const notificationOperation: MigrateOperation = {
       },
       {
         state: 'migrate-setting',
+        mode: 'upgrade',
         func: migrateSettings
       },
       {
         state: 'move-doc-notify',
+        mode: 'upgrade',
         func: async (client) => {
           await client.move(DOMAIN_NOTIFICATION, { _class: notification.class.DocNotifyContext }, DOMAIN_DOC_NOTIFY)
         }
       },
       {
         state: 'remove-last-view',
+        mode: 'upgrade',
         func: async (client) => {
           await client.deleteMany(DOMAIN_NOTIFICATION, { _class: 'notification:class:LastView' as any })
         }
       },
       {
         state: 'remove-notification',
+        mode: 'upgrade',
         func: async (client) => {
           await client.deleteMany(DOMAIN_NOTIFICATION, { _class: 'notification:class:Notification' as any })
         }
       },
       {
         state: 'remove-email-notification',
+        mode: 'upgrade',
         func: async (client) => {
           await client.deleteMany(DOMAIN_NOTIFICATION, { _class: 'notification:class:EmailNotification' as any })
         }
       },
       {
         state: 'move-user',
+        mode: 'upgrade',
         func: async (client) => {
           await client.move(
             DOMAIN_NOTIFICATION,
@@ -739,6 +749,7 @@ export const notificationOperation: MigrateOperation = {
       },
       {
         state: 'fill-notification-archived-field-v1',
+        mode: 'upgrade',
         func: async (client) => {
           await client.update<InboxNotification>(
             DOMAIN_NOTIFICATION,
@@ -759,6 +770,7 @@ export const notificationOperation: MigrateOperation = {
       },
       {
         state: 'fill-contexts-pinned-field-v1',
+        mode: 'upgrade',
         func: async (client) => {
           await client.update<DocNotifyContext>(
             DOMAIN_DOC_NOTIFY,
@@ -769,10 +781,12 @@ export const notificationOperation: MigrateOperation = {
       },
       {
         state: 'migrate-notifications-space-v1',
+        mode: 'upgrade',
         func: migrateNotificationsSpace
       },
       {
         state: 'migrate-employee-space-v1',
+        mode: 'upgrade',
         func: async () => {
           await client.update<DocNotifyContext>(
             DOMAIN_DOC_NOTIFY,
@@ -783,6 +797,7 @@ export const notificationOperation: MigrateOperation = {
       },
       {
         state: 'migrate-wrong-spaces-v1',
+        mode: 'upgrade',
         func: async () => {
           await client.update<DocNotifyContext>(
             DOMAIN_DOC_NOTIFY,
@@ -803,10 +818,12 @@ export const notificationOperation: MigrateOperation = {
       },
       {
         state: 'migrate-duplicated-contexts-v4',
+        mode: 'upgrade',
         func: migrateDuplicateContexts
       },
       {
         state: 'set-default-hidden',
+        mode: 'upgrade',
         func: async () => {
           await client.update(
             DOMAIN_DOC_NOTIFY,
@@ -817,6 +834,7 @@ export const notificationOperation: MigrateOperation = {
       },
       {
         state: 'remove-update-txes-docnotify-ctx-v2',
+        mode: 'upgrade',
         func: async (client) => {
           await client.deleteMany(DOMAIN_TX, {
             _class: core.class.TxUpdateDoc,
@@ -836,6 +854,7 @@ export const notificationOperation: MigrateOperation = {
       },
       {
         state: 'remove-browser-notification-v2',
+        mode: 'upgrade',
         func: async (client) => {
           await client.deleteMany<BrowserNotification>(DOMAIN_USER_NOTIFY, {
             _class: notification.class.BrowserNotification
@@ -848,6 +867,7 @@ export const notificationOperation: MigrateOperation = {
       },
       {
         state: 'migrate-dnc-space',
+        mode: 'upgrade',
         func: async (client) => {
           await client.update(DOMAIN_DOC_NOTIFY, { space: core.space.Space }, { space: core.space.Workspace })
         }
@@ -858,11 +878,13 @@ export const notificationOperation: MigrateOperation = {
       // },
       {
         state: 'accounts-to-social-ids',
+        mode: 'upgrade',
         func: migrateAccounts
       },
       // ONLY FOR STAGING. REMOVE IT BEFORE MERGING TO PRODUCTION
       {
         state: 'migrate-social-ids-to-account-uuids',
+        mode: 'upgrade',
         func: migrateSocialIdsToAccountUuids
       }
     ])

--- a/models/preference/src/migration.ts
+++ b/models/preference/src/migration.ts
@@ -24,8 +24,8 @@ import {
 import { DOMAIN_PREFERENCE, preferenceId } from '@hcengineering/preference'
 
 export const preferenceOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, preferenceId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, preferenceId, [
       {
         state: 'removeDeprecatedSpace',
         func: async (client: MigrationClient) => {

--- a/models/recruit/src/migration.ts
+++ b/models/recruit/src/migration.ts
@@ -43,18 +43,19 @@ import recruit from './plugin'
 import { defaultApplicantStatuses } from './spaceType'
 
 export const recruitOperation: MigrateOperation = {
-  async preMigrate (client: MigrationClient, logger: ModelLogger): Promise<void> {
-    await tryMigrate(client, recruitId, [
+  async preMigrate (client: MigrationClient, logger: ModelLogger, mode): Promise<void> {
+    await tryMigrate(mode, client, recruitId, [
       {
         state: 'migrate-default-statuses',
         func: (client) => migrateDefaultStatuses(client, logger)
       }
     ])
   },
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, recruitId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, recruitId, [
       {
         state: 'identifier',
+        mode: 'upgrade',
         func: migrateIdentifiers
       },
       {
@@ -71,6 +72,7 @@ export const recruitOperation: MigrateOperation = {
       },
       {
         state: 'migrate-applicants',
+        mode: 'upgrade',
         func: async (client: MigrationClient) => {
           await client.update(
             DOMAIN_TASK,
@@ -81,8 +83,8 @@ export const recruitOperation: MigrateOperation = {
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, recruitId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, recruitId, [
       {
         state: 'create-defaults-v2',
         func: async (client) => {

--- a/models/request/src/migration.ts
+++ b/models/request/src/migration.ts
@@ -21,8 +21,8 @@ import {
 } from '@hcengineering/model'
 
 export const requestOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, requestId, [])
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, requestId, [])
   },
   async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {}
 }

--- a/models/server-activity/src/migration.ts
+++ b/models/server-activity/src/migration.ts
@@ -32,7 +32,8 @@ import {
   type MigrateOperation,
   type MigrationClient,
   type MigrationIterator,
-  type MigrationUpgradeClient
+  type MigrationUpgradeClient,
+  type MigrateMode
 } from '@hcengineering/model'
 import { DOMAIN_ACTIVITY } from '@hcengineering/model-activity'
 import {
@@ -263,8 +264,8 @@ async function createDocUpdateMessages (client: MigrationClient): Promise<void> 
 }
 
 export const activityServerOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, serverActivityId, [
+  async migrate (client: MigrationClient, mode: MigrateMode): Promise<void> {
+    await tryMigrate(mode, client, serverActivityId, [
       {
         state: 'doc-update-messages',
         mode: 'upgrade',

--- a/models/setting/src/migration.ts
+++ b/models/setting/src/migration.ts
@@ -142,8 +142,8 @@ async function migrateSocialIdsToAccountUuids (client: MigrationClient): Promise
 }
 
 export const settingOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, settingId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, settingId, [
       {
         state: 'removeDeprecatedSpace',
         func: async (client: MigrationClient) => {

--- a/models/survey/src/migration.ts
+++ b/models/survey/src/migration.ts
@@ -25,11 +25,11 @@ import {
 import survey, { surveyId } from './index'
 
 export const surveyOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, surveyId, [])
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, surveyId, [])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, surveyId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, surveyId, [
       {
         state: 'createSpace',
         func: async (client) => {

--- a/models/tags/src/migration.ts
+++ b/models/tags/src/migration.ts
@@ -10,8 +10,8 @@ import { tagsId } from '@hcengineering/tags'
 import { DOMAIN_TAGS } from '.'
 
 export const tagsOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, tagsId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, tagsId, [
       {
         state: 'removeDeprecatedSpace',
         func: async (client: MigrationClient) => {

--- a/models/task/src/migration.ts
+++ b/models/task/src/migration.ts
@@ -515,10 +515,11 @@ function areSameArrays (arr1: any[] | undefined, arr2: any[] | undefined): boole
 }
 
 export const taskOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, taskId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, taskId, [
       {
         state: 'migrate-tt-model-states',
+        mode: 'upgrade',
         func: async (client) => {
           const prTaskTypes = client.model.findAllSync(task.class.TaskType, {})
 
@@ -547,10 +548,12 @@ export const taskOperation: MigrateOperation = {
       },
       {
         state: 'migrateRanks',
+        mode: 'upgrade',
         func: migrateRanks
       },
       {
         state: 'migrate_wrong_isdone',
+        mode: 'upgrade',
         func: async (client: MigrationClient) => {
           const statuses = client.model.findAllSync(core.class.Status, {
             category: { $in: [task.statusCategory.Won, task.statusCategory.Lost] }
@@ -582,6 +585,7 @@ export const taskOperation: MigrateOperation = {
       },
       {
         state: 'migrateSequnce',
+        mode: 'upgrade',
         func: async (client: MigrationClient) => {
           await client.update(
             'kanban' as Domain,
@@ -593,8 +597,8 @@ export const taskOperation: MigrateOperation = {
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, taskId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, taskId, [
       {
         state: 'u-task-001',
         func: async (client) => {

--- a/models/telegram/src/migration.ts
+++ b/models/telegram/src/migration.ts
@@ -25,8 +25,8 @@ import { telegramId } from '@hcengineering/telegram'
 import { DOMAIN_TELEGRAM } from '.'
 
 export const telegramOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, telegramId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, telegramId, [
       {
         state: 'removeDeprecatedSpace',
         func: async (client: MigrationClient) => {

--- a/models/templates/src/migration.ts
+++ b/models/templates/src/migration.ts
@@ -25,8 +25,8 @@ import { templatesId } from '@hcengineering/templates'
 
 export const templatesOperation: MigrateOperation = {
   async migrate (client: MigrationClient): Promise<void> {},
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, templatesId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, templatesId, [
       {
         state: 'create-defaults',
         func: async (client) => {

--- a/models/text-editor/src/migration.ts
+++ b/models/text-editor/src/migration.ts
@@ -163,14 +163,16 @@ async function processFixMigrateMarkupFor (
 }
 
 export const textEditorOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, 'text-editor', [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, 'text-editor', [
       {
         state: 'markup',
+        mode: 'upgrade',
         func: migrateMarkup
       },
       {
         state: 'fix-markup',
+        mode: 'upgrade',
         func: fixMigrateMarkup
       }
     ])

--- a/models/time/src/migration.ts
+++ b/models/time/src/migration.ts
@@ -44,18 +44,19 @@ async function fillProps (client: MigrationClient): Promise<void> {
 }
 
 export const timeOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, timeId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, timeId, [
       {
         state: 'm-time-001',
+        mode: 'upgrade',
         func: async (client) => {
           await fillProps(client)
         }
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, timeId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, timeId, [
       {
         state: 'create-defaults-v2',
         func: async (client) => {

--- a/models/tracker/src/migration.ts
+++ b/models/tracker/src/migration.ts
@@ -363,8 +363,8 @@ async function migrateIssueStatuses (client: MigrationClient): Promise<void> {
 }
 
 export const trackerOperation: MigrateOperation = {
-  async preMigrate (client: MigrationClient, logger: ModelLogger): Promise<void> {
-    await tryMigrate(client, trackerId, [
+  async preMigrate (client: MigrationClient, logger: ModelLogger, mode): Promise<void> {
+    await tryMigrate(mode, client, trackerId, [
       {
         state: 'fixIncorrectIssueStatuses',
         func: migrateIssueStatuses
@@ -375,28 +375,32 @@ export const trackerOperation: MigrateOperation = {
       }
     ])
   },
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, trackerId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, trackerId, [
       {
         state: 'identifier',
+        mode: 'upgrade',
         func: migrateIdentifiers
       },
       {
         state: 'passIdentifierToParentInfo',
+        mode: 'upgrade',
         func: passIdentifierToParentInfo
       },
       {
         state: 'statusesToModel-2',
+        mode: 'upgrade',
         func: migrateStatusesToModel
       },
       {
         state: 'migrateDefaultTypeMixins',
+        mode: 'upgrade',
         func: migrateDefaultTypeMixins
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, trackerId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, trackerId, [
       {
         state: 'create-defaults',
         func: async (client) => {

--- a/models/training/src/migration.ts
+++ b/models/training/src/migration.ts
@@ -26,10 +26,11 @@ import training, { trainingId } from '@hcengineering/training'
 import { DOMAIN_TRAINING } from './types'
 
 export const trainingOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, trainingId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, trainingId, [
       {
         state: 'migrateSequnce',
+        mode: 'upgrade',
         func: async (client: MigrationClient) => {
           await client.update(
             DOMAIN_TRAINING,
@@ -41,8 +42,8 @@ export const trainingOperation: MigrateOperation = {
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, trainingId, [
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, trainingId, [
       {
         state: 'create-defaults',
         func: async (client) => {

--- a/models/view/src/migration.ts
+++ b/models/view/src/migration.ts
@@ -127,14 +127,16 @@ async function migrateAccountsToSocialIds (client: MigrationClient): Promise<voi
 }
 
 export const viewOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, viewId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, viewId, [
       {
         state: 'remove-done-state-pref',
+        mode: 'upgrade',
         func: removeDoneStatePref
       },
       {
         state: 'remove-done-state-filter',
+        mode: 'upgrade',
         func: removeDoneStateFilter
       },
       {

--- a/models/workbench/src/migration.ts
+++ b/models/workbench/src/migration.ts
@@ -44,14 +44,16 @@ async function migrateTabsToSocialIds (client: MigrationClient): Promise<void> {
 }
 
 export const workbenchOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, workbenchId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, workbenchId, [
       {
         state: 'remove-wrong-tabs-v1',
+        mode: 'upgrade',
         func: removeTabs
       },
       {
         state: 'remove-txes-update-tabs-v1',
+        mode: 'upgrade',
         func: async () => {
           await client.deleteMany(DOMAIN_TX, {
             objectClass: workbench.class.WorkbenchTab,

--- a/packages/model/src/migration.ts
+++ b/packages/model/src/migration.ts
@@ -162,10 +162,10 @@ export interface UpgradeOperations {
  * @public
  */
 export async function tryMigrate (
+  mode: MigrateMode,
   client: MigrationClient,
   plugin: string,
-  migrations: Migrations[],
-  mode: MigrateMode = 'upgrade'
+  migrations: Migrations[]
 ): Promise<void> {
   const states = client.migrateState.get(plugin) ?? new Set()
   for (const migration of migrations) {
@@ -197,11 +197,11 @@ export async function tryMigrate (
  * @public
  */
 export async function tryUpgrade (
+  mode: MigrateMode,
   state: Map<string, Set<string>>,
   client: () => Promise<MigrationUpgradeClient>,
   plugin: string,
-  migrations: UpgradeOperations[],
-  mode: MigrateMode = 'upgrade'
+  migrations: UpgradeOperations[]
 ): Promise<void> {
   const states = state.get(plugin) ?? new Set()
   for (const upgrades of migrations) {

--- a/pods/workspace/download-init-scripts.sh
+++ b/pods/workspace/download-init-scripts.sh
@@ -8,6 +8,7 @@ else
   wget https://github.com/hcengineering/init/archive/refs/heads/${INIT_SCRIPTS_BRANCH}.zip
 fi
 
-unzip ${INIT_SCRIPTS_BRANCH}.zip -d ./temp 
+unzip ${INIT_SCRIPTS_BRANCH}.zip -d ./temp
+rm -rf ./init 
 mv temp/init-${INIT_SCRIPTS_BRANCH} ./init
 rm -rf ./temp

--- a/server/tool/src/index.ts
+++ b/server/tool/src/index.ts
@@ -164,23 +164,27 @@ export async function updateModel (
 
   const migrateState = new Map<string, Set<string>>(sts.map((it) => [it[0], _toSet(it[1])]))
 
-  try {
-    let i = 0
-    for (const op of migrateOperations) {
-      const st = platformNow()
-      await op[1].upgrade(migrateState, async () => connection as any, 'upgrade')
-      const tdelta = platformNowDiff(st)
-      if (tdelta > 0.5) {
-        logger.log('Create', { name: op[0], time: tdelta })
+  await ctx.with('create-upgrade', {}, async () => {
+    try {
+      let i = 0
+      for (const op of migrateOperations) {
+        const st = platformNow()
+        await ctx.with(op[0], {}, async () => {
+          await op[1].upgrade(migrateState, async () => connection as any, mode)
+        })
+        const tdelta = platformNowDiff(st)
+        if (tdelta > 0) {
+          logger.log('Create', { name: op[0], time: tdelta })
+        }
+        i++
+        await progress((((100 / migrateOperations.length) * i) / 100) * 100)
       }
-      i++
-      await progress((((100 / migrateOperations.length) * i) / 100) * 100)
+      await progress(100)
+    } catch (e: any) {
+      logger.error('error', { error: e })
+      throw e
     }
-    await progress(100)
-  } catch (e: any) {
-    logger.error('error', { error: e })
-    throw e
-  }
+  })
 }
 
 /**
@@ -336,7 +340,7 @@ export async function upgradeModel (
     }
 
     if (updateIndexes === 'skip') {
-      await tryMigrate(migrateClient, coreId, [
+      await tryMigrate('upgrade', migrateClient, coreId, [
         {
           state: 'indexes-v5',
           func: upgradeIndexes

--- a/services/github/model-github/src/migration.ts
+++ b/services/github/model-github/src/migration.ts
@@ -127,20 +127,22 @@ async function migrateDocSyncInfo (client: MigrationClient): Promise<void> {
 }
 
 export const githubOperation: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, githubId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, githubId, [
       {
         state: 'pull-requests',
+        mode: 'upgrade',
         func: migratePullRequests
       },
       {
         state: 'update-doc-sync-info',
+        mode: 'upgrade',
         func: migrateDocSyncInfo
       }
     ])
   },
-  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>): Promise<void> {
-    await tryUpgrade(state, client, githubId, [])
+  async upgrade (state: Map<string, Set<string>>, client: () => Promise<MigrationUpgradeClient>, mode): Promise<void> {
+    await tryUpgrade(mode, state, client, githubId, [])
   }
 }
 
@@ -301,36 +303,43 @@ async function processMigrateMarkupFor (
 }
 
 export const githubOperationPreTime: MigrateOperation = {
-  async migrate (client: MigrationClient): Promise<void> {
-    await tryMigrate(client, githubId, [
+  async migrate (client: MigrationClient, mode): Promise<void> {
+    await tryMigrate(mode, client, githubId, [
       {
         state: 'fix-todo-spaces',
+        mode: 'upgrade',
         func: migrateTodoSpaces
       },
       {
         state: 'fix-missing-doc-sync-info',
+        mode: 'upgrade',
         func: migrateFixMissingDocSyncInfo
       },
       {
         state: 'remove-github-components',
+        mode: 'upgrade',
         func: migrateRemoveGithubComponents
       },
       {
         state: 'markup',
+        mode: 'upgrade',
         func: migrateMarkup
       },
       {
         state: 'migrate-missing-states',
+        mode: 'upgrade',
         func: migrateMissingStates
       },
       {
         state: 'remove-doc-sync-info-txes',
+        mode: 'upgrade',
         func: async (client) => {
           await client.deleteMany(DOMAIN_TX, { objectClass: github.class.DocSyncInfo })
         }
       },
       {
         state: 'migrate-github-sync-domain',
+        mode: 'upgrade',
         func: async (client) => {
           await client.move(DOMAIN_GITHUB, { _class: github.class.DocSyncInfo }, DOMAIN_GITHUB_SYNC, 100)
           await client.move(DOMAIN_GITHUB, { _class: github.class.GithubUserInfo }, DOMAIN_GITHUB_USER)

--- a/ws-tests/create-version-override.sh
+++ b/ws-tests/create-version-override.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Define the target version
+VERSION="$1"
+
+# Path to docker-compose.yaml file
+COMPOSE_FILE="./docker-compose.yaml"
+OVERRIDE_FILE="./docker-compose.override.yml"
+
+# Check if docker-compose file exists
+if [ ! -f "$COMPOSE_FILE" ]; then
+    echo "Error: $COMPOSE_FILE not found"
+    exit 1
+fi
+
+# Create override file with header
+echo "# Automatically generated docker-compose override with fixed versions" > $OVERRIDE_FILE
+echo "services:" >> $OVERRIDE_FILE
+
+# Extract hardcoreeng services and add them to the override file with fixed versions
+grep -B 1 "image: hardcoreeng/" $COMPOSE_FILE | grep -v "\-\-" | grep -v "image:" | sed 's/:$//g' | while read -r service; do
+    service=$(echo $service | tr -d ' ')
+    if [ -n "$service" ]; then
+        echo "  $service:" >> $OVERRIDE_FILE
+        
+        # Get the image name
+        image=$(grep -A 1 "$service:" $COMPOSE_FILE | grep "image: hardcoreeng/" | awk '{print $2}')
+        pod_name=$(echo $image | sed 's/hardcoreeng\///')
+        
+        echo "    image: hardcoreeng/$pod_name:$VERSION" >> $OVERRIDE_FILE
+        if [ "$pod_name" == "account" ]; then
+          echo "    environment:" >> $OVERRIDE_FILE
+          echo "      - REGION_INFO=|;europe|Europe" >> $OVERRIDE_FILE
+        fi
+    fi
+done
+
+echo "Created $OVERRIDE_FILE with fixed version $VERSION for all hardcoreeng services"
+echo "To use it, run: prepare.sh"
+

--- a/ws-tests/fetch-tool-bundle.sh
+++ b/ws-tests/fetch-tool-bundle.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+# Define the path to the docker-compose.override.yml
+DOCKER_COMPOSE_PATH="./docker-compose.override.yml"
+
+# Extract the version of hardcoreeng/transactor from the docker-compose file
+VERSION=$(grep "image: hardcoreeng/transactor:" "$DOCKER_COMPOSE_PATH" | head -1 | sed -E 's/.*image: hardcoreeng\/transactor:([^[:space:]]+).*/\1/')
+
+if [ -z "$VERSION" ]; then
+  echo "Error: Could not find transactor version in docker-compose file"
+  exit 1
+fi
+
+echo "Found transactor version: $VERSION"
+echo "Fetching hardcoreeng/tool:$VERSION..."
+
+# Pull the tool image with the same version
+docker pull "hardcoreeng/tool:$VERSION"
+
+# Create a temporary container from the image
+CONTAINER_ID=$(docker container create "hardcoreeng/tool:$VERSION")
+
+# Extract bundle.js from the container
+echo "Extracting bundle.js..."
+docker cp "$CONTAINER_ID:/usr/src/app/bundle.js" "bundle.js"
+
+# Clean up the temporary container
+docker rm "$CONTAINER_ID"
+
+echo "Successfully extracted bundle.js to bundle.js"

--- a/ws-tests/prepare.sh
+++ b/ws-tests/prepare.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 
-docker compose -p sanity kill
-docker compose -p sanity down --volumes
-docker compose -p sanity up -d --force-recreate --renew-anon-volumes
+
+
+# Check if docker-compose.override.yml exists
+if [ -f "docker-compose.override.yml" ]; then
+    echo "Using docker-compose.override.yml"
+    docker compose -p sanity -f docker-compose.yaml -f docker-compose.override.yml kill
+    docker compose -p sanity -f docker-compose.yaml -f docker-compose.override.yml down --volumes
+    docker compose -p sanity -f docker-compose.yaml -f docker-compose.override.yml up -d --force-recreate --renew-anon-volumes
+else
+    docker compose -p sanity kill
+    docker compose -p sanity down --volumes
+    docker compose -p sanity up -d --force-recreate --renew-anon-volumes
+fi
 docker_exit=$?
 if [ ${docker_exit} -eq 0 ]; then
     echo "Container started successfully"

--- a/ws-tests/pull-images.sh
+++ b/ws-tests/pull-images.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Function to handle interrupt
+handle_interrupt() {
+  echo -e "\nInterrupt received. Exiting..."
+  exit 1
+}
+
+# Set trap for Ctrl+C (SIGINT)
+trap handle_interrupt INT
+
+# Path to docker-compose override file
+OVERRIDE_FILE="./docker-compose.override.yml"
+
+# Check if override file exists
+if [ ! -f "$OVERRIDE_FILE" ]; then
+  echo "Error: $OVERRIDE_FILE not found"
+  exit 1
+fi
+
+echo "Pulling images specified in $OVERRIDE_FILE..."
+
+# Extract all images from the override file without using a pipe to a subshell
+images=($(grep "image:" $OVERRIDE_FILE | awk '{print $2}'))
+
+# Pull each image
+for image in "${images[@]}"; do
+  if [ -n "$image" ]; then
+    echo "Pulling $image..."
+    docker pull $image 2>&1 | grep -v "What's next:" | grep -v "docker scout"
+    pull_status=${PIPESTATUS[0]}
+    if [ $pull_status -ne 0 ]; then
+      echo "Failed to pull $image"
+    else
+      echo "Successfully pulled $image"
+    fi
+  fi
+done
+
+echo "All images have been processed."

--- a/ws-tests/reset-version.sh
+++ b/ws-tests/reset-version.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+rm -rf ./docker-compose.override.yml
+rm -rf ./bundle.js

--- a/ws-tests/tool-europe.sh
+++ b/ws-tests/tool-europe.sh
@@ -16,4 +16,10 @@ export DB_URL=postgresql://root@localhost:26258/defaultdb?sslmode=disable
 export REGION_INFO="|America;europe|" # Europe without name will not be available for creation of new workspaces.
 export TRANSACTOR_URL="ws://transactor:3334;ws://localhost:3334,ws://transactor-europe:3335;ws://localhost:3335;europe,"
 
-node ${TOOL_OPTIONS} --max-old-space-size=8096 ../dev/tool/bundle/bundle.js $@
+# Check if local bundle.js exists and use it if available
+BUNDLE_PATH="../dev/tool/bundle/bundle.js"
+if [ -f "./bundle.js" ]; then
+  BUNDLE_PATH="./bundle.js"
+fi
+
+node ${TOOL_OPTIONS} --max-old-space-size=8096 $BUNDLE_PATH $@

--- a/ws-tests/tool.sh
+++ b/ws-tests/tool.sh
@@ -13,4 +13,10 @@ export ELASTIC_URL=http://localhost:9201
 export SERVER_SECRET=secret
 export DB_URL=$MONGO_URL
 
-node ${TOOL_OPTIONS} --max-old-space-size=8096 ../dev/tool/bundle/bundle.js $@
+# Check if local bundle.js exists and use it if available
+BUNDLE_PATH="../dev/tool/bundle/bundle.js"
+if [ -f "./bundle.js" ]; then
+  BUNDLE_PATH="./bundle.js"
+fi
+
+node ${TOOL_OPTIONS} --max-old-space-size=8096 $BUNDLE_PATH $@


### PR DESCRIPTION
UBERF-9633: Use proper split of create/upgrade in migrations