### PR TITLE
Potential fix for code scanning alert no. 98: Use of a broken or weak cryptographic algorithm

### DIFF
--- a/server/ws/src/rpc.ts
+++ b/server/ws/src/rpc.ts
@@ -53,7 +53,7 @@ async function sendJson (
   // Calculate ETag
   let body: any = JSON.stringify(result, rpcJSONReplacer)
 
-  const etag = createHash('sha1').update(body).digest('hex')
+  const etag = createHash('sha256').update(body).digest('hex')
   const headers: OutgoingHttpHeaders = {
     ...(extraHeaders ?? {}),
     'Content-Type': 'application/json',


### PR DESCRIPTION
Potential fix for [https://github.com/hcengineering/platform/security/code-scanning/98](https://github.com/hcengineering/platform/security/code-scanning/98)

To fix the problem, we need to replace the SHA-1 hashing algorithm with a stronger one, such as SHA-256. This involves changing the `createHash` function call to use 'sha256' instead of 'sha1'. This change will ensure that the ETag is generated using a more secure hashing algorithm.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
