### PR TITLE
qfix: upload a folder produces duplicates

### DIFF
--- a/plugins/uploader-resources/src/utils.ts
+++ b/plugins/uploader-resources/src/utils.ts
@@ -155,7 +155,7 @@ export async function uploadFile (
         if (uuid !== undefined && onFileUploaded !== undefined) {
           try {
             void callbackLimiter.exec(async () => {
-              void onFileUploaded({
+              await onFileUploaded({
                 type: metadata.type,
                 uuid,
                 name: metadata.name,


### PR DESCRIPTION
upload of folder with content may produce duplicates.

Example:

upload target:

```
folder1/file1
       /file2
```

upload result

```
folder1/file1
folder1/file2
```