### PR TITLE
CSS fix: prevent underlining when hovering buttons within links

### DIFF
--- a/packages/theme/styles/_layouts.scss
+++ b/packages/theme/styles/_layouts.scss
@@ -21,26 +21,34 @@ a {
   text-decoration: none;
   color: var(--theme-content-color);
   outline: none;
+  
   &:hover {
     color: var(--theme-caption-color);
-    text-decoration: underline;
+    
+    &:not(:has(button)):not(.stealth):not(.no-underline) {
+      text-decoration: underline;
+    }
   }
+  
   &:active {
     color: var(--theme-content-color);
-    text-decoration: underline;
+    
+    &:not(:has(button)):not(.stealth):not(.no-underline) {
+      text-decoration: underline;
+    }
   }
-  &:visited { color: var(--theme-content-color); }
-
-  &.stealth,
-  &.no-underline {
-    &:hover, &:active { text-decoration: none; }
+  
+  &:visited { 
+    color: var(--theme-content-color); 
   }
+  
   &.stealth {
     display: inline-flex;
     align-items: center;
     width: 100%;
   }
 }
+
 button {
   display: flex;
   justify-content: center;

--- a/plugins/workbench-resources/src/components/HelpAndSupport.svelte
+++ b/plugins/workbench-resources/src/components/HelpAndSupport.svelte
@@ -246,6 +246,7 @@
     align-items: flex-end;
     margin: 0 0.5rem 0.5rem;
     padding-top: 0.625rem;
+    gap: 0.25rem;
   }
   .key-box {
     padding: 0 0.5rem;


### PR DESCRIPTION
I noticed that when hovering over a button wrapped in a link, text underlining appears. Therefore, I've modified the link styles so that underlining is only applied when there is no button inside the link.

### Before

https://github.com/user-attachments/assets/dd76396d-7527-40f3-8a2b-12496e791a8c

### After

https://github.com/user-attachments/assets/88f27ef1-cb6c-40d0-a46f-9fe99480dff4

