### PR TITLE
Bug fix

### DIFF
--- a/plugins/tracker-resources/src/components/CreateIssue.svelte
+++ b/plugins/tracker-resources/src/components/CreateIssue.svelte
@@ -957,7 +957,7 @@
         addTagRef(evt.detail)
       }}
       on:delete={(evt) => {
-        object.labels = object.labels.filter((it) => it._id !== evt.detail)
+        object.labels = object.labels.filter((it) => it.tag !== evt.detail)
       }}
     />
     <ComponentSelector


### PR DESCRIPTION
When creating an issue tracker, the dispatch command wasn't removing the tag and consequently not counting the labels properly

The bug was as a result of using the `_id`  key in the object as opposed to the `tag` key in the `objects.labels` filter

closes #8071