### PR TITLE
fix: handle token errors in front service

### DIFF
--- a/server/front/src/index.ts
+++ b/server/front/src/index.ts
@@ -525,6 +525,10 @@ export function start (
             )
           }
         } catch (error: any) {
+          if (error instanceof TokenError) {
+            res.status(401).send()
+            return
+          }
           if (
             error?.code === 'NoSuchKey' ||
             error?.code === 'NotFound' ||
@@ -633,6 +637,10 @@ export function start (
 
       res.status(200).send()
     } catch (error: any) {
+      if (error instanceof TokenError) {
+        res.status(401).send()
+        return
+      }
       Analytics.handleError(error)
       ctx.error('failed to delete', { url: req.url })
       res.status(500).send()

--- a/server/token/src/token.ts
+++ b/server/token/src/token.ts
@@ -45,7 +45,11 @@ export function generateToken (
  * @public
  */
 export function decodeToken (token: string, verify: boolean = true, secret?: string): Token {
-  return decode(token, secret ?? getSecret(), !verify)
+  try {
+    return decode(token, secret ?? getSecret(), !verify)
+  } catch (err: any) {
+    throw new TokenError(err.message)
+  }
 }
 
 /**


### PR DESCRIPTION
get rid of multiple errors reported to sentry