### PR TITLE
UBERF-9727: Allow adding social id to existing person

### DIFF
--- a/packages/account-client/src/client.ts
+++ b/packages/account-client/src/client.ts
@@ -126,6 +126,7 @@ export interface AccountClient {
     firstName: string,
     lastName: string
   ) => Promise<{ uuid: PersonUuid, socialId: PersonId }>
+  addSocialIdToPerson: (person: PersonUuid, type: SocialIdType, value: string, confirmed: boolean) => Promise<PersonId>
 
   setCookie: () => Promise<void>
   deleteCookie: () => Promise<void>
@@ -639,6 +640,20 @@ class AccountClientImpl implements AccountClient {
     const request = {
       method: 'ensurePerson' as const,
       params: { socialType, socialValue, firstName, lastName }
+    }
+
+    return await this.rpc(request)
+  }
+
+  async addSocialIdToPerson (
+    person: PersonUuid,
+    type: SocialIdType,
+    value: string,
+    confirmed: boolean
+  ): Promise<PersonId> {
+    const request = {
+      method: 'addSocialIdToPerson' as const,
+      params: { person, type, value, confirmed }
     }
 
     return await this.rpc(request)

--- a/packages/platform/src/platform.ts
+++ b/packages/platform/src/platform.ts
@@ -163,7 +163,8 @@ export default plugin(platformId, {
     WorkspaceLimitReached: '' as StatusCode<{ workspace: string }>,
     InvalidOtp: '' as StatusCode,
     InviteNotFound: '' as StatusCode<{ email: string }>,
-    MailboxError: '' as StatusCode<{ reason: string }>
+    MailboxError: '' as StatusCode<{ reason: string }>,
+    SocialIdAlreadyExists: '' as StatusCode
   },
   metadata: {
     locale: '' as Metadata<string>,

--- a/server/account/src/__tests__/operations.test.ts
+++ b/server/account/src/__tests__/operations.test.ts
@@ -13,14 +13,13 @@
 // limitations under the License.
 //
 
-// src/__tests__/operations.test.ts
-
-import { AccountRole, MeasureContext, PersonUuid, WorkspaceUuid } from '@hcengineering/core'
+import { AccountRole, MeasureContext, PersonId, PersonUuid, SocialIdType, WorkspaceUuid } from '@hcengineering/core'
 import platform, { PlatformError, Status, Severity, getMetadata } from '@hcengineering/platform'
 import { decodeTokenVerbose } from '@hcengineering/server-token'
+import * as utils from '../utils'
 
 import { AccountDB } from '../types'
-import { createInvite, createInviteLink, sendInvite, resendInvite } from '../operations'
+import { createInvite, createInviteLink, sendInvite, resendInvite, addSocialIdToPerson } from '../operations'
 import { accountPlugin } from '../plugin'
 
 // Mock platform
@@ -452,6 +451,108 @@ describe('invite operations', () => {
 
       expect(mockDb.invite.insertOne).toHaveBeenCalled()
       expect(global.fetch).toHaveBeenCalled()
+    })
+  })
+
+  describe('addSocialIdToPerson', () => {
+    const mockCtx = {
+      error: jest.fn()
+    } as unknown as MeasureContext
+
+    const mockDb = {} as unknown as AccountDB
+    const mockBranding = null
+    const mockToken = 'test-token'
+
+    // Create spy only for this test suite
+    const addSocialIdSpy = jest.spyOn(utils, 'addSocialId')
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    afterAll(() => {
+      // Restore the original implementation
+      addSocialIdSpy.mockRestore()
+    })
+
+    test('should allow github service to add social id', async () => {
+      ;(decodeTokenVerbose as jest.Mock).mockReturnValue({
+        extra: { service: 'github' }
+      })
+      const newSocialId = 'new-social-id' as PersonId
+      addSocialIdSpy.mockResolvedValue(newSocialId)
+
+      const params = {
+        person: 'test-person' as PersonUuid,
+        type: SocialIdType.GITHUB,
+        value: 'test-value',
+        confirmed: true
+      }
+
+      const result = await addSocialIdToPerson(mockCtx, mockDb, mockBranding, mockToken, params)
+
+      expect(result).toBe(newSocialId)
+      expect(addSocialIdSpy).toHaveBeenCalledWith(mockDb, params.person, params.type, params.value, params.confirmed)
+    })
+
+    test('should allow admin to add social id', async () => {
+      ;(decodeTokenVerbose as jest.Mock).mockReturnValue({
+        extra: { admin: 'true' }
+      })
+      const newSocialId = 'new-social-id' as PersonId
+      addSocialIdSpy.mockResolvedValue(newSocialId)
+
+      const params = {
+        person: 'test-person' as PersonUuid,
+        type: SocialIdType.GITHUB,
+        value: 'test-value',
+        confirmed: false
+      }
+
+      const result = await addSocialIdToPerson(mockCtx, mockDb, mockBranding, mockToken, params)
+
+      expect(result).toBe(newSocialId)
+      expect(addSocialIdSpy).toHaveBeenCalledWith(mockDb, params.person, params.type, params.value, params.confirmed)
+    })
+
+    test('should throw error for unauthorized service', async () => {
+      ;(decodeTokenVerbose as jest.Mock).mockReturnValue({
+        extra: { service: 'other-service' }
+      })
+
+      const params = {
+        person: 'test-person' as PersonUuid,
+        type: SocialIdType.GITHUB,
+        value: 'test-value',
+        confirmed: false
+      }
+
+      await expect(addSocialIdToPerson(mockCtx, mockDb, mockBranding, mockToken, params)).rejects.toThrow(
+        new PlatformError(new Status(Severity.ERROR, platform.status.Forbidden, {}))
+      )
+
+      expect(addSocialIdSpy).not.toHaveBeenCalled()
+    })
+
+    test('should throw error for regular user', async () => {
+      ;(decodeTokenVerbose as jest.Mock).mockReturnValue({
+        account: 'test-account',
+        workspace: 'test-workspace',
+        extra: {}
+      })
+
+      const params = {
+        person: 'test-person' as PersonUuid,
+        type: SocialIdType.GITHUB,
+        value: 'test-value',
+        confirmed: false
+      }
+
+      await expect(addSocialIdToPerson(mockCtx, mockDb, mockBranding, mockToken, params)).rejects.toThrow(
+        new PlatformError(new Status(Severity.ERROR, platform.status.Forbidden, {}))
+      )
+
+      expect(addSocialIdSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/server/account/src/operations.ts
+++ b/server/account/src/operations.ts
@@ -101,7 +101,8 @@ import {
   getWorkspaceRole,
   normalizeValue,
   isEmail,
-  generatePassword
+  generatePassword,
+  addSocialId
 } from './utils'
 
 // Move to config?
@@ -2107,6 +2108,21 @@ async function deleteMailbox (
   ctx.info('Mailbox deleted', { mailbox, account })
 }
 
+export async function addSocialIdToPerson (
+  ctx: MeasureContext,
+  db: AccountDB,
+  branding: Branding | null,
+  token: string,
+  params: { person: PersonUuid, type: SocialIdType, value: string, confirmed: boolean }
+): Promise<PersonId> {
+  const { person, type, value, confirmed } = params
+  const { extra } = decodeTokenVerbose(ctx, token)
+
+  verifyAllowedServices(['github'], extra)
+
+  return await addSocialId(db, person, type, value, confirmed)
+}
+
 async function releaseSocialId (
   db: AccountDB,
   personUuid: PersonUuid,
@@ -2169,6 +2185,7 @@ export type AccountMethods =
   | 'createMailbox'
   | 'getMailboxes'
   | 'deleteMailbox'
+  | 'addSocialIdToPerson'
 
 /**
  * @public
@@ -2228,7 +2245,8 @@ export function getMethods (hasSignUp: boolean = true): Partial<Record<AccountMe
     listWorkspaces: wrap(listWorkspaces),
     performWorkspaceOperation: wrap(performWorkspaceOperation),
     updateWorkspaceRoleBySocialKey: wrap(updateWorkspaceRoleBySocialKey),
-    ensurePerson: wrap(ensurePerson)
+    ensurePerson: wrap(ensurePerson),
+    addSocialIdToPerson: wrap(addSocialIdToPerson)
   }
 }
 


### PR DESCRIPTION
* Added new `addSocialIdToPerson` method to the accounts service

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-9727