### PR TITLE
Fix the description of a user creation in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,22 +160,6 @@ sh ./scripts/build.sh
 
 By default, Docker volumes named dev_db, dev_elastic, and dev_files will be created for the MongoDB, Elasticsearch, and MinIO instances.
 
-Before you can begin, you need to create a workspace and an account and associate it with the workspace.
-
-```bash
-cd ./tool # dev/tool in the repository root
-rushx run-local create-account user1 -p 1234 -f John -l Appleseed # Create account
-rushx run-local create-workspace ws1 email:user1 # Create workspace
-rushx run-local configure ws1 --list --enable '*' # Enable all modules, even if they are not yet intended to be used by a wide audience
-rushx run-local assign-workspace user1 ws1 # Assign user to workspace
-```
-
-Alternatively, you can just execute:
-
-```bash
-sh ./scripts/create-workspace.sh
-```
-
 Add the following line to your /etc/hosts file
 
 ```plain
@@ -201,13 +185,7 @@ rushx dev-server
 
 Then go to <http://localhost:8080>
 
-Click on "Login with password" link on the bottom of the right panel and use the following login credentials:
-
-```plain
-Email: user1
-Password: 1234
-Workspace: ws1
-```
+Select "Sign up" on the right panel and click the "Sign up with password" link at the bottom. Enter the new user's credentials, then proceed to create a workspace for them.
 
 ## Update project structure and database
 

--- a/scripts/create-workspace.sh
+++ b/scripts/create-workspace.sh
@@ -1,5 +1,0 @@
-cd ./dev/tool
-rushx run-local create-account user1 -p 1234 -f John -l Appleseed # Create account
-rushx run-local create-workspace ws1 email:user1
-rushx run-local configure ws1 --list --enable '*' # Enable all modules, even if they are not yet intended to be used by a wide audience.
-rushx run-local assign-workspace user1 ws1 # Assign workspace to user.


### PR DESCRIPTION
The previous utilities and script for creating users and workspaces are not functioning properly, so the README now suggests creating them via the web UI. To eliminate the temptation to use the wrong approach, the create-workspace.sh script has also been removed.