### PR TITLE
UBERF-10346: Combined ensure person

### DIFF
--- a/desktop/src/main/start.ts
+++ b/desktop/src/main/start.ts
@@ -136,9 +136,10 @@ function hookOpenWindow (window: BrowserWindow): void {
 }
 
 function setupCookieHandler (config: Config): void {
+  const normalizedAccountsUrl = config.ACCOUNTS_URL.endsWith('/') ? config.ACCOUNTS_URL : config.ACCOUNTS_URL + '/'
   const urls = [
-    config.ACCOUNTS_URL,
-    config.ACCOUNTS_URL + '*'
+    normalizedAccountsUrl,
+    normalizedAccountsUrl + '*'
   ]
 
   session.defaultSession.webRequest.onHeadersReceived({ urls }, handleSetCookie)

--- a/packages/api-client/src/rest/rest.ts
+++ b/packages/api-client/src/rest/rest.ts
@@ -25,10 +25,13 @@ import {
   Hierarchy,
   MeasureMetricsContext,
   ModelDb,
+  PersonId,
+  PersonUuid,
   type Ref,
   type SearchOptions,
   type SearchQuery,
   type SearchResult,
+  SocialIdType,
   type Tx,
   type TxResult,
   type WithLookup
@@ -236,5 +239,29 @@ export class RestClientImpl implements RestClient {
       throw new PlatformError(unknownError(response.statusText))
     }
     return await extractJson<TxResult>(response)
+  }
+
+  async ensurePerson (
+    socialType: SocialIdType,
+    socialValue: string,
+    firstName: string,
+    lastName: string
+  ): Promise<{ uuid: PersonUuid, socialId: PersonId, localPerson: string }> {
+    const requestUrl = concatLink(this.endpoint, `/api/v1/ensure-person/${this.workspace}`)
+    const response = await fetch(requestUrl, {
+      method: 'POST',
+      headers: this.jsonHeaders(),
+      keepalive: true,
+      body: JSON.stringify({
+        socialType,
+        socialValue,
+        firstName,
+        lastName
+      })
+    })
+    if (!response.ok) {
+      throw new PlatformError(unknownError(response.statusText))
+    }
+    return await extractJson<{ uuid: PersonUuid, socialId: PersonId, localPerson: string }>(response)
   }
 }

--- a/packages/api-client/src/rest/types.ts
+++ b/packages/api-client/src/rest/types.ts
@@ -14,6 +14,9 @@
 //
 
 import {
+  PersonId,
+  PersonUuid,
+  SocialIdType,
   type Account,
   type Class,
   type Doc,
@@ -36,4 +39,10 @@ export interface RestClient extends Storage {
   ) => Promise<WithLookup<T> | undefined>
 
   getModel: () => Promise<{ hierarchy: Hierarchy, model: ModelDb }>
+  ensurePerson: (
+    socialType: SocialIdType,
+    socialValue: string,
+    firstName: string,
+    lastName: string
+  ) => Promise<{ uuid: PersonUuid, socialId: PersonId, localPerson: string }>
 }

--- a/pods/server/src/rpc.ts
+++ b/pods/server/src/rpc.ts
@@ -133,7 +133,12 @@ export function registerRPC (app: Express, sessions: SessionManager, ctx: Measur
   async function withSession (
     req: Request,
     res: ExpressResponse,
-    operation: (ctx: ClientSessionCtx, session: Session, rateLimit: RateLimitInfo | undefined, token: string) => Promise<void>
+    operation: (
+      ctx: ClientSessionCtx,
+      session: Session,
+      rateLimit: RateLimitInfo | undefined,
+      token: string
+    ) => Promise<void>
   ): Promise<void> {
     try {
       if (req.params.workspaceId === undefined || req.params.workspaceId === '') {

--- a/pods/server/src/server_http.ts
+++ b/pods/server/src/server_http.ts
@@ -396,7 +396,7 @@ export function startHttpServer (
     })
   )
 
-  registerRPC(app, sessions, ctx)
+  registerRPC(app, sessions, ctx, accountsUrl)
 
   app.put('/api/v1/broadcast', (req, res) => {
     try {

--- a/ws-tests/api-tests/src/__tests__/rest.test.ts
+++ b/ws-tests/api-tests/src/__tests__/rest.test.ts
@@ -22,25 +22,27 @@ import {
   type WorkspaceToken
 } from '@hcengineering/api-client'
 import core, {
+  buildSocialIdString,
   generateId,
   MeasureMetricsContext,
   pickPrimarySocialId,
+  SocialIdType,
+  type Ref,
   type SocialId,
   type Space,
   type TxCreateDoc,
   type TxOperations
 } from '@hcengineering/core'
-
-import { getClient as getAccountClient } from '@hcengineering/account-client'
-
+import { type AccountClient, getClient as getAccountClient } from '@hcengineering/account-client'
 import chunter from '@hcengineering/chunter'
-import contact, { ensureEmployee } from '@hcengineering/contact'
+import contact, { ensureEmployee, type SocialIdentityRef, type Person } from '@hcengineering/contact'
 
 describe('rest-api-server', () => {
   const testCtx = new MeasureMetricsContext('test', {})
   const wsName = 'api-tests'
   let apiWorkspace1: WorkspaceToken
   let apiWorkspace2: WorkspaceToken
+  let accountClient: AccountClient
 
   beforeAll(async () => {
     const config = await loadServerConfig('http://huly.local:8083')
@@ -65,10 +67,10 @@ describe('rest-api-server', () => {
       config
     )
 
-    const account = getAccountClient(config.ACCOUNTS_URL, apiWorkspace1.token)
-    const person = await account.getPerson()
+    accountClient = getAccountClient(config.ACCOUNTS_URL, apiWorkspace1.token)
+    const person = await accountClient.getPerson()
 
-    const socialIds: SocialId[] = await account.getSocialIds()
+    const socialIds: SocialId[] = await accountClient.getSocialIds()
 
     // Ensure employee is created
 
@@ -214,7 +216,35 @@ describe('rest-api-server', () => {
     expect(employee.length).toBeGreaterThanOrEqual(1)
     expect(employee[0].active).toBe(true)
   })
+
+  it('ensure-person', async () => {
+    const socialType = SocialIdType.TELEGRAM
+    const socialValue = '123456789'
+    const first = 'John'
+    const last = 'Doe'
+    const conn = connect()
+    const { uuid, socialId, localPerson } = await conn.ensurePerson(socialType, socialValue, first, last)
+    const globalPerson = await accountClient.findPersonBySocialKey(
+      buildSocialIdString({ type: socialType, value: socialValue })
+    )
+
+    expect(globalPerson).toBe(uuid)
+
+    const person = await conn.findOne(contact.class.Person, { _id: localPerson as Ref<Person>, personUuid: uuid })
+
+    expect(person).not.toBeNull()
+
+    const socialIdObj = await conn.findOne(contact.class.SocialIdentity, {
+      type: socialType,
+      value: socialValue,
+      attachedTo: person?._id,
+      _id: socialId as SocialIdentityRef
+    })
+
+    expect(socialIdObj).not.toBeNull()
+  })
 })
+
 async function checkFindPerformance (conn: RestClient): Promise<void> {
   let ops = 0
   let total = 0

--- a/ws-tests/docker-compose.yaml
+++ b/ws-tests/docker-compose.yaml
@@ -384,7 +384,6 @@ services:
       - STATS_URL=http://huly.local:4901
       - REKONI_URL=http://huly.local:4007
       - ACCOUNTS_URL=http://huly.local:3003
-      - SERVER_SECRET=secret
     restart: unless-stopped
   aiBot:
     image: hardcoreeng/ai-bot

--- a/ws-tests/prepare.sh
+++ b/ws-tests/prepare.sh
@@ -28,13 +28,18 @@ fi
 
 ./wait-elastic.sh 9201
 
-# Create user record in accounts
+echo "Creating user accounts..."
 ./tool.sh create-account admin -f Super -l Admin -p 1234
 ./tool.sh create-account user1 -f John -l Appleseed -p 1234
 ./tool.sh create-account user2 -f Kainin -l Dirak -p 1234
 
+echo "Creating workspace api-tests..."
 ./tool.sh create-workspace api-tests email:user1
+
+echo "Creating workspace api-tests-cr..."
 ./tool-europe.sh create-workspace api-tests-cr email:user1 --region 'europe'
+
+echo "Assigning user1 to workspaces..."
 ./tool.sh assign-workspace user1 api-tests
 ./tool.sh assign-workspace user1 api-tests-cr
 


### PR DESCRIPTION
* Added ensure person to REST API which ensures the user both globally in accounts and locally in the workspace

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-10346
Closes https://github.com/hcengineering/platform/issues/8695