### PR TITLE
Support fulltext search api in REST api-client

### DIFF
--- a/packages/api-client/src/rest/rest.ts
+++ b/packages/api-client/src/rest/rest.ts
@@ -229,7 +229,7 @@ export class RestClientImpl implements RestClient {
     if (options.limit != null) {
       params.append('limit', `${options.limit}`)
     }
-    const requestUrl = concatLink(this.endpoint, `/api/v1/search-fulltext/${this.workspace}?${params}`)
+    const requestUrl = concatLink(this.endpoint, `/api/v1/search-fulltext/${this.workspace}?${params.toString()}`)
     const response = await fetch(requestUrl, {
       method: 'GET',
       headers: this.jsonHeaders(),

--- a/packages/api-client/src/rest/rest.ts
+++ b/packages/api-client/src/rest/rest.ts
@@ -229,7 +229,7 @@ export class RestClientImpl implements RestClient {
     if (options.limit != null) {
       params.append('limit', `${options.limit}`)
     }
-    const requestUrl = concatLink(this.endpoint, `/api/v1/search-fulltext/${this.workspace}`)
+    const requestUrl = concatLink(this.endpoint, `/api/v1/search-fulltext/${this.workspace}?${params}`)
     const response = await fetch(requestUrl, {
       method: 'GET',
       headers: this.jsonHeaders(),

--- a/packages/api-client/src/rest/types.ts
+++ b/packages/api-client/src/rest/types.ts
@@ -22,6 +22,7 @@ import {
   type Doc,
   type DocumentQuery,
   type FindOptions,
+  type FulltextStorage,
   type Hierarchy,
   type ModelDb,
   type Ref,
@@ -29,7 +30,7 @@ import {
   type WithLookup
 } from '@hcengineering/core'
 
-export interface RestClient extends Storage {
+export interface RestClient extends Storage, FulltextStorage {
   getAccount: () => Promise<Account>
 
   findOne: <T extends Doc>(


### PR DESCRIPTION
Fulltext api was mostly implemented in REST client, but was not declared in interface