### PR TITLE
fix: add more logs do collaborator doc saving

### DIFF
--- a/server/collaborator/src/extensions/authentication.ts
+++ b/server/collaborator/src/extensions/authentication.ts
@@ -40,7 +40,12 @@ export class AuthenticationExtension implements Extension {
       const token = decodeToken(data.token)
       const readonly = isGuest(token)
 
-      ctx.info('authenticate', { workspaceId, mode: token.extra?.mode ?? '', readonly })
+      ctx.info('authenticate', {
+        workspaceId,
+        account: token.account,
+        mode: token.extra?.mode ?? '',
+        readonly
+      })
 
       if (readonly) {
         data.connection.readOnly = true

--- a/server/collaborator/src/storage/platform.ts
+++ b/server/collaborator/src/storage/platform.ts
@@ -44,6 +44,7 @@ export class PlatformStorageAdapter implements CollabStorageAdapter {
       })
 
       if (ydoc !== undefined) {
+        ctx.info('loaded from storage', { documentName })
         return ydoc
       }
     } catch (err: any) {
@@ -69,6 +70,7 @@ export class PlatformStorageAdapter implements CollabStorageAdapter {
           // it to ensure the next time we load it from the ydoc document
           await saveCollabYdoc(ctx, this.storage, wsIds, documentId, ydoc)
 
+          ctx.info('loaded from initial content', { documentName, content })
           return ydoc
         }
       } catch (err: any) {


### PR DESCRIPTION
Still trying to catch issue when document is saved on open.

1. Add more logging for document loading/saving
2. Do not save loading documents on disconnect