### PR TITLE
chore: Remove deprecated types packages from dependencies

### DIFF
--- a/packages/importer/package.json
+++ b/packages/importer/package.json
@@ -37,7 +37,6 @@
     "@types/jest": "^29.5.5",
     "@types/node": "~20.11.16",
     "@types/mime-types": "~2.1.1",
-    "@types/csvtojson": "^2.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/uuid": "^8.3.1"
   },

--- a/pods/front/package.json
+++ b/pods/front/package.json
@@ -50,7 +50,6 @@
     "cross-env": "~7.0.3",
     "ts-node": "^10.8.0",
     "@types/compression": "~1.7.2",
-    "@types/sharp": "~0.32.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "@types/jest": "^29.5.5"

--- a/server/front/package.json
+++ b/server/front/package.json
@@ -40,7 +40,6 @@
     "@types/body-parser": "~1.19.2",
     "cross-env": "~7.0.3",
     "ts-node": "^10.8.0",
-    "@types/sharp": "~0.32.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "@types/jest": "^29.5.5",

--- a/services/datalake/pod-datalake/package.json
+++ b/services/datalake/pod-datalake/package.json
@@ -53,7 +53,6 @@
     "prettier": "^3.1.0",
     "ts-node": "^10.8.0",
     "typescript": "^5.3.3",
-    "@types/sharp": "~0.32.0",
     "@types/morgan": "~1.9.9",
     "@types/on-headers": "^1.0.2"
   },

--- a/services/rekoni/package.json
+++ b/services/rekoni/package.json
@@ -41,10 +41,7 @@
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
     "@types/html-to-text": "^8.1.1",
-    "@types/jimp": "^0.2.28",
     "@types/node": "~20.11.16",
-    "@types/pdfjs-dist": "2.10.378",
-    "@types/sharp": "~0.32.0",
     "node-loader": "~2.0.0",
     "@types/body-parser": "~1.19.2",
     "@types/mime-types": "~2.1.1",
@@ -70,7 +67,6 @@
   "dependencies": {
     "@anticrm/skillset": "^0.6.0",
     "@hcengineering/core": "^0.6.32",
-    "@types/email-addresses": "^3.0.0",
     "body-parser": "^1.20.3",
     "cors": "^2.8.5",
     "dotenv": "~16.0.0",


### PR DESCRIPTION
These packages are already stub only and do not affect anything, some are very outdated, will remove some `rush update` warnings