### PR TITLE
UBEF-10370 Collaborator fixes

### DIFF
--- a/plugins/text-editor-resources/src/components/CollaborativeTextEditor.svelte
+++ b/plugins/text-editor-resources/src/components/CollaborativeTextEditor.svelte
@@ -131,7 +131,7 @@
   const content = getAttribute(client, object, attribute)
   const collaborativeDoc = makeDocCollabId(object, objectAttr)
 
-  const ydoc = getContext<YDoc>(CollaborationIds.Doc) ?? new YDoc({ guid: generateId() })
+  const ydoc = getContext<YDoc>(CollaborationIds.Doc) ?? new YDoc({ guid: generateId(), gc: false })
   const contextProvider = getContext<Provider>(CollaborationIds.Provider)
 
   const localProvider = createLocalProvider(ydoc, collaborativeDoc)
@@ -412,7 +412,7 @@
   function getSavedBoard (id: string): SavedBoard {
     let board = savedBoards[id]
     if (board === undefined) {
-      const ydoc = new YDoc({ guid: id })
+      const ydoc = new YDoc({ guid: id, gc: false })
       // We don't have a real class for boards,
       // but collaborator only needs a string id
       // which is produced from such an id-object
@@ -448,6 +448,10 @@
         })
       )
     }
+
+    // it is recommended to wait for the local provider to be loaded
+    // https://discuss.yjs.dev/t/initial-offline-value-of-a-shared-document/465/4
+    await localProvider.loaded
 
     editor = new Editor({
       enableContentCheck: true,

--- a/server/collaborator/src/config.ts
+++ b/server/collaborator/src/config.ts
@@ -21,6 +21,8 @@ export interface Config {
   Secret: string
 
   Interval: number
+  StorageRetryCount: number
+  StorageRetryInterval: number
 
   Port: number
 
@@ -32,7 +34,9 @@ const envMap: { [key in keyof Config]: string } = {
   Secret: 'SECRET',
   Interval: 'INTERVAL',
   Port: 'COLLABORATOR_PORT',
-  AccountsUrl: 'ACCOUNTS_URL'
+  AccountsUrl: 'ACCOUNTS_URL',
+  StorageRetryCount: 'STORAGE_RETRY_COUNT',
+  StorageRetryInterval: 'STORAGE_RETRY_INTERVAL'
 }
 
 const required: Array<keyof Config> = ['Secret', 'ServiceID', 'Port', 'AccountsUrl']
@@ -43,7 +47,9 @@ const config: Config = (() => {
     ServiceID: process.env[envMap.ServiceID] ?? 'collaborator-service',
     Interval: parseInt(process.env[envMap.Interval] ?? '30000'),
     Port: parseInt(process.env[envMap.Port] ?? '3078'),
-    AccountsUrl: process.env[envMap.AccountsUrl]
+    AccountsUrl: process.env[envMap.AccountsUrl],
+    StorageRetryCount: parseInt(process.env[envMap.StorageRetryCount] ?? '5'),
+    StorageRetryInterval: parseInt(process.env[envMap.StorageRetryInterval] ?? '50')
   }
 
   const missingEnv = required.filter((key) => params[key] === undefined).map((key) => envMap[key])

--- a/server/collaborator/src/extensions/storage.ts
+++ b/server/collaborator/src/extensions/storage.ts
@@ -56,10 +56,11 @@ export class StorageExtension implements Extension {
   }
 
   async onChange ({ context, document, documentName }: withContext<onChangePayload>): Promise<any> {
+    const { ctx } = this.configuration
     const { connectionId } = context
 
     if (document.isLoading) {
-      console.warn('document changed while is loading', { documentName, connectionId })
+      ctx.warn('document changed while is loading', { documentName, connectionId })
       return
     }
 

--- a/server/collaborator/src/server.ts
+++ b/server/collaborator/src/server.ts
@@ -44,8 +44,10 @@ export type Shutdown = () => Promise<void>
  */
 export async function start (ctx: MeasureContext, config: Config, storageAdapter: StorageAdapter): Promise<Shutdown> {
   const port = config.Port
+  const retryCount = config.StorageRetryCount
+  const retryInterval = config.StorageRetryInterval
 
-  ctx.info('Starting collaborator server', { port })
+  ctx.info('Starting collaborator server', { config })
 
   const app = express()
   app.use(cors())
@@ -96,7 +98,7 @@ export async function start (ctx: MeasureContext, config: Config, storageAdapter
       }),
       new StorageExtension({
         ctx: extensionsCtx.newChild('storage', {}),
-        adapter: new PlatformStorageAdapter(storageAdapter),
+        adapter: new PlatformStorageAdapter(storageAdapter, { retryCount, retryInterval }),
         transformer
       })
     ]


### PR DESCRIPTION
Couple of fixes in collaborative documents:

1. Wait for local content to be synced before initializing editor
2. Expose storage retry parameters
3. Disable gc