### PR TITLE
UBERF-10550: Support internal endpoint in getLoginInfoByToken

### DIFF
--- a/server/account-service/src/index.ts
+++ b/server/account-service/src/index.ts
@@ -5,6 +5,7 @@
 import account, {
   type AccountMethods,
   type Meta,
+  type ClientNetworkPosition,
   EndpointKind,
   accountId,
   getAccountDB,
@@ -175,7 +176,19 @@ export function serveAccount (measureCtx: MeasureContext, brandings: BrandingMap
   }
 
   const getRequestMeta = (headers: IncomingHttpHeaders): Meta => {
-    return headers?.['x-timezone'] !== undefined ? { timezone: headers['x-timezone'] as string } : {}
+    const meta: Meta = {}
+    if (headers?.['x-timezone'] !== undefined) {
+      meta.timezone = headers['x-timezone'] as string
+    }
+
+    if (headers?.['x-client-network-position'] !== undefined) {
+      const val = headers['x-client-network-position'] as string
+      if (['internal', 'external'].includes(val)) {
+        meta.clientNetworkPosition = val as ClientNetworkPosition
+      }
+    }
+
+    return meta
   }
 
   function getCookieOptions (ctx: Koa.Context): Cookies.SetOption {

--- a/server/account/src/__tests__/operations.test.ts
+++ b/server/account/src/__tests__/operations.test.ts
@@ -518,7 +518,7 @@ describe('invite operations', () => {
       test('should return login info with external endpoint when clientNetworkPosition is external', async () => {
         ;(mockDb.workspace.findOne as jest.Mock).mockResolvedValue(mockWorkspaceEu)
 
-        const result = await getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken, {
+        const result = await getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken, {}, {
           clientNetworkPosition: 'external'
         })
 
@@ -540,7 +540,7 @@ describe('invite operations', () => {
         }
         ;(mockDb.workspace.findOne as jest.Mock).mockResolvedValue(mockWorkspaceUs)
 
-        const result = await getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken, {
+        const result = await getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken, {}, {
           clientNetworkPosition: 'internal'
         })
 
@@ -558,7 +558,7 @@ describe('invite operations', () => {
       test('should default to external endpoint when clientNetworkPosition is not provided', async () => {
         ;(mockDb.workspace.findOne as jest.Mock).mockResolvedValue(mockWorkspaceEu)
 
-        const result = await getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken)
+        const result = await getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken, {})
 
         expect(result).toEqual({
           account: mockPersonId,
@@ -587,7 +587,7 @@ describe('invite operations', () => {
       ;(mockDb.person.findOne as jest.Mock).mockResolvedValue(mockPerson)
       ;(mockDb.socialId.find as jest.Mock).mockResolvedValue([{ _id: 'social-id-1' }])
 
-      const result = await getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken)
+      const result = await getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken, {})
 
       expect(result).toEqual({
         account: mockPersonId,
@@ -615,7 +615,7 @@ describe('invite operations', () => {
       })
       ;(mockDb.socialId.find as jest.Mock).mockResolvedValue([{ _id: 'social-id-1' }])
 
-      await expect(getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken)).rejects.toThrow(
+      await expect(getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken, {})).rejects.toThrow(
         new PlatformError(
           new Status(Severity.ERROR, platform.status.WorkspaceNotFound, { workspaceUuid: mockWorkspace.uuid })
         )

--- a/server/account/src/__tests__/operations.test.ts
+++ b/server/account/src/__tests__/operations.test.ts
@@ -518,9 +518,16 @@ describe('invite operations', () => {
       test('should return login info with external endpoint when clientNetworkPosition is external', async () => {
         ;(mockDb.workspace.findOne as jest.Mock).mockResolvedValue(mockWorkspaceEu)
 
-        const result = await getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken, {}, {
-          clientNetworkPosition: 'external'
-        })
+        const result = await getLoginInfoByToken(
+          mockCtx,
+          mockDb,
+          mockBranding,
+          mockToken,
+          {},
+          {
+            clientNetworkPosition: 'external'
+          }
+        )
 
         expect(result).toEqual({
           account: mockPersonId,
@@ -540,9 +547,16 @@ describe('invite operations', () => {
         }
         ;(mockDb.workspace.findOne as jest.Mock).mockResolvedValue(mockWorkspaceUs)
 
-        const result = await getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken, {}, {
-          clientNetworkPosition: 'internal'
-        })
+        const result = await getLoginInfoByToken(
+          mockCtx,
+          mockDb,
+          mockBranding,
+          mockToken,
+          {},
+          {
+            clientNetworkPosition: 'internal'
+          }
+        )
 
         expect(result).toEqual({
           account: mockPersonId,

--- a/server/account/src/__tests__/operations.test.ts
+++ b/server/account/src/__tests__/operations.test.ts
@@ -18,7 +18,7 @@ import platform, { PlatformError, Status, Severity, getMetadata } from '@hcengin
 import { decodeTokenVerbose } from '@hcengineering/server-token'
 
 import { AccountDB } from '../types'
-import { createInvite, createInviteLink, sendInvite, resendInvite } from '../operations'
+import { createInvite, createInviteLink, sendInvite, resendInvite, getLoginInfoByToken } from '../operations'
 import { accountPlugin } from '../plugin'
 
 // Mock platform
@@ -450,6 +450,176 @@ describe('invite operations', () => {
 
       expect(mockDb.invite.insertOne).toHaveBeenCalled()
       expect(global.fetch).toHaveBeenCalled()
+    })
+  })
+
+  describe('getLoginInfoByToken', () => {
+    const mockCtx = {
+      error: jest.fn(),
+      info: jest.fn()
+    } as unknown as MeasureContext
+
+    const mockBranding = null
+    const mockToken = 'test-token'
+    const mockPersonId = 'test-person-id'
+
+    const mockDb = {
+      account: {
+        findOne: jest.fn()
+      },
+      workspace: {
+        findOne: jest.fn()
+      },
+      person: {
+        findOne: jest.fn()
+      },
+      socialId: {
+        find: jest.fn()
+      },
+      getWorkspaceRole: jest.fn()
+    } as unknown as AccountDB
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+      // Mock the metadata for endpoints
+      ;(getMetadata as jest.Mock).mockImplementation((key) => {
+        if (key === accountPlugin.metadata.Transactors) {
+          return 'ws://external:3000;ws://external:3000;eu,ws://internal:3000;ws://internal:3000;us'
+        }
+        return undefined
+      })
+    })
+
+    describe('endpoint selection', () => {
+      const mockWorkspaceEu = {
+        uuid: 'workspace-uuid' as WorkspaceUuid,
+        name: 'Test Workspace',
+        url: 'test-workspace',
+        region: 'eu'
+      }
+
+      const mockPerson = {
+        uuid: mockPersonId as PersonUuid,
+        firstName: 'John',
+        lastName: 'Doe'
+      }
+
+      beforeEach(() => {
+        ;(mockDb.person.findOne as jest.Mock).mockResolvedValue(mockPerson)
+        ;(mockDb.getWorkspaceRole as jest.Mock).mockResolvedValue(AccountRole.User)
+        ;(mockDb.socialId.find as jest.Mock).mockResolvedValue([{ _id: 'social-id-1' }])
+        ;(decodeTokenVerbose as jest.Mock).mockReturnValue({
+          account: mockPersonId,
+          workspace: mockWorkspaceEu.uuid,
+          extra: {}
+        })
+      })
+
+      test('should return login info with external endpoint when clientNetworkPosition is external', async () => {
+        ;(mockDb.workspace.findOne as jest.Mock).mockResolvedValue(mockWorkspaceEu)
+
+        const result = await getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken, {
+          clientNetworkPosition: 'external'
+        })
+
+        expect(result).toEqual({
+          account: mockPersonId,
+          name: 'John Doe',
+          socialId: 'social-id-1',
+          token: mockToken,
+          workspace: mockWorkspaceEu.uuid,
+          endpoint: 'ws://external:3000',
+          role: AccountRole.User
+        })
+      })
+
+      test('should return login info with internal endpoint when clientNetworkPosition is internal', async () => {
+        const mockWorkspaceUs = {
+          ...mockWorkspaceEu,
+          region: 'us'
+        }
+        ;(mockDb.workspace.findOne as jest.Mock).mockResolvedValue(mockWorkspaceUs)
+
+        const result = await getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken, {
+          clientNetworkPosition: 'internal'
+        })
+
+        expect(result).toEqual({
+          account: mockPersonId,
+          name: 'John Doe',
+          socialId: 'social-id-1',
+          token: mockToken,
+          workspace: mockWorkspaceUs.uuid,
+          endpoint: 'ws://internal:3000',
+          role: AccountRole.User
+        })
+      })
+
+      test('should default to external endpoint when clientNetworkPosition is not provided', async () => {
+        ;(mockDb.workspace.findOne as jest.Mock).mockResolvedValue(mockWorkspaceEu)
+
+        const result = await getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken)
+
+        expect(result).toEqual({
+          account: mockPersonId,
+          name: 'John Doe',
+          socialId: 'social-id-1',
+          token: mockToken,
+          workspace: mockWorkspaceEu.uuid,
+          endpoint: 'ws://external:3000',
+          role: AccountRole.User
+        })
+      })
+    })
+
+    test('should return login info without workspace when no workspace in token', async () => {
+      const mockPerson = {
+        uuid: mockPersonId as PersonUuid,
+        firstName: 'John',
+        lastName: 'Doe'
+      }
+
+      ;(decodeTokenVerbose as jest.Mock).mockReturnValue({
+        account: mockPersonId,
+        workspace: undefined,
+        extra: {}
+      })
+      ;(mockDb.person.findOne as jest.Mock).mockResolvedValue(mockPerson)
+      ;(mockDb.socialId.find as jest.Mock).mockResolvedValue([{ _id: 'social-id-1' }])
+
+      const result = await getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken)
+
+      expect(result).toEqual({
+        account: mockPersonId,
+        name: 'John Doe',
+        socialId: 'social-id-1',
+        token: mockToken
+      })
+    })
+
+    test('should throw error when workspace not found', async () => {
+      const mockWorkspace = {
+        uuid: 'workspace-uuid' as WorkspaceUuid
+      }
+
+      ;(decodeTokenVerbose as jest.Mock).mockReturnValue({
+        account: mockPersonId,
+        workspace: mockWorkspace.uuid,
+        extra: {}
+      })
+      ;(mockDb.workspace.findOne as jest.Mock).mockResolvedValue(null)
+      ;(mockDb.person.findOne as jest.Mock).mockResolvedValue({
+        uuid: mockPersonId,
+        firstName: 'John',
+        lastName: 'Doe'
+      })
+      ;(mockDb.socialId.find as jest.Mock).mockResolvedValue([{ _id: 'social-id-1' }])
+
+      await expect(getLoginInfoByToken(mockCtx, mockDb, mockBranding, mockToken)).rejects.toThrow(
+        new PlatformError(
+          new Status(Severity.ERROR, platform.status.WorkspaceNotFound, { workspaceUuid: mockWorkspace.uuid })
+        )
+      )
     })
   })
 })

--- a/server/account/src/operations.ts
+++ b/server/account/src/operations.ts
@@ -1273,7 +1273,7 @@ export async function getLoginInfoByToken (
   db: AccountDB,
   branding: Branding | null,
   token: string,
-  params: unknown,
+  params?: unknown,
   meta?: Meta
 ): Promise<LoginInfo | WorkspaceLoginInfo> {
   let accountUuid: AccountUuid

--- a/server/account/src/operations.ts
+++ b/server/account/src/operations.ts
@@ -1273,6 +1273,7 @@ export async function getLoginInfoByToken (
   db: AccountDB,
   branding: Branding | null,
   token: string,
+  params: unknown,
   meta?: Meta
 ): Promise<LoginInfo | WorkspaceLoginInfo> {
   let accountUuid: AccountUuid
@@ -1344,11 +1345,14 @@ export async function getLoginInfoByToken (
       throw new PlatformError(new Status(Severity.ERROR, platform.status.WorkspaceNotFound, { workspaceUuid }))
     }
 
+    const endpointKind = meta?.clientNetworkPosition === 'internal' ? EndpointKind.Internal : EndpointKind.External
+    const endpoint = getEndpoint(workspace.uuid, workspace.region, endpointKind)
+
     if (isDocGuest) {
       return {
         ...loginInfo,
         workspace: workspaceUuid,
-        endpoint: getEndpoint(workspace.uuid, workspace.region, EndpointKind.External),
+        endpoint,
         role: AccountRole.DocGuest
       }
     }
@@ -1364,7 +1368,7 @@ export async function getLoginInfoByToken (
       ...loginInfo,
       workspace: workspace.uuid,
       workspaceDataId: workspace.dataId,
-      endpoint: getEndpoint(workspace.uuid, workspace.region, EndpointKind.External),
+      endpoint,
       role
     }
   } else {

--- a/server/account/src/types.ts
+++ b/server/account/src/types.ts
@@ -330,6 +330,9 @@ export interface MailboxOptions {
   maxMailboxCount: number
 }
 
+export type ClientNetworkPosition = 'internal' | 'external'
+
 export interface Meta {
   timezone?: string
+  clientNetworkPosition?: ClientNetworkPosition
 }

--- a/server/account/src/utils.ts
+++ b/server/account/src/utils.ts
@@ -542,7 +542,7 @@ export async function selectWorkspace (
       case 'byregion':
         return externalRegions.includes(region ?? '') ? EndpointKind.External : EndpointKind.Internal
       default:
-        return EndpointKind.External
+        return meta?.clientNetworkPosition === 'internal' ? EndpointKind.Internal : EndpointKind.External
     }
   }
 

--- a/ws-tests/tool-europe.sh
+++ b/ws-tests/tool-europe.sh
@@ -14,7 +14,7 @@ export SERVER_SECRET=secret
 export DB_URL=postgresql://root@huly.local:26258/defaultdb?sslmode=disable
 
 export REGION_INFO="|America;europe|" # Europe without name will not be available for creation of new workspaces.
-export TRANSACTOR_URL="ws://huly.local:3334;ws://huly.localv:3334,ws://huly.local:3335;ws://huly.local:3335;europe,"
+export TRANSACTOR_URL="ws://huly.local:3334;ws://huly.local:3334,ws://huly.local:3335;ws://huly.local:3335;europe,"
 export QUEUE_CONFIG=huly.local:19093
 
 # Check if local bundle.js exists and use it if available


### PR DESCRIPTION
* Adds new `X-Client-Network-Position` header handling with `internal`/`external` values. 

Related to: https://front.hc.engineering/workbench/platform/tracker/UBERF-10550
Closes https://github.com/hcengineering/platform/issues/8894