### PR TITLE
UBERF-10599: Fix ws not found in gmail

### DIFF
--- a/packages/api-client/src/socket/node.ts
+++ b/packages/api-client/src/socket/node.ts
@@ -19,7 +19,12 @@ import { type ClientSocket, type ClientSocketFactory } from '@hcengineering/clie
 export const NodeWebSocketFactory: ClientSocketFactory = (url: string): ClientSocket => {
   // We need to override default factory with 'ws' one.
   // eslint-disable-next-line
-  const WebSocket = require('ws')
+  let WebSocket
+  try {
+    WebSocket = require('ws')
+  } catch (error) {
+    throw new Error('The "ws" package is required for NodeWebSocketFactory. ')
+  }
   type WebSocketData = Parameters<typeof ws.on>[1]
 
   const ws = new WebSocket(url)

--- a/services/gmail/pod-gmail/Dockerfile
+++ b/services/gmail/pod-gmail/Dockerfile
@@ -2,7 +2,7 @@ FROM hardcoreeng/base:v20250310
 WORKDIR /usr/src/app
 
 COPY package.json ./
-# Install ws, since it is external dependency and it not included in the base image
+# Install ws, since it is external dependency and it is not included in the base image
 RUN WS_VERSION=$(grep -o '"ws": *"[^"]*"' package.json | grep -o '[0-9][^"]*' | head -1) && \
     if [ -z "$WS_VERSION" ]; then WS_VERSION="8.18.0"; fi && \
     echo "Installing ws version: $WS_VERSION" && \

--- a/services/gmail/pod-gmail/Dockerfile
+++ b/services/gmail/pod-gmail/Dockerfile
@@ -1,14 +1,6 @@
 FROM hardcoreeng/base:v20250310
 WORKDIR /usr/src/app
 
-COPY package.json ./
-# Install ws, since it is external dependency and it is not included in the base image
-RUN WS_VERSION=$(grep -o '"ws": *"[^"]*"' package.json | grep -o '[0-9][^"]*' | head -1) && \
-    if [ -z "$WS_VERSION" ]; then WS_VERSION="8.18.0"; fi && \
-    echo "Installing ws version: $WS_VERSION" && \
-    rm package.json && \
-    npm install --no-package-lock ws@$WS_VERSION
-
 COPY bundle/bundle.js ./
 
 EXPOSE 8087

--- a/services/gmail/pod-gmail/Dockerfile
+++ b/services/gmail/pod-gmail/Dockerfile
@@ -1,6 +1,14 @@
 FROM hardcoreeng/base:v20250310
 WORKDIR /usr/src/app
 
+COPY package.json ./
+# Install ws, since it is external dependency and it not included in the base image
+RUN WS_VERSION=$(grep -o '"ws": *"[^"]*"' package.json | grep -o '[0-9][^"]*' | head -1) && \
+    if [ -z "$WS_VERSION" ]; then WS_VERSION="8.18.0"; fi && \
+    echo "Installing ws version: $WS_VERSION" && \
+    rm package.json && \
+    npm install --no-package-lock ws@$WS_VERSION
+
 COPY bundle/bundle.js ./
 
 EXPOSE 8087

--- a/services/gmail/pod-gmail/package.json
+++ b/services/gmail/pod-gmail/package.json
@@ -14,7 +14,7 @@
     "build": "compile",
     "build:watch": "compile",
     "test": "jest --passWithNoTests --silent",
-    "_phase:bundle": "rushx bundle --external=ws",
+    "_phase:bundle": "rushx bundle",
     "_phase:docker-build": "rushx docker:build",
     "_phase:docker-staging": "rushx docker:staging",
     "bundle": "node ../../../common/scripts/esbuild.js --external=ws",

--- a/services/gmail/pod-gmail/package.json
+++ b/services/gmail/pod-gmail/package.json
@@ -17,7 +17,7 @@
     "_phase:bundle": "rushx bundle",
     "_phase:docker-build": "rushx docker:build",
     "_phase:docker-staging": "rushx docker:staging",
-    "bundle": "node ../../../common/scripts/esbuild.js --external=ws",
+    "bundle": "node ../../../common/scripts/esbuild.js",
     "docker:build": "../../../common/scripts/docker_build.sh hardcoreeng/gmail",
     "docker:tbuild": "docker build -t hardcoreeng/gmail . --platform=linux/amd64 && ../../../common/scripts/docker_tag_push.sh hardcoreeng/gmail",
     "docker:staging": "../../../common/scripts/docker_tag.sh hardcoreeng/gmail staging",


### PR DESCRIPTION
Fix `Cannot find module 'ws'` in gmail container
ws is not included in bundle, since api-client cannot resolve ws from optional dependency in this case
So installed ws in dockerfile as external dependency