### PR TITLE
add HIDE_LOCAL_LOGIN env to to only show the Providers when logging in

### DIFF
--- a/desktop/src/ui/platform.ts
+++ b/desktop/src/ui/platform.ts
@@ -250,6 +250,7 @@ export async function configurePlatform (): Promise<void> {
 
   setMetadata(login.metadata.AccountsUrl, config.ACCOUNTS_URL)
   setMetadata(login.metadata.DisableSignUp, config.DISABLE_SIGNUP === 'true')
+  setMetadata(login.metadata.HideLocalLogin, config.HIDE_LOCAL_LOGIN === 'true')
   setMetadata(presentation.metadata.UploadURL, config.UPLOAD_URL)
   setMetadata(presentation.metadata.FilesURL, config.FILES_URL)
   setMetadata(presentation.metadata.CollaboratorUrl, config.COLLABORATOR_URL)

--- a/desktop/src/ui/types.ts
+++ b/desktop/src/ui/types.ts
@@ -15,6 +15,7 @@ export interface Config {
   DESKTOP_UPDATES_CHANNEL?: string
   DESKTOP_UPDATES_URL?: string
   DISABLE_SIGNUP?: string
+  HIDE_LOCAL_LOGIN?: string
   FILES_URL: string
   FRONT_URL: string
   GITHUB_APP: string

--- a/dev/prod/src/platform.ts
+++ b/dev/prod/src/platform.ts
@@ -175,6 +175,7 @@ export interface Config {
   TELEGRAM_BOT_URL?: string
   AI_URL?: string
   DISABLE_SIGNUP?: string
+  HIDE_LOCAL_LOGIN?: string
   LINK_PREVIEW_URL?: string
   PASSWORD_STRICTNESS?: 'very_strict' | 'strict' | 'normal' | 'none'
   // Could be defined for dev environment
@@ -423,6 +424,7 @@ export async function configurePlatform() {
 
   setMetadata(login.metadata.AccountsUrl, config.ACCOUNTS_URL)
   setMetadata(login.metadata.DisableSignUp, config.DISABLE_SIGNUP === 'true')
+  setMetadata(login.metadata.HideLocalLogin, config.HIDE_LOCAL_LOGIN === 'true')
 
   setMetadata(login.metadata.PasswordValidations, PASSWORD_REQUIREMENTS[config.PASSWORD_STRICTNESS ?? 'none'])
 

--- a/plugins/login-resources/src/components/LoginApp.svelte
+++ b/plugins/login-resources/src/components/LoginApp.svelte
@@ -36,6 +36,7 @@
   import Join from './Join.svelte'
   import AutoJoin from './AutoJoin.svelte'
   import LoginForm from './LoginForm.svelte'
+  import ProvidersOnlyForm from './ProvidersOnlyForm.svelte'
   import PasswordRequest from './PasswordRequest.svelte'
   import PasswordRestore from './PasswordRestore.svelte'
   import SelectWorkspace from './SelectWorkspace.svelte'
@@ -55,6 +56,8 @@
   export let page: Pages = 'signup'
 
   const signUpDisabled = getMetadata(login.metadata.DisableSignUp) ?? false
+  const localLoginHidden = getMetadata(login.metadata.HideLocalLogin) ?? false
+  console.log('Ratte: ', localLoginHidden)
   const useOTP = getMetadata(presentation.metadata.MailUrl) != null && getMetadata(presentation.metadata.MailUrl) !== ''
   let navigateUrl: string | undefined
 
@@ -150,7 +153,11 @@
         <Scroller padding={'1rem 0'}>
           <div class="form-content">
             {#if page === 'login'}
-              <LoginForm {navigateUrl} {signUpDisabled} {useOTP} />
+              {#if localLoginHidden}
+                <ProvidersOnlyForm />
+              {:else}
+                <LoginForm {navigateUrl} {signUpDisabled} {useOTP} />
+              {/if}
             {:else if page === 'signup'}
               <SignupForm {navigateUrl} {signUpDisabled} {useOTP} />
             {:else if page === 'createWorkspace'}

--- a/plugins/login-resources/src/components/LoginApp.svelte
+++ b/plugins/login-resources/src/components/LoginApp.svelte
@@ -159,7 +159,7 @@
                 <LoginForm {navigateUrl} {signUpDisabled} {useOTP} />
               {/if}
             {:else if page === 'signup'}
-              <SignupForm {navigateUrl} {signUpDisabled} {useOTP} />
+              <SignupForm {navigateUrl} {signUpDisabled} {localLoginHidden} {useOTP} />
             {:else if page === 'createWorkspace'}
               <CreateWorkspaceForm />
             {:else if page === 'password'}

--- a/plugins/login-resources/src/components/ProvidersOnlyForm.svelte
+++ b/plugins/login-resources/src/components/ProvidersOnlyForm.svelte
@@ -1,0 +1,28 @@
+<!--
+// Copyright © 2024 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+-->
+<script lang="ts">
+  import { deviceOptionsStore as deviceInfo } from '@hcengineering/ui'
+
+  import Tabs from './Tabs.svelte'
+  import Providers from './Providers.svelte'
+</script>
+
+<div
+  style:padding={$deviceInfo.docWidth <= 480 ? '.25rem 1.25rem' : '4rem 5rem'}
+  style:min-height={$deviceInfo.docHeight > 720 ? '42rem' : '0'}
+>
+  <Tabs loginState={'login'} signUpDisabled={true} />
+  <Providers />
+</div>

--- a/plugins/login-resources/src/components/SignupForm.svelte
+++ b/plugins/login-resources/src/components/SignupForm.svelte
@@ -27,6 +27,7 @@
   import OtpForm from './OtpForm.svelte'
 
   export let signUpDisabled = false
+  export let localLoginHidden = false
   export let navigateUrl: string | undefined = undefined
   export let useOTP = true // False only for dev/tests
 
@@ -65,7 +66,7 @@
   let step = OtpLoginSteps.Email
   let otpRetryOn = 0
 
-  if (signUpDisabled) {
+  if (signUpDisabled || localLoginHidden) {
     goTo('login')
   }
 

--- a/plugins/login/src/index.ts
+++ b/plugins/login/src/index.ts
@@ -50,6 +50,7 @@ export default plugin(loginId, {
     LoginEndpoint: '' as Metadata<string>,
     LoginAccount: '' as Metadata<string>,
     DisableSignUp: '' as Metadata<boolean>,
+    HideLocalLogin: '' as Metadata<boolean>,
     TransactorOverride: '' as Metadata<string>,
     PasswordValidations: '' as Metadata<{
       MinLength: number

--- a/server/front/src/index.ts
+++ b/server/front/src/index.ts
@@ -273,6 +273,7 @@ export function start (
     linkPreviewUrl?: string
     pushPublicKey?: string
     disableSignUp?: string
+    hideLocalLogin?: string
     streamUrl?: string
     mailUrl?: string
   },
@@ -348,6 +349,7 @@ export function start (
       UPLOAD_CONFIG: config.uploadConfig,
       PUSH_PUBLIC_KEY: config.pushPublicKey,
       DISABLE_SIGNUP: config.disableSignUp,
+      HIDE_LOCAL_LOGIN: config.hideLocalLogin,
       MAIL_URL: config.mailUrl,
       ...(extraConfig ?? {})
     }

--- a/server/front/src/starter.ts
+++ b/server/front/src/starter.ts
@@ -119,6 +119,8 @@ export function startFront (ctx: MeasureContext, extraConfig?: Record<string, st
 
   const disableSignUp = process.env.DISABLE_SIGNUP
 
+  const hideLocalLogin = process.env.HIDE_LOCAL_LOGIN
+
   const mailUrl = process.env.MAIL_URL
 
   const config = {
@@ -140,6 +142,7 @@ export function startFront (ctx: MeasureContext, extraConfig?: Record<string, st
     uploadConfig,
     pushPublicKey,
     disableSignUp,
+    hideLocalLogin,
     linkPreviewUrl,
     streamUrl,
     mailUrl


### PR DESCRIPTION
This adds a new ProvidersOnlyForm that will only show the Providers login buttons, no local login form. The Form also contains the Tabs component, but with LogIn-tab only. I left out signup because when using openid, the functionality of the login/signup tab is identical. Therefor, the user is also redirected from signup to login when HIDE_LOCAL_LOGIN is set to true