### PR TITLE
Corrected color for an unassigned avatar

### DIFF
--- a/plugins/contact-resources/src/components/AvatarInstance.svelte
+++ b/plugins/contact-resources/src/components/AvatarInstance.svelte
@@ -122,7 +122,11 @@
       />
     {:else}
       <div class="icon">
-        <Icon icon={icon ?? AvatarIcon} fill={'var(--white-color)'} size={'full'} />
+        <Icon
+          icon={icon ?? AvatarIcon}
+          fill={color ? 'var(--primary-button-color)' : 'var(--theme-caption-color)'}
+          size={'full'}
+        />
       </div>
     {/if}
   </div>


### PR DESCRIPTION
<img width="214" alt="screen-undef-icon-2-dark" src="https://github.com/user-attachments/assets/4091a6af-453f-43a7-9647-f35d6fb3f387" /> <img width="214" alt="screen-undef-icon-2-light" src="https://github.com/user-attachments/assets/d16b6821-c7fb-4ff7-bb2a-25d463e764bc" /> <img width="126" alt="screen-undef-icon-1-dark" src="https://github.com/user-attachments/assets/f09dda74-4ddb-4c90-9cb0-b1e4216b7160" /> <img width="126" alt="screen-undef-icon-1-light" src="https://github.com/user-attachments/assets/e8b855c4-1587-47bf-a1ad-76fe915be651" />
