### PR TITLE
UBERF-11175: Fix new person names in mail

### DIFF
--- a/services/mail/mail-common/src/__tests__/parseEmailHeader.test.ts
+++ b/services/mail/mail-common/src/__tests__/parseEmailHeader.test.ts
@@ -47,8 +47,8 @@ describe('parseEmailHeader', () => {
     expect(result).toEqual([
       {
         email: 'john.doe@example.com',
-        firstName: '<john.doe@example.com>',
-        lastName: 'John Doe'
+        firstName: 'John',
+        lastName: 'Doe'
       }
     ])
   })
@@ -58,8 +58,8 @@ describe('parseEmailHeader', () => {
     expect(result).toEqual([
       {
         email: 'john.doe@example.com',
-        firstName: '<john.doe@example.com>',
-        lastName: 'John Doe'
+        firstName: 'John',
+        lastName: 'Doe'
       }
     ])
   })
@@ -69,8 +69,8 @@ describe('parseEmailHeader', () => {
     expect(result).toEqual([
       {
         email: 'john.doe@example.com',
-        firstName: '<john.doe@example.com>',
-        lastName: 'John Doe Smith'
+        firstName: 'John Doe Smith',
+        lastName: ''
       }
     ])
   })
@@ -96,13 +96,13 @@ describe('parseEmailHeader', () => {
     expect(result).toEqual([
       {
         email: 'john@example.com',
-        firstName: '<john@example.com>',
-        lastName: 'John'
+        firstName: 'John',
+        lastName: ''
       },
       {
         email: 'jane@example.com',
-        firstName: '<jane@example.com>',
-        lastName: 'Jane Doe'
+        firstName: 'Jane',
+        lastName: 'Doe'
       }
     ])
   })
@@ -112,13 +112,13 @@ describe('parseEmailHeader', () => {
     expect(result).toEqual([
       {
         email: 'john@example.com',
-        firstName: '<john@example.com>',
-        lastName: 'Doe, John'
+        firstName: 'Doe',
+        lastName: 'John'
       },
       {
         email: 'jane@example.com',
-        firstName: '<jane@example.com>',
-        lastName: 'Jane Doe'
+        firstName: 'Jane',
+        lastName: 'Doe'
       }
     ])
   })
@@ -133,8 +133,8 @@ describe('parseEmailHeader', () => {
       },
       {
         email: 'jane@example.com',
-        firstName: '<jane@example.com>',
-        lastName: 'Jane Doe'
+        firstName: 'Jane',
+        lastName: 'Doe'
       }
     ])
   })
@@ -165,8 +165,8 @@ describe('parseEmailHeader', () => {
       },
       {
         email: 'jane@example.com',
-        firstName: '<jane@example.com>',
-        lastName: 'Jane Doe'
+        firstName: 'Jane',
+        lastName: 'Doe'
       }
     ])
   })
@@ -176,13 +176,13 @@ describe('parseEmailHeader', () => {
     expect(result).toEqual([
       {
         email: 'example-staff@example.com',
-        firstName: '<example-staff@example.com>',
-        lastName: 'example staff'
+        firstName: 'example',
+        lastName: 'staff'
       },
       {
         email: 'personnel@example.com',
-        firstName: '<personnel@example.com>',
-        lastName: 'personnel'
+        firstName: 'personnel',
+        lastName: ''
       }
     ])
   })
@@ -208,13 +208,13 @@ describe('parseEmailHeader', () => {
     expect(result).toEqual([
       {
         email: 'john@example.com',
-        firstName: '<john@example.com>',
-        lastName: 'John'
+        firstName: 'John',
+        lastName: ''
       },
       {
         email: 'jane@example.com',
-        firstName: '<jane@example.com>',
-        lastName: 'Jane'
+        firstName: 'Jane',
+        lastName: ''
       }
     ])
   })
@@ -224,13 +224,13 @@ describe('parseEmailHeader', () => {
     expect(result).toEqual([
       {
         email: 'john@example.com',
-        firstName: '<john@example.com>',
-        lastName: 'John'
+        firstName: 'John',
+        lastName: ''
       },
       {
         email: 'jane@example.com',
-        firstName: '<jane@example.com>',
-        lastName: 'Jane'
+        firstName: 'Jane',
+        lastName: ''
       }
     ])
   })

--- a/services/mail/mail-common/src/__tests__/parseNameFromEmailHeader.test.ts
+++ b/services/mail/mail-common/src/__tests__/parseNameFromEmailHeader.test.ts
@@ -21,8 +21,8 @@ describe('parseNameFromEmailHeader', () => {
     const input = '"John Doe" <john.doe@example.com>'
     const expected: EmailContact = {
       email: 'john.doe@example.com',
-      firstName: '<john.doe@example.com>',
-      lastName: 'John Doe'
+      firstName: 'John',
+      lastName: 'Doe'
     }
 
     expect(parseNameFromEmailHeader(input)).toEqual(expected)
@@ -32,8 +32,8 @@ describe('parseNameFromEmailHeader', () => {
     const input = 'Jane Smith <jane.smith@example.com>'
     const expected: EmailContact = {
       email: 'jane.smith@example.com',
-      firstName: '<jane.smith@example.com>',
-      lastName: 'Jane Smith'
+      firstName: 'Jane',
+      lastName: 'Smith'
     }
 
     expect(parseNameFromEmailHeader(input)).toEqual(expected)
@@ -65,8 +65,8 @@ describe('parseNameFromEmailHeader', () => {
     const input = 'Maria Van Der Berg <maria@example.com>'
     const expected: EmailContact = {
       email: 'maria@example.com',
-      firstName: '<maria@example.com>',
-      lastName: 'Maria Van Der Berg'
+      firstName: 'Maria Van Der Berg',
+      lastName: ''
     }
 
     expect(parseNameFromEmailHeader(input)).toEqual(expected)
@@ -108,8 +108,8 @@ describe('parseNameFromEmailHeader', () => {
     const input = 'Support <help@example.com>'
     const expected: EmailContact = {
       email: 'help@example.com',
-      firstName: '<help@example.com>',
-      lastName: 'Support'
+      firstName: 'Support',
+      lastName: ''
     }
 
     expect(parseNameFromEmailHeader(input)).toEqual(expected)
@@ -119,8 +119,8 @@ describe('parseNameFromEmailHeader', () => {
     const input = '"O\'Neill, James" <james.oneill@example.com>'
     const expected: EmailContact = {
       email: 'james.oneill@example.com',
-      firstName: '<james.oneill@example.com>',
-      lastName: "O'Neill, James"
+      firstName: 'O\'Neill',
+      lastName: 'James'
     }
 
     expect(parseNameFromEmailHeader(input)).toEqual(expected)

--- a/services/mail/mail-common/src/__tests__/parseNameFromEmailHeader.test.ts
+++ b/services/mail/mail-common/src/__tests__/parseNameFromEmailHeader.test.ts
@@ -119,7 +119,7 @@ describe('parseNameFromEmailHeader', () => {
     const input = '"O\'Neill, James" <james.oneill@example.com>'
     const expected: EmailContact = {
       email: 'james.oneill@example.com',
-      firstName: 'O\'Neill',
+      firstName: "O'Neill",
       lastName: 'James'
     }
 

--- a/services/mail/mail-common/src/utils.ts
+++ b/services/mail/mail-common/src/utils.ts
@@ -18,6 +18,9 @@ import sanitizeHtml from 'sanitize-html'
 import { MeasureContext } from '@hcengineering/core'
 import { EmailContact, EmailMessage } from './types'
 
+const NAME_EMAIL_PATTERN = /^(?:"?([^"<]+)"?\s*)?<([^>]+)>$/
+const NAME_SEGMENT_REGEX = /[\s,;]+/
+
 export function getMdContent (ctx: MeasureContext, email: EmailMessage): string {
   if (email.content !== undefined) {
     try {
@@ -89,8 +92,7 @@ export function parseNameFromEmailHeader (headerValue: string | undefined): Emai
   }
 
   // Match pattern like: "Name" <email@example.com> or Name <email@example.com>
-  const nameEmailPattern = /^(?:"?([^"<]+)"?\s*)?<([^>]+)>$/
-  const match = headerValue.trim().match(nameEmailPattern)
+  const match = headerValue.trim().match(NAME_EMAIL_PATTERN)
 
   if (match == null) {
     const address = headerValue.trim()
@@ -111,9 +113,7 @@ export function parseNameFromEmailHeader (headerValue: string | undefined): Emai
       lastName: ''
     }
   }
-  const nameParts = displayName
-    .split(/[\s,;]+/)
-    .filter((part) => part !== '')
+  const nameParts = displayName.split(NAME_SEGMENT_REGEX).filter((part) => part !== '')
   if (nameParts.length === 2) {
     return {
       email,

--- a/services/mail/mail-common/src/utils.ts
+++ b/services/mail/mail-common/src/utils.ts
@@ -104,10 +104,26 @@ export function parseNameFromEmailHeader (headerValue: string | undefined): Emai
   const displayName = match[1]?.trim()
   const email = match[2].trim()
 
-  const wrappedEmail = displayName != null && displayName.length > 0 ? `<${email}>` : email
+  if (displayName == null || displayName === '') {
+    return {
+      email,
+      firstName: email,
+      lastName: ''
+    }
+  }
+  const nameParts = displayName
+    .split(/[\s,;]+/)
+    .filter((part) => part !== '')
+  if (nameParts.length === 2) {
+    return {
+      email,
+      firstName: nameParts[0],
+      lastName: nameParts[1]
+    }
+  }
   return {
     email,
-    firstName: wrappedEmail,
-    lastName: displayName ?? ''
+    firstName: displayName,
+    lastName: ''
   }
 }


### PR DESCRIPTION
1. Use email as first name if display name is not provided
2. Use first and last name from display name if it separated to two parts only
3. Use display name as first name otherwise
<img width="1094" alt="Screenshot 2025-05-26 at 14 58 45" src="https://github.com/user-attachments/assets/a9e9b070-9c16-4e20-9a3d-62dec4992536" />
