### PR TITLE
Fix notification when Request.requested changed

### DIFF
--- a/models/controlled-documents/src/types.ts
+++ b/models/controlled-documents/src/types.ts
@@ -462,11 +462,11 @@ export class TDocumentComment extends TChatMessage implements DocumentComment {
 export class TDocumentRequest extends TRequest implements DocumentRequest {}
 
 @Model(documents.class.DocumentReviewRequest, documents.class.DocumentRequest)
-@UX(documents.string.DocumentReviewRequest)
+@UX(documents.string.DocumentReviewRequest, documents.icon.Document)
 export class TDocumentReviewRequest extends TDocumentRequest implements DocumentReviewRequest {}
 
 @Model(documents.class.DocumentApprovalRequest, documents.class.DocumentRequest)
-@UX(documents.string.DocumentApprovalRequest)
+@UX(documents.string.DocumentApprovalRequest, documents.icon.Document)
 export class TDocumentApprovalRequest extends TDocumentRequest implements DocumentApprovalRequest {}
 
 @Mixin(documents.mixin.DocumentSpaceTypeData, documents.class.DocumentSpace)

--- a/models/request/src/index.ts
+++ b/models/request/src/index.ts
@@ -133,24 +133,56 @@ export function createModel (builder: Builder): void {
       field: 'requested',
       generated: false,
       group: request.ids.RequestNotificationGroup,
-      label: request.string.Request,
+      label: request.string.NewRequest,
       allowedForAuthor: true,
       defaultEnabled: true,
       templates: {
-        textTemplate: '{sender} sent you a {doc}',
-        htmlTemplate: '<p><b>{sender}</b> sent you a {doc}</p>',
+        textTemplate: '{sender} sent you a request for the {doc}',
+        htmlTemplate: '<p><b>{sender}</b> sent you a request for the {doc}</p>',
         subjectTemplate: '{doc}'
       }
     },
     request.ids.CreateRequestNotification
   )
 
+  builder.createDoc(
+    notification.class.NotificationType,
+    core.space.Model,
+    {
+      hidden: false,
+      objectClass: request.class.Request,
+      txClasses: [core.class.TxUpdateDoc],
+      field: 'requested',
+      generated: false,
+      group: request.ids.RequestNotificationGroup,
+      label: request.string.CancelRequest,
+      allowedForAuthor: true,
+      defaultEnabled: true,
+      templates: {
+        textTemplate: '{sender} canceled the request for the {doc}',
+        htmlTemplate: '<p><b>{sender}</b> canceled the request for the {doc}</p>',
+        subjectTemplate: '{doc}'
+      }
+    },
+    request.ids.RemoveRequestNotification
+  )
+
+  builder.createDoc(notification.class.ActivityNotificationViewlet, core.space.Model, {
+    messageMatch: {
+      _class: activity.class.DocUpdateMessage,
+      objectClass: request.class.Request,
+      action: 'update',
+      'attributeUpdates.attrKey': 'requested'
+    },
+    presenter: request.component.RequestedChangedNotification
+  })
+
   generateClassNotificationTypes(
     builder,
     request.class.Request,
     request.ids.RequestNotificationGroup,
     ['requested'],
-    ['comments', 'approved', 'rejected', 'status']
+    ['comments']
   )
 
   builder.createDoc(core.class.DomainIndexConfiguration, core.space.Model, {

--- a/models/request/src/plugin.ts
+++ b/models/request/src/plugin.ts
@@ -24,14 +24,18 @@ import type { NotificationGroup, NotificationType } from '@hcengineering/notific
 export default mergeIds(requestId, request, {
   component: {
     EditRequest: '' as AnyComponent,
-    NotificationRequestView: '' as AnyComponent
+    NotificationRequestView: '' as AnyComponent,
+    RequestedChangedNotification: '' as AnyComponent
   },
   ids: {
     RequestNotificationGroup: '' as Ref<NotificationGroup>,
-    CreateRequestNotification: '' as Ref<NotificationType>
+    CreateRequestNotification: '' as Ref<NotificationType>,
+    RemoveRequestNotification: '' as Ref<NotificationType>
   },
   string: {
     Status: '' as IntlString,
-    Requested: '' as IntlString
+    Requested: '' as IntlString,
+    NewRequest: '' as IntlString,
+    CancelRequest: '' as IntlString
   }
 })

--- a/models/server-request/package.json
+++ b/models/server-request/package.json
@@ -35,6 +35,7 @@
     "@hcengineering/server-request": "^0.6.0",
     "@hcengineering/server-core": "^0.6.1",
     "@hcengineering/model-request": "^0.6.0",
-    "@hcengineering/server-notification": "^0.6.1"
+    "@hcengineering/server-notification": "^0.6.1",
+    "@hcengineering/notification": "^0.6.23"
   }
 }

--- a/models/server-request/src/index.ts
+++ b/models/server-request/src/index.ts
@@ -20,6 +20,7 @@ import serverCore from '@hcengineering/server-core'
 import serverRequest from '@hcengineering/server-request'
 import serverNotification from '@hcengineering/server-notification'
 import request from '@hcengineering/model-request'
+import notification from '@hcengineering/notification'
 
 export { serverRequestId } from '@hcengineering/server-request'
 
@@ -34,4 +35,22 @@ export function createModel (builder: Builder): void {
   builder.mixin(request.class.Request, core.class.Class, serverNotification.mixin.TextPresenter, {
     presenter: serverRequest.function.RequestTextPresenter
   })
+
+  builder.mixin(
+    request.ids.CreateRequestNotification,
+    notification.class.NotificationType,
+    serverNotification.mixin.TypeMatch,
+    {
+      func: serverRequest.function.SendRequestMatch
+    }
+  )
+
+  builder.mixin(
+    request.ids.RemoveRequestNotification,
+    notification.class.NotificationType,
+    serverNotification.mixin.TypeMatch,
+    {
+      func: serverRequest.function.RemoveRequestMatch
+    }
+  )
 }

--- a/plugins/controlled-documents-resources/src/components/SignatureDialog.svelte
+++ b/plugins/controlled-documents-resources/src/components/SignatureDialog.svelte
@@ -84,7 +84,7 @@
     const accountClient = getAccountClient(accountsUrl)
 
     try {
-      // await accountClient.login(email, password)
+      await accountClient.login(email, password)
 
       return OK
     } catch (err: any) {

--- a/plugins/controlled-documents-resources/src/components/SignatureDialog.svelte
+++ b/plugins/controlled-documents-resources/src/components/SignatureDialog.svelte
@@ -84,7 +84,7 @@
     const accountClient = getAccountClient(accountsUrl)
 
     try {
-      await accountClient.login(email, password)
+      // await accountClient.login(email, password)
 
       return OK
     } catch (err: any) {

--- a/plugins/request-assets/lang/cs.json
+++ b/plugins/request-assets/lang/cs.json
@@ -18,6 +18,8 @@
     "PleaseTypeMessage": "Zadejte prosím zprávu ke komentáři, abyste mohli pokračovat...",
     "NoRequests": "Žádné žádosti",
     "Cancel": "Zrušit",
-    "Cancelled": "Zrušeno"
+    "Cancelled": "Zrušeno",
+    "NewRequest": "Nový požadavek",
+    "CancelRequest": "Zrušit požadavek"
   }
 }

--- a/plugins/request-assets/lang/de.json
+++ b/plugins/request-assets/lang/de.json
@@ -18,6 +18,8 @@
     "PleaseTypeMessage": "Bitte geben Sie eine Kommentarnachricht ein, um fortzufahren...",
     "NoRequests": "Keine Anfragen",
     "Cancel": "Abbrechen",
-    "Cancelled": "Abgebrochen"
+    "Cancelled": "Abgebrochen",
+    "NewRequest": "Neue Anfrage",
+    "CancelRequest": "Anfrage abbrechen"
   }
 }

--- a/plugins/request-assets/lang/en.json
+++ b/plugins/request-assets/lang/en.json
@@ -18,6 +18,8 @@
     "PleaseTypeMessage": "Please type comment message to continue...",
     "NoRequests": "No requests",
     "Cancel": "Cancel",
-    "Cancelled": "Cancelled"
+    "Cancelled": "Cancelled",
+    "NewRequest": "New Request",
+    "CancelRequest": "Cancel Request"
   }
 }

--- a/plugins/request-assets/lang/es.json
+++ b/plugins/request-assets/lang/es.json
@@ -18,6 +18,8 @@
     "PleaseTypeMessage": "Escriba un mensaje de comentario para continuar...",
     "NoRequests": "No hay solicitudes",
     "Cancel": "Cancelar",
-    "Cancelled": "Cancelado"
+    "Cancelled": "Cancelado",
+    "NewRequest": "Nueva solicitud",
+    "CancelRequest": "Cancelar solicitud"
   }
 }

--- a/plugins/request-assets/lang/fr.json
+++ b/plugins/request-assets/lang/fr.json
@@ -18,6 +18,8 @@
     "PleaseTypeMessage": "Veuillez taper un message de commentaire pour continuer...",
     "NoRequests": "Aucune demande",
     "Cancel": "Annuler",
-    "Cancelled": "Annulé"
+    "Cancelled": "Annulé",
+    "NewRequest": "Nouvelle demande",
+    "CancelRequest": "Annuler la demande"
   }
 }

--- a/plugins/request-assets/lang/it.json
+++ b/plugins/request-assets/lang/it.json
@@ -18,6 +18,8 @@
     "PleaseTypeMessage": "Per favore, digita un commento per continuare...",
     "NoRequests": "Nessuna richiesta",
     "Cancel": "Annulla",
-    "Cancelled": "Annullato"
+    "Cancelled": "Annullato",
+    "NewRequest": "Nuova richiesta",
+    "CancelRequest": "Annulla richiesta"
   }
 }

--- a/plugins/request-assets/lang/ja.json
+++ b/plugins/request-assets/lang/ja.json
@@ -18,6 +18,8 @@
     "PleaseTypeMessage": "コメントを入力して続行...",
     "NoRequests": "リクエストはありません",
     "Cancel": "キャンセル",
-    "Cancelled": "キャンセル済み"
+    "Cancelled": "キャンセル済み",
+    "NewRequest": "新しいリクエスト",
+    "CancelRequest": "リクエストをキャンセル"
   }
 }

--- a/plugins/request-assets/lang/pt.json
+++ b/plugins/request-assets/lang/pt.json
@@ -18,6 +18,8 @@
     "PleaseTypeMessage": "Digite uma mensagem de comentário para continuar...",
     "NoRequests": "Sem solicitações",
     "Cancel": "Cancelar",
-    "Cancelled": "Cancelado"
+    "Cancelled": "Cancelado",
+    "NewRequest": "Nova solicitação",
+    "CancelRequest": "Cancelar solicitação"
   }
 }

--- a/plugins/request-assets/lang/ru.json
+++ b/plugins/request-assets/lang/ru.json
@@ -18,6 +18,8 @@
     "PleaseTypeMessage": "Пожалуйста, оставьте комментарий, чтобы продолжить...",
     "NoRequests": "Нет запросов",
     "Cancel": "Отменить",
-    "Cancelled": "Отменен"
+    "Cancelled": "Отменен",
+    "NewRequest": "Новый запрос",
+    "CancelRequest": "Отмена запроса"
   }
 }

--- a/plugins/request-assets/lang/zh.json
+++ b/plugins/request-assets/lang/zh.json
@@ -18,6 +18,8 @@
     "PleaseTypeMessage": "请键入评论消息以继续...",
     "NoRequests": "没有请求",
     "Cancel": "取消",
-    "Cancelled": "已取消"
+    "Cancelled": "已取消",
+    "NewRequest": "新请求",
+    "CancelRequest": "取消请求"
   }
 }

--- a/plugins/request-resources/src/components/RequestedChangedNotification.svelte
+++ b/plugins/request-resources/src/components/RequestedChangedNotification.svelte
@@ -1,0 +1,80 @@
+<!--
+// Copyright © 2025 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+-->
+<script lang="ts">
+  import activity, { DisplayDocUpdateMessage } from '@hcengineering/activity'
+  import { BaseMessagePreview } from '@hcengineering/activity-resources'
+  import { getCurrentEmployee } from '@hcengineering/contact'
+  import { getClient } from '@hcengineering/presentation'
+  import { Icon, Label } from '@hcengineering/ui'
+  import { ObjectPresenter } from '@hcengineering/view-resources'
+
+  import request from '../plugin'
+
+  export let message: DisplayDocUpdateMessage
+
+  const me = getCurrentEmployee()
+  const client = getClient()
+
+  $: isRemovedMe = message.attributeUpdates?.removed.includes(me) ?? false
+  $: isAddedMe = message.attributeUpdates?.added.includes(me) ?? false
+</script>
+
+<BaseMessagePreview {message} on:click>
+  <slot name="content">
+    <div class="content overflow-label ml-1" class:preview={true}>
+      <span class="mr-1">
+        <Icon icon={client.getHierarchy().getClass(message.objectClass).icon ?? activity.icon.Activity} size="small" />
+      </span>
+      {#if isAddedMe}
+        <Label label={activity.string.New} />
+      {:else if isRemovedMe}
+        <Label label={request.string.Cancelled} />
+      {:else}
+        <Label label={activity.string.Updated} />
+      {/if}
+      <span class="lower">
+        <Label label={request.string.Requests} />
+      </span>
+      :
+      <span class="overflow-label values" class:preview={true}>
+        <ObjectPresenter objectId={message.objectId} _class={message.objectClass} shouldShowAvatar={false} />
+      </span>
+    </div>
+  </slot>
+</BaseMessagePreview>
+
+<style lang="scss">
+  .content {
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+    flex-wrap: wrap;
+    color: var(--global-primary-TextColor);
+
+    &.preview {
+      flex-wrap: nowrap;
+    }
+  }
+
+  .values {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+
+    &.preview {
+      flex-wrap: nowrap;
+    }
+  }
+</style>

--- a/plugins/request-resources/src/index.ts
+++ b/plugins/request-resources/src/index.ts
@@ -18,6 +18,7 @@ import EditRequest from './components/EditRequest.svelte'
 import RequestPresenter from './components/RequestPresenter.svelte'
 import RequestView from './components/RequestView.svelte'
 import NotificationRequestView from './components/NotificationRequestView.svelte'
+import RequestedChangedNotification from './components/RequestedChangedNotification.svelte'
 
 export { default as RequestStatusPresenter } from './components/RequestStatusPresenter.svelte'
 export { default as RequestDetailPopup } from './components/RequestDetailPopup.svelte'
@@ -27,6 +28,7 @@ export default async (): Promise<Resources> => ({
     EditRequest,
     RequestPresenter,
     RequestView,
-    NotificationRequestView
+    NotificationRequestView,
+    RequestedChangedNotification
   }
 })

--- a/server-plugins/request/src/index.ts
+++ b/server-plugins/request/src/index.ts
@@ -15,7 +15,7 @@
 
 import { Plugin, plugin, Resource } from '@hcengineering/platform'
 import type { TriggerFunc } from '@hcengineering/server-core'
-import { Presenter } from '@hcengineering/server-notification'
+import { Presenter, TypeMatchFunc } from '@hcengineering/server-notification'
 
 /**
  * @public
@@ -27,7 +27,9 @@ export const serverRequestId = 'server-request' as Plugin
  */
 export default plugin(serverRequestId, {
   function: {
-    RequestTextPresenter: '' as Resource<Presenter>
+    RequestTextPresenter: '' as Resource<Presenter>,
+    SendRequestMatch: '' as TypeMatchFunc,
+    RemoveRequestMatch: '' as TypeMatchFunc
   },
   trigger: {
     OnRequest: '' as Resource<TriggerFunc>


### PR DESCRIPTION
- Use `$push`/`$pull` for array updates
- Send notifications for user only if it in `requested`
- Add notification when request cancelled (user removed from `requested`)


<img width="610" alt="Screenshot 2025-05-26 at 21 05 06" src="https://github.com/user-attachments/assets/0b28e9e6-7343-4b9a-9886-097294301d4d" />


<img width="853" alt="Screenshot 2025-05-26 at 21 24 48" src="https://github.com/user-attachments/assets/e37ef905-669b-4d68-a3ba-efacd36942e4" />
