### PR TITLE
Redrawing the Avatar when changing the persona in UserInfo

### DIFF
--- a/plugins/contact-resources/src/components/UserInfo.svelte
+++ b/plugins/contact-resources/src/components/UserInfo.svelte
@@ -33,7 +33,9 @@
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div class="flex-row-center" on:click>
-  <Avatar person={value} {size} {icon} name={value.name} on:accent-color {showStatus} />
+  {#key value._id}
+    <Avatar person={value} {size} {icon} name={value.name} on:accent-color {showStatus} />
+  {/key}
   <div class="flex-col min-w-0 {size === 'tiny' || size === 'inline' ? 'ml-1' : 'ml-2'}" class:max-w-20={short}>
     {#if subtitle}<div class="content-dark-color text-sm">{subtitle}</div>{/if}
     <div class="label text-left overflow-label">{getName(client.getHierarchy(), value)}</div>


### PR DESCRIPTION
Redrawing the Avatar when changing the persona in UserInfo. Corrects incorrect display of Avatar types when multiple users are selected.