### PR TITLE
fix: correct filename in content-disposition header

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -367,9 +367,7 @@
         "METRICS_CONSOLE": "true",
         "ACCOUNTS_URL": "http://localhost:3000",
         "MONGO_URL": "mongodb://localhost:27017",
-        "MINIO_ACCESS_KEY": "minioadmin",
-        "MINIO_SECRET_KEY": "minioadmin",
-        "MINIO_ENDPOINT": "localhost"
+        "STORAGE_CONFIG": "datalake|http://localhost:4030"
       },
       "runtimeVersion": "20",
       "runtimeArgs": ["--nolazy", "-r", "ts-node/register"],
@@ -764,8 +762,8 @@
       "env": {
         "PORT": "4030",
         "SECRET": "secret",
-        "DB_URL": "",
-        "BUCKETS": "",
+        "DB_URL": "postgresql://root@localhost:26257/defaultdb?sslmode=disable",
+        "BUCKETS": "blobs,eu|http://localhost:9000?accessKey=minioadmin&secretKey=minioadmin",
         "ACCOUNTS_URL": "http://localhost:3000",
         "STATS_URL": "http://huly.local:4900",
         "STREAM_URL": "http://huly.local:1080/recording"

--- a/services/datalake/pod-datalake/src/handlers/blob.ts
+++ b/services/datalake/pod-datalake/src/handlers/blob.ts
@@ -70,7 +70,7 @@ export async function handleBlobGet (
   res.setHeader('Content-Security-Policy', "default-src 'none';")
   res.setHeader(
     'Content-Disposition',
-    filename !== undefined ? `attachment; filename*=UTF-8''${encodeURIComponent(filename)}"` : 'attachment'
+    filename !== undefined ? `attachment; filename*=UTF-8''${encodeURIComponent(filename)}` : 'attachment'
   )
   res.setHeader('Cache-Control', blob.cacheControl ?? cacheControl)
   res.setHeader('Last-Modified', new Date(blob.lastModified).toUTCString())
@@ -122,7 +122,10 @@ export async function handleBlobHead (
   res.setHeader('Content-Length', head.size.toString())
   res.setHeader('Content-Type', head.contentType ?? '')
   res.setHeader('Content-Security-Policy', "default-src 'none';")
-  res.setHeader('Content-Disposition', filename !== undefined ? `attachment; filename="${filename}"` : 'attachment')
+  res.setHeader(
+    'Content-Disposition',
+    filename !== undefined ? `attachment; filename*=UTF-8''${encodeURIComponent(filename)}` : 'attachment'
+  )
   res.setHeader('Cache-Control', head.cacheControl ?? cacheControl)
   res.setHeader('Last-Modified', new Date(head.lastModified).toUTCString())
   res.setHeader('ETag', wrapETag(head.etag))


### PR DESCRIPTION
Properly format Content-Disposition header in Datalake, so we can download blob with correct filename