### PR TITLE
Fix rendering of custom attributes without icons

### DIFF
--- a/plugins/setting-resources/src/components/ClassAttributeRow.svelte
+++ b/plugins/setting-resources/src/components/ClassAttributeRow.svelte
@@ -53,7 +53,7 @@
   <button class="hulyTableAttr-content__row-dragMenu" on:click|stopPropagation={clickMore}>
     <IconMoreV2 size={'small'} />
   </button>
-  {#if attribute.icon !== undefined}
+  {#if attribute.icon !== undefined && attribute.icon !== null}
     <div class="hulyTableAttr-content__row-icon">
       <Icon icon={attribute.icon} size={'small'} />
     </div>


### PR DESCRIPTION
Hello! I've stumbled into a bug – when a custom attribute is created without an icon, it has weird left padding, unlike other class attributes.

<img width="1073" alt="Screenshot 2025-06-04 at 18 10 51" src="https://github.com/user-attachments/assets/48b71e41-bd93-4e34-b612-1c32c949f2df" />


After some research, I've found out that it's not only a frontend bug of rendering 'empty' icon (which I fix in this PR): 
the app is sending correct values to the backend on attribute creation (setting icon to be 'undefined'), but the problem is caused by mongodb nodejs driver, [serializing 'undefined' values](https://www.mongodb.com/docs/drivers/node/current/fundamentals/bson/undefined-values/) (that are expected to be handled by the app) to 'null'. Thus, there might be other places in the platform code that are vulnerable to `!== undefined` checks

According to the article, a better option would probably be to pass flag 'ignoreUndefined' and completely remove 'undefined' fields from mongo documents, but I wouldn't be so sure if that change breaks more than it fixes, considering size of the platform

<img width="387" alt="Screenshot 2025-06-04 at 18 22 48" src="https://github.com/user-attachments/assets/73f899b2-75dc-42d4-a670-3935bfcf536e" />
