### PR TITLE
Don't show public spaces for readonly role

### DIFF
--- a/server/middleware/src/spaceSecurity.ts
+++ b/server/middleware/src/spaceSecurity.ts
@@ -466,7 +466,8 @@ export class SpaceSecurityMiddleware extends BaseMiddleware implements Middlewar
       ...this.systemSpaces,
       ...this.mainSpaces
     ]
-    const unfilteredRes = isData ? res : [...res, ...this.publicSpaces]
+    const ignorePublicSpaces = isData || account.role === AccountRole.ReadOnlyGuest
+    const unfilteredRes = ignorePublicSpaces ? res : [...res, ...this.publicSpaces]
     if (showArchived) {
       return unfilteredRes
     }


### PR DESCRIPTION
Since they won't be able to join them anyway. Readonly accounts will only see spaces to which they have been explicitly added.