### PR TITLE
Use LK api instead of webhook to track sessions

### DIFF
--- a/services/love/src/config.ts
+++ b/services/love/src/config.ts
@@ -30,6 +30,7 @@ interface Config {
 
   MongoUrl: string
   BillingUrl: string
+  BillingPollInterval: number
 }
 
 const envMap: { [key in keyof Config]: string } = {
@@ -47,7 +48,8 @@ const envMap: { [key in keyof Config]: string } = {
   Secret: 'SECRET',
   ServiceID: 'SERVICE_ID',
   MongoUrl: 'MONGO_URL',
-  BillingUrl: 'BILLING_URL'
+  BillingUrl: 'BILLING_URL',
+  BillingPollInterval: 'BILLING_POLL_INTERVAL'
 }
 
 const parseNumber = (str: string | undefined): number | undefined => (str !== undefined ? Number(str) : undefined)
@@ -66,7 +68,8 @@ const config: Config = (() => {
     Secret: process.env[envMap.Secret],
     ServiceID: process.env[envMap.ServiceID] ?? 'love-service',
     MongoUrl: process.env[envMap.MongoUrl],
-    BillingUrl: process.env[envMap.BillingUrl] ?? ''
+    BillingUrl: process.env[envMap.BillingUrl] ?? '',
+    BillingPollInterval: parseNumber(process.env[envMap.BillingPollInterval]) ?? 15
   }
 
   const optional = ['StorageConfig', 'S3StorageConfig', 'LiveKitProject', 'BillingUrl']

--- a/services/love/src/main.ts
+++ b/services/love/src/main.ts
@@ -284,15 +284,13 @@ export const main = async (): Promise<void> => {
       () => {
         try {
           void updateLiveKitSessions(ctx)
-        } catch {
-        }
+        } catch {}
       },
       config.BillingPollInterval * 60 * 1000
     )
     try {
       void updateLiveKitSessions(ctx)
-    } catch {
-    }
+    } catch {}
   }
 }
 

--- a/services/love/src/main.ts
+++ b/services/love/src/main.ts
@@ -37,7 +37,7 @@ import {
   WebhookReceiver
 } from 'livekit-server-sdk'
 import config from './config'
-import { saveLiveKitEgressBilling, saveLiveKitSessionBilling } from './billing'
+import { saveLiveKitEgressBilling, updateLiveKitSessions } from './billing'
 import { getS3UploadParams, saveFile } from './storage'
 import { WorkspaceClient } from './workspaceClient'
 import { join } from 'path'
@@ -135,11 +135,6 @@ export const main = async (): Promise<void> => {
       } else if (event.event === 'room_finished' && event.room !== undefined) {
         const { sid, name } = event.room
         ctx.info('webhook event', { event: event.event, room: { sid, name } })
-        try {
-          await saveLiveKitSessionBilling(ctx, event.room.sid)
-        } catch {
-          // Ensure we don't fail the webhook if billing fails
-        }
         res.send()
         return
       }
@@ -283,6 +278,22 @@ export const main = async (): Promise<void> => {
   process.on('unhandledRejection', (e) => {
     console.error(e)
   })
+
+  if (config.BillingUrl !== '') {
+    setInterval(
+      () => {
+        try {
+          void updateLiveKitSessions(ctx)
+        } catch {
+        }
+      },
+      config.BillingPollInterval * 60 * 1000
+    )
+    try {
+      void updateLiveKitSessions(ctx)
+    } catch {
+    }
+  }
 }
 
 const stopEgress = async (egressClient: EgressClient, roomName: string): Promise<void> => {


### PR DESCRIPTION
Since the webhook does not return all the necessary session data, we need to additionally request it via API, but it may become available there with a significant interval after the webhook. Therefore, instead, we request via API a list of all sessions that were created since yesterday, including unfinished ones, and update the information in billing.