### PR TITLE
UBERF-11529: Fix parseMail test

### DIFF
--- a/services/mail/pod-inbound-mail/src/__tests__/parseMail.test.ts
+++ b/services/mail/pod-inbound-mail/src/__tests__/parseMail.test.ts
@@ -16,7 +16,6 @@
 import fs from 'fs/promises'
 import path from 'path'
 import { MeasureContext } from '@hcengineering/core'
-import { parseContent } from '../utils'
 import { type MtaMessage } from '../types'
 
 // Mock config to ensure storage is available for tests
@@ -41,6 +40,7 @@ describe('parseContent', () => {
   })
 
   test('should parse email with attachment', async () => {
+    const { parseContent } = await import('../utils')
     const attachmentEml = await fs.readFile(path.join(__dirname, '__mocks__/attachment.txt'), 'utf-8')
     // Create MTA message from the sample email file
     const mtaMessage: MtaMessage = {
@@ -75,6 +75,7 @@ describe('parseContent', () => {
   })
 
   test('should parse email with 2 attachments', async () => {
+    const { parseContent } = await import('../utils')
     const attachmentEml = await fs.readFile(path.join(__dirname, '__mocks__/2attachments.txt'), 'utf-8')
     // Create MTA message from the sample email file
     const mtaMessage: MtaMessage = {


### PR DESCRIPTION
Import `parseContent` after config mock init