### PR TITLE
qfix: ignore ancestor error for txremovedoc

### DIFF
--- a/packages/core/src/hierarchy.ts
+++ b/packages/core/src/hierarchy.ts
@@ -376,7 +376,16 @@ export class Hierarchy {
   }
 
   private updateDescendant (_class: Ref<Classifier>, add = true): void {
-    const hierarchy = this.getAncestors(_class)
+    let hierarchy: Ref<Classifier>[] = []
+
+    try {
+      hierarchy = this.getAncestors(_class)
+    } catch (err) {
+      if (add) {
+        throw err
+      }
+    }
+
     for (const cls of hierarchy) {
       const list = this.descendants.get(cls)
       if (list === undefined) {


### PR DESCRIPTION
when deleting classes in wrong order, parent first then child, this code will always fail.
this pr makes it ignore ancestor errors for remove transactions