### PR TITLE
Fix error on removing default task states

### DIFF
--- a/plugins/contact-resources/src/components/DeleteConfirmationPopup.svelte
+++ b/plugins/contact-resources/src/components/DeleteConfirmationPopup.svelte
@@ -75,7 +75,7 @@
       </div>
       <div class="mb-2">
         <Label label={view.string.DeletePopupCreatorLabel} />
-        {#each creators as person}
+        {#each creators ?? [] as person}
           <div class="my-2">
             <PersonRefPresenter value={person} />
           </div>

--- a/plugins/contact-resources/src/components/DeleteConfirmationPopup.svelte
+++ b/plugins/contact-resources/src/components/DeleteConfirmationPopup.svelte
@@ -33,14 +33,14 @@
   const me = getCurrentEmployee()
   const objectArray = Array.isArray(object) ? object : [object]
   const dispatch = createEventDispatcher()
-  let creators: Ref<Person>[]
+  let creators: Ref<Person>[] | undefined
   $: getPersonRefsByPersonIdsCb(uniqueNotEmpty(objectArray.map((obj) => obj.createdBy)), (refs) => {
     creators = Array.from(refs.values())
   })
 
   $: canDelete =
     (skipCheck ||
-      (creators.length === 1 && creators[0] === me) ||
+      (creators !== undefined && creators.length === 1 && creators[0] === me) ||
       getCurrentAccount().role === AccountRole.Owner ||
       isAdminUser()) &&
     canDeleteExtra


### PR DESCRIPTION
Fixes issue #9265. The problem originated because default task states (e.g., 'todo'/'done') had an undefined `creators` property. Attempting to access `undefined.length` subsequently threw an error, which prevented users from deleting these objects.