### PR TITLE
fix: adjust video player controls

### DIFF
--- a/packages/hls/src/components/HlsVideo.svelte
+++ b/packages/hls/src/components/HlsVideo.svelte
@@ -58,7 +58,7 @@
   }
 
   const options: Plyr.Options = {
-    controls: ['play-large', 'play', 'progress', 'current-time', 'volume', 'settings', 'fullscreen']
+    controls: ['play-large', 'play', 'progress', 'current-time', 'mute', 'volume', 'settings', 'fullscreen']
   }
 
   function initialize (src: string): void {
@@ -193,5 +193,7 @@
   @import 'plyr/dist/plyr.css';
   :global(.plyr) {
     min-width: 10rem;
+    --plyr-control-spacing: 0.5rem;
+    --plyr-control-icon-size: 1rem;
   }
 </style>

--- a/plugins/attachment-resources/src/components/AttachmentVideoPreview.svelte
+++ b/plugins/attachment-resources/src/components/AttachmentVideoPreview.svelte
@@ -70,7 +70,7 @@
     {#if meta?.hls?.source !== undefined}
       <HlsVideo {src} {preload} hlsSrc={meta.hls.source} hlsThumbnail={meta.hls.thumbnail} />
     {:else}
-      <Video {src} {preload} {name} />
+      <Video {src} {name} preload />
     {/if}
   {/await}
 </div>

--- a/plugins/view-resources/src/components/viewer/VideoViewer.svelte
+++ b/plugins/view-resources/src/components/viewer/VideoViewer.svelte
@@ -39,7 +39,7 @@
 >
   {#if contentType.toLowerCase().endsWith('x-mpegurl')}
     {@const src = getFileUrl(value, '')}
-    <HlsVideo {src} hlsSrc={src} preload={true} />
+    <HlsVideo {src} hlsSrc={src} preload />
   {:else}
     {#await getVideoMeta(value, name) then meta}
       {#if meta?.hls?.source !== undefined}
@@ -47,7 +47,7 @@
         <HlsVideo {src} hlsSrc={meta.hls.source} hlsThumbnail={meta.hls.thumbnail} preload={false} />
       {:else}
         {@const src = getFileUrl(value, '')}
-        <Video {src} {name} />
+        <Video {src} {name} preload />
       {/if}
     {/await}
   {/if}


### PR DESCRIPTION
1. Adjust buttons and their size
2. Preload non-hls videos so we don't show empty player