### PR TITLE
Qfix: adding/deleting social ids

### DIFF
--- a/plugins/setting-resources/src/components/socialIds/SocialIdsEditor.svelte
+++ b/plugins/setting-resources/src/components/socialIds/SocialIdsEditor.svelte
@@ -79,7 +79,7 @@
             : loginSocialTypes.includes(socialId.type)
               ? !onlyLogin
               : true}
-        {#if socialIdProvider}
+        {#if socialIdProvider != null && socialId.type !== SocialIdType.HULY}
           <div class="item">
             <SocialIdPresenter {socialId} {socialIdProvider} {canRelease} on:released={handleAccountUpdated} />
           </div>


### PR DESCRIPTION
* Hide Huly social ids for now
* Fix update when removing multiple ids in a row
* Fix ensureEmployee to correctly handle when existing local person's social id is merged into an account
* Create/update local social id immediately upon adding
* Show displayValue if exists