### PR TITLE
Disable emoji img margin 

### DIFF
--- a/packages/presentation/src/components/IconWithEmoji.svelte
+++ b/packages/presentation/src/components/IconWithEmoji.svelte
@@ -55,6 +55,10 @@
     align-items: center;
     justify-content: center;
     color: black;
+
+    img {
+      margin: 0;
+    }
   }
   .emoji-inline {
     width: 1em;


### PR DESCRIPTION
@utkaka  please check and maybe change fix

I dont understand why we need it https://github.com/hcengineering/platform/blob/develop/packages/theme/styles/common.scss#L889

because of this the emoji is not centered and the layout is crooked