### PR TITLE
Added optional REPLY_TO for email service 

### DIFF
--- a/services/mail/pod-mail/README.md
+++ b/services/mail/pod-mail/README.md
@@ -11,6 +11,8 @@ Environment variables should be set to configure the Mail Service:
 - `PORT`: The port on which the mail service listens for incoming HTTP requests.
 - `API_KEY`: An API key that clients must pass. The parameter is optional, should be provided when external access to the service is allowed.
 - `SENTRY_DSN`: (optional) The Data Source Name for Sentry error tracking. This is optional and should be set if you wish to enable error tracking with Sentry.
+- `SOURCE`: The sender source (fallback for when emails emit from the system).
+- `REPLY_TO`: (optional) Email to use for replies (useful for uni-directional STMP setups where emails are only emitted, but not received).
 
 Settings for SMTP or SES email service should be specified, simultaneous use of both protocols is not supported
 

--- a/services/mail/pod-mail/src/config.ts
+++ b/services/mail/pod-mail/src/config.ts
@@ -19,6 +19,7 @@ dotenvConfig()
 export interface Config {
   port: number
   source?: string
+  replyTo?: string,
   sesConfig?: SesConfig
   smtpConfig?: SmtpConfig
 }
@@ -69,6 +70,7 @@ export function getTlsSettings (config: SmtpConfig): TlsSettings {
 const envMap = {
   Port: 'PORT',
   Source: 'SOURCE',
+  ReplyTo: 'REPLY_TO',
   DefaultProtocol: 'DEFAULT_PROTOCOL',
   SesAccessKey: 'SES_ACCESS_KEY',
   SesSecretKey: 'SES_SECRET_KEY',
@@ -157,6 +159,7 @@ const config: Config = (() => {
   const params: Config = {
     port,
     source: process.env[envMap.Source],
+    replyTo: process.env[envMap.ReplyTo],
     sesConfig: isSesConfig ? buildSesConfig() : undefined,
     smtpConfig: isSmtpConfig ? buildSmtpConfig() : undefined
   }

--- a/services/mail/pod-mail/src/config.ts
+++ b/services/mail/pod-mail/src/config.ts
@@ -19,7 +19,7 @@ dotenvConfig()
 export interface Config {
   port: number
   source?: string
-  replyTo?: string,
+  replyTo?: string
   sesConfig?: SesConfig
   smtpConfig?: SmtpConfig
 }

--- a/services/mail/pod-mail/src/main.ts
+++ b/services/mail/pod-mail/src/main.ts
@@ -109,6 +109,10 @@ export async function handleSendMail (
     subject,
     text
   }
+  // When sending system message, ensure we enable replying to a different domain as needed
+  if (config.replyTo !== undefined && fromAddress === config.source) {
+    message.replyTo = config.replyTo
+  }
   if (html !== undefined) {
     message.html = html
   }


### PR DESCRIPTION
While testing self-hosted Huly, I noted that my SMTP setups (the unidirectional ones) weren't available in a way where replies to emails would be caught.

This created situations where a password reset would be sent, or a notification - but replies to those emails would end up sucked into a SMTP hell where I'm unable to see them due to the fixed way I'm handling email domains. This PR adds an optional REPLY_TO environment variable that will apply itself when emails are being emitted from the same address as SOURCE (system emails).

I also updated the readme, since I noted that it didn't have the SOURCE env value documented.

> Rebased from #9489 - I forgot to enable signed commits on this specific machine