### PR TITLE
Use /usr/bin/env bash instead of /bin/bash in common scripts

### DIFF
--- a/common/scripts/fast-format.sh
+++ b/common/scripts/fast-format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo $@
 BASE_BRANCH=${1:-develop}
 while [[ "$#" -gt 0 ]]; do

--- a/common/scripts/mongo_dump.sh
+++ b/common/scripts/mongo_dump.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 MONGO_URL="mongodb://127.0.0.1:27017"
 DAYS=365
 dump='dump'

--- a/common/scripts/outdated.sh
+++ b/common/scripts/outdated.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the absolute path for the base directory
 BASE_DIR=$(pwd)


### PR DESCRIPTION
Improves compatibility with systems with non-standard bash location, a lot of scripts are already using it