### PR TITLE
Use internal mongodb url for account in tests

### DIFF
--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -124,7 +124,7 @@ services:
       - SERVER_SECRET=secret
       - ADMIN_EMAILS=admin,${PLATFORM_ADMIN_EMAILS}
       - WORKSPACE_LIMIT_PER_USER=100
-      - DB_URL=${MONGO_URL}
+      - DB_URL=mongodb://mongodb:27018
       - REGION_INFO=|America
       - TRANSACTOR_URL=ws://transactor:3334;ws://localhost:3334
       - STORAGE_CONFIG=${STORAGE_CONFIG}


### PR DESCRIPTION
For rootless docker MONGO_URL should be host-gateway but it is localhost, use internal url for consistency with other services