### PR TITLE
Fix grouping error in Execution viewlet configuration

### DIFF
--- a/models/process/src/index.ts
+++ b/models/process/src/index.ts
@@ -728,7 +728,7 @@ export function createModel (builder: Builder): void {
         baseMenuClass: process.class.Execution
       },
       viewOptions: {
-        groupBy: ['process', 'status', 'card'],
+        groupBy: ['process', 'currentState', 'card'],
         orderBy: [
           ['modifiedOn', SortingOrder.Descending],
           ['createdOn', SortingOrder.Descending]
@@ -753,12 +753,12 @@ export function createModel (builder: Builder): void {
           key: 'card'
         },
         {
-          key: '',
+          key: 'process',
           label: process.string.Process,
           presenter: process.component.ExecutonPresenter
         },
         {
-          key: '',
+          key: 'currentState',
           label: process.string.Step,
           presenter: process.component.ExecutonProgressPresenter
         },


### PR DESCRIPTION
Replace 'status' with 'currentState' in viewlet configuration for process.class.Execution.
<img width="370" alt="screen" src="https://github.com/user-attachments/assets/b4f08126-e7b9-4e0d-ae2f-5fbcf8195ad3" />
