### PR TITLE
Fix navigation buttons visibility on mobile devices

### DIFF
--- a/plugins/workbench-resources/src/components/Workbench.svelte
+++ b/plugins/workbench-resources/src/components/Workbench.svelte
@@ -1124,6 +1124,7 @@
   .hamburger-container {
     display: flex;
     align-items: center;
+    z-index: 1;
 
     &.portrait {
       margin-left: 1rem;

--- a/plugins/workbench-resources/src/components/Workbench.svelte
+++ b/plugins/workbench-resources/src/components/Workbench.svelte
@@ -1122,6 +1122,7 @@
   }
 
   .hamburger-container {
+    position: relative;
     display: flex;
     align-items: center;
     z-index: 1;


### PR DESCRIPTION
Fixed an issue where workspace selection and menu toggle buttons were not visible on mobile devices.
<img width="442" height="340" alt="screen" src="https://github.com/user-attachments/assets/fe3e06d1-dfff-4e2a-9eb3-cdd04b202081" />
