### PR TITLE
Hide excluded apps for guests

### DIFF
--- a/plugins/workbench-resources/src/components/Applications.svelte
+++ b/plugins/workbench-resources/src/components/Applications.svelte
@@ -57,7 +57,7 @@
   function updateExcludedApps (): void {
     const me = getCurrentAccount()
 
-    if (me.role === AccountRole.ReadOnlyGuest) {
+    if (me.role === AccountRole.ReadOnlyGuest || me.role === AccountRole.Guest) {
       excludedApps = getMetadata(workbench.metadata.ExcludedApplicationsForAnonymous) ?? []
     } else {
       excludedApps = []

--- a/plugins/workbench-resources/src/components/Workbench.svelte
+++ b/plugins/workbench-resources/src/components/Workbench.svelte
@@ -766,7 +766,7 @@
   function isExcludedApp (alias: string): boolean {
     const me = getCurrentAccount()
 
-    if (me.role === AccountRole.ReadOnlyGuest) {
+    if (me.role === AccountRole.ReadOnlyGuest || me.role === AccountRole.Guest) {
       return (getMetadata(workbench.metadata.ExcludedApplicationsForAnonymous) ?? []).includes(alias)
     } else {
       return false


### PR DESCRIPTION
Guests should see the same apps as anonymous guests