### PR TITLE
Fixes display of custom attributes in ListView

### DIFF
--- a/models/card/src/index.ts
+++ b/models/card/src/index.ts
@@ -170,7 +170,7 @@ export class TFavoriteCard extends TPreference implements FavoriteCard {
 export * from './migration'
 
 const listConfig: (BuildModelKey | string)[] = [
-  { key: '', props: { showParent: true } },
+  { key: '' },
   { key: '_class' },
   { key: '', displayProps: { grow: true } },
   {
@@ -180,14 +180,13 @@ const listConfig: (BuildModelKey | string)[] = [
     props: {
       showType: false
     },
-    displayProps: { key: 'tags', fixed: 'right' }
+    displayProps: { optional: true }
   },
   {
     key: '',
     presenter: card.component.LabelsPresenter,
     label: card.string.Labels,
-    props: { fullSize: true },
-    displayProps: { fixed: 'right', key: 'labels' }
+    props: { fullSize: true }
   },
   {
     key: 'modifiedOn',

--- a/packages/theme/styles/components.scss
+++ b/packages/theme/styles/components.scss
@@ -2504,6 +2504,8 @@
   }
   .panel-trigger > * { pointer-events: none; }
 }
+// Custom on the ListView
+.list-container .listGrid .yesno-container { flex-shrink: 0; }
 // Labels on the ListView
 .list-container .listitems-container,
 .list-container .listitems-container:hover,

--- a/plugins/contact-resources/src/components/AssigneeBox.svelte
+++ b/plugins/contact-resources/src/components/AssigneeBox.svelte
@@ -132,7 +132,7 @@
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
-<div {id} bind:this={container} class="min-w-0 h-full" class:w-full={width === '100%'} style:flex-shrink={shrink}>
+<div {id} bind:this={container} class="min-w-0" class:w-full={width === '100%'} style:flex-shrink={shrink}>
   {#if $$slots.content}
     <div
       class="w-full h-full flex-streatch"

--- a/plugins/view-resources/src/components/EnumEditor.svelte
+++ b/plugins/view-resources/src/components/EnumEditor.svelte
@@ -33,7 +33,7 @@
 
   const query = createQuery()
 
-  query.query(
+  $: query.query(
     core.class.Enum,
     {
       _id: type.of

--- a/plugins/view-resources/src/components/ViewletSetting.svelte
+++ b/plugins/view-resources/src/components/ViewletSetting.svelte
@@ -111,9 +111,10 @@
         if (param.length === 0) {
           result.push(getObjectConfig(viewlet.attachTo, param))
         } else {
+          const paramValue = param.startsWith('custom') ? { key: param, displayProps: { optional: true } } : param
           const attrCfg: AttributeConfig = {
             type: 'attribute',
-            value: param,
+            value: paramValue,
             enabled: true,
             label: getKeyLabel(client, viewlet.attachTo, param, lookup),
             _class: viewlet.attachTo,
@@ -201,9 +202,12 @@
         result.push(newValue)
       }
     } else {
+      const isCustomAttribute = attribute.name.startsWith('custom')
+      const attributeValue = isCustomAttribute ? { key: value, displayProps: { optional: true } } : value
+
       const newValue: AttributeConfig = {
         type: 'attribute',
-        value: extraProps ? { ...extraProps, key: value } : value,
+        value: extraProps != null ? { ...extraProps, key: value } : attributeValue,
         label: attribute.label,
         enabled: false,
         _class: attribute.attributeOf,
@@ -272,7 +276,13 @@
         ((p.type === 'divider' && typeof p.value === 'object' && p.value.displayProps?.grow) ||
           (p.type === 'attribute' && (p as AttributeConfig).enabled))
     )
-    const config = configValues.map((p) => p.value as string | BuildModelKey)
+    const config = configValues.map((p) => {
+      const value = p.value as string | BuildModelKey
+      if (typeof value === 'string' && value.startsWith('custom')) {
+        return { key: value, displayProps: { optional: true } }
+      }
+      return value
+    })
     const preference = preferences.find((p) => p.attachedTo === viewletId)
     if (preference !== undefined) {
       await client.update(preference, {

--- a/plugins/view-resources/src/components/list/ListItem.svelte
+++ b/plugins/view-resources/src/components/list/ListItem.svelte
@@ -22,7 +22,6 @@
   import view from '../../plugin'
   import GrowPresenter from './GrowPresenter.svelte'
   import ListPresenter from './ListPresenter.svelte'
-  import { restrictionStore } from '../../utils'
 
   export let docObject: Doc
   export let model: AttributeModel[]


### PR DESCRIPTION
### Changes:
- **ViewletSetting.svelte**: Added automatic processing of custom fields with `displayProps: { optional: true }`
- **Data migration**: Added migration to update existing viewlet configurations, transforming custom field strings to objects with displayProps
- **Minor fixes**: Removed unused imports, fixed reactivity in EnumEditor, added CSS styles

### Result:
Custom fields now correctly display in the hidden panel of compact mode, providing better UX when working with user-defined attributes.

<img width="496" alt="screen-full" src="https://github.com/user-attachments/assets/357c6d4f-a916-4968-b025-4aa4ac00240b" /> <img width="232" alt="screen-min" src="https://github.com/user-attachments/assets/3d1fe494-fd25-44ce-9341-6bb2d232f846" /> <img width="375" alt="screen-compact-1" src="https://github.com/user-attachments/assets/9622594a-c94f-441c-88bd-8aad14bf5663" /> <img width="375" alt="screen-compact-2" src="https://github.com/user-attachments/assets/8ada9b58-dc6a-46fa-9e72-1079d7924a2d" />
