### PR TITLE
alt+tab in desktop fix: drops menu focus now

### DIFF
--- a/desktop/src/main/start.ts
+++ b/desktop/src/main/start.ts
@@ -273,6 +273,10 @@ const createWindow = async (): Promise<void> => {
     mainWindow?.webContents.send('window-state-changed', maximized ? 'maximized' : 'unmaximized')
   }
 
+  mainWindow.on('blur', () => {
+    mainWindow?.webContents.send('window-focus-loss')
+  });
+
   mainWindow.on('maximize', () => {
     sendWindowMaximizedMessage(true)
   });
@@ -309,8 +313,18 @@ function sendCommand(cmd: string, ...args: any[]): void {
   mainWindow?.webContents.send(cmd, ...args)
 }
 
+function activateWindow (): void {
+  if (mainWindow) {
+    if (mainWindow.isMinimized()) {
+      mainWindow.restore()
+    }
+    mainWindow.show()
+    mainWindow.focus()
+  }
+}
+
 if (isWindows) {
-  setupWindowsSpecific(sendCommand)
+  setupWindowsSpecific(activateWindow, sendCommand)
 } else {
   addMenus(sendCommand)
 }

--- a/desktop/src/ui/preload.ts
+++ b/desktop/src/ui/preload.ts
@@ -78,6 +78,10 @@ const expose: IPCMainExposed = {
     ipcRenderer.on('window-state-changed', callback)
   },
 
+  onWindowFocusLoss: (callback) => {
+    ipcRenderer.on('window-focus-loss', callback)
+  },
+
   isOsUsingDarkTheme: async ()  =>  { 
     return await ipcRenderer.invoke('get-is-os-using-dark-theme')
   },

--- a/desktop/src/ui/titleBarMenu.ts
+++ b/desktop/src/ui/titleBarMenu.ts
@@ -19,7 +19,7 @@ import { TitleBarMenuState } from './titleBarMenuState'
 
 export function setupTitleBarMenu(ipcMain: IPCMainExposed, root: HTMLElement): MenuBar {
     const themeManager = new ThemeManager('light')
-    const menuManager = new MenuBarManager(ipcMain, root)
+    const menuManager = new MenuBarManager(root)
 
     const menuBar = menuManager.getView();
 
@@ -282,7 +282,7 @@ class MenuBarManager {
     private readonly StateStyleKeyboardSelected = 'desktop-app-keyboard-selected'
     private readonly StateStyleAltModeActive = 'desktop-app-alt-active'
 
-    constructor(ipcMain: IPCMainExposed, private readonly root: HTMLElement) {
+    constructor(private readonly root: HTMLElement) {
         this.state = new TitleBarMenuState(
             () => this.topLevelMenus().length,
             (topLevelMenuIndex: number) => {
@@ -333,6 +333,13 @@ class MenuBarManager {
 
         document.querySelectorAll<HTMLButtonElement>(this.DropdownItemStyle + '[data-action]').forEach(item => {
             item.addEventListener('click', async () => this.handleMenuButtonClick(ipcMain, item))
+        })
+
+        ipcMain.onWindowFocusLoss(() => {
+            this.state.exitAltMode()
+            this.altPressed = false
+            this.controlKeysActivated = false
+            this.renderState()
         })
     }
 

--- a/desktop/src/ui/types.ts
+++ b/desktop/src/ui/types.ts
@@ -142,6 +142,8 @@ export interface IPCMainExposed {
   maximizeWindow: () => void
   closeWindow: () => void
   onWindowStateChange: (callback: (event: IpcRendererEvent, newState: string) => void) => void
+  onWindowFocusLoss: (callback: () => void) => void
+  
   isOsUsingDarkTheme: () => Promise<boolean>
   executeMenuBarAction: (action: MenuBarAction) => void
 


### PR DESCRIPTION
This pull request introduces improvements to window focus handling and streamlines the menu bar management, particularly for the Windows platform. The main changes include sending a new event when the window loses focus, updating the Windows-specific setup to ensure the app window is activated when handling jump list commands, and simplifying the `MenuBarManager`'s dependencies and behavior.