### PR TITLE
Change lk connection options

### DIFF
--- a/plugins/love-resources/src/liveKitClient.ts
+++ b/plugins/love-resources/src/liveKitClient.ts
@@ -76,34 +76,40 @@ export class LiveKitClient {
   async connect (wsURL: string, token: string, withVideo: boolean): Promise<void> {
     this.currentSessionSupportsVideo = withVideo
     try {
-      const [, session] = await Promise.all([
-        this.liveKitRoom.connect(wsURL, token, { maxRetries: 3 }),
-        useMedia({
+      const setupMediaSession = async () => {
+        this.currentMediaSession = await useMedia({
           state: {
             camera: this.currentSessionSupportsVideo ? { enabled: $myPreferences?.camEnabled ?? true } : undefined,
             microphone: { enabled: $myPreferences?.micEnabled ?? this.liveKitRoom.remoteParticipants.size < 16 }
           },
           autoDestroy: false
         })
+      }
+      await Promise.all([
+        this.liveKitRoom.connect(wsURL, token, {
+          maxRetries: 1,
+          websocketTimeout: 10000,
+          peerConnectionTimeout: 10000
+        }),
+        setupMediaSession() 
       ])
 
-      this.currentMediaSession = session
-      session?.on('camera', (enabled) => {
+      this.currentMediaSession?.on('camera', (enabled) => {
         void this.setCameraEnabled(enabled)
       })
-      session?.on('microphone', (enabled) => {
+      this.currentMediaSession?.on('microphone', (enabled) => {
         void this.setMicrophoneEnabled(enabled)
       })
-      session?.on('selected-camera', (deviceId) => {
+      this.currentMediaSession?.on('selected-camera', (deviceId) => {
         void this.setActiveCamera(deviceId)
       })
-      session?.on('selected-microphone', (deviceId) => {
+      this.currentMediaSession?.on('selected-microphone', (deviceId) => {
         void this.setActiveMicrophone(deviceId)
       })
-      session?.on('selected-speaker', (deviceId) => {
+      this.currentMediaSession?.on('selected-speaker', (deviceId) => {
         void this.setActiveSpeaker(deviceId)
       })
-      session?.on('feature', (feature, enabled) => {
+      this.currentMediaSession?.on('feature', (feature, enabled) => {
         if (feature !== 'sharing') return
         void this.setScreenShareEnabled(enabled, true)
       })
@@ -111,6 +117,7 @@ export class LiveKitClient {
       await this.updateActiveDevices()
     } catch (error) {
       this.currentMediaSession?.close()
+      this.currentMediaSession?.removeAllListeners()
       this.currentMediaSession = undefined
       throw error
     }

--- a/plugins/love-resources/src/liveKitClient.ts
+++ b/plugins/love-resources/src/liveKitClient.ts
@@ -76,7 +76,7 @@ export class LiveKitClient {
   async connect (wsURL: string, token: string, withVideo: boolean): Promise<void> {
     this.currentSessionSupportsVideo = withVideo
     try {
-      const setupMediaSession = async () => {
+      const setupMediaSession = async (): Promise<void> => {
         this.currentMediaSession = await useMedia({
           state: {
             camera: this.currentSessionSupportsVideo ? { enabled: $myPreferences?.camEnabled ?? true } : undefined,
@@ -91,7 +91,7 @@ export class LiveKitClient {
           websocketTimeout: 10000,
           peerConnectionTimeout: 10000
         }),
-        setupMediaSession() 
+        setupMediaSession()
       ])
 
       this.currentMediaSession?.on('camera', (enabled) => {

--- a/plugins/love-resources/src/utils.ts
+++ b/plugins/love-resources/src/utils.ts
@@ -370,22 +370,6 @@ function parseMetadata (metadata: string | undefined): RoomMetadata {
   }
 }
 
-async function withRetries (fn: () => Promise<void>, retries: number, delay: number): Promise<void> {
-  for (let attempt = 0; attempt < retries; attempt++) {
-    try {
-      await fn()
-      return
-    } catch (error) {
-      if (attempt >= retries - 1) {
-        throw error
-      }
-      console.error(error)
-      console.log(`Attempt ${attempt} failed. Retrying in ${delay}ms...`)
-      await new Promise((resolve) => setTimeout(resolve, delay))
-    }
-  }
-}
-
 export async function disconnect (): Promise<void> {
   await liveKitClient.disconnect()
   screenSharing.set(false)
@@ -536,13 +520,7 @@ export async function connectRoom (
   await disconnect()
   const token = await getToken(room.name, room._id, currentPerson._id, currentPerson.name)
   try {
-    await withRetries(
-      async () => {
-        await connectLK(token, room)
-      },
-      3,
-      1000
-    )
+    await connectLK(token, room)
   } catch (err) {
     console.error(err)
     await leaveRoom(currentInfo, get(myOffice))


### PR DESCRIPTION
- Fixed a bug with incorrect termination of a media session in case of a failed connection attempt
- The timeout for establishing a connection with the livekit server is set to 10 seconds instead of the default 15
- The number of reconnect attempts is set to 1. Because it turns out that this is the number of consecutive attempts to connect to one LiveKit region from several available. And we should probably try to connect to others as soon as possible.