### PR TITLE
Fix race condition during lk connection

### DIFF
--- a/plugins/love-resources/src/liveKitClient.ts
+++ b/plugins/love-resources/src/liveKitClient.ts
@@ -40,6 +40,7 @@ const defaultCaptureOptions: VideoCaptureOptions = {
 export class LiveKitClient {
   public readonly liveKitRoom: LKRoom
 
+  public isConnecting: boolean = false
   public currentMediaSession: MediaSession | undefined = undefined
   private currentSessionSupportsVideo: boolean = false
   private lastParticipantNotificationTimeout: number = -1
@@ -74,6 +75,7 @@ export class LiveKitClient {
   }
 
   async connect (wsURL: string, token: string, withVideo: boolean): Promise<void> {
+    this.isConnecting = true
     this.currentSessionSupportsVideo = withVideo
     try {
       const setupMediaSession = async (): Promise<void> => {
@@ -116,6 +118,7 @@ export class LiveKitClient {
 
       await this.updateActiveDevices()
     } catch (error) {
+      this.isConnecting = false
       this.currentMediaSession?.close()
       this.currentMediaSession?.removeAllListeners()
       this.currentMediaSession = undefined
@@ -146,6 +149,7 @@ export class LiveKitClient {
   }
 
   onConnected = (): void => {
+    this.isConnecting = false
     lkSessionConnected.set(true)
     this.liveKitRoom.on(RoomEvent.ParticipantConnected, this.onParticipantConnected)
     this.liveKitRoom.on(RoomEvent.ParticipantDisconnected, this.onParticipantDisconnected)

--- a/plugins/love-resources/src/utils.ts
+++ b/plugins/love-resources/src/utils.ts
@@ -512,6 +512,7 @@ export async function connectRoom (
   currentPerson: Person,
   room: Room
 ): Promise<void> {
+  liveKitClient.isConnecting = true
   await moveToRoom(x, y, currentInfo, currentPerson, room, getMetadata(presentation.metadata.SessionId) ?? null)
   selectedRoomPlace.set(undefined)
   if (getCurrentAccount().role === AccountRole.ReadOnlyGuest) {
@@ -580,6 +581,7 @@ export async function tryConnect (
   currentInvites: Invite[],
   place?: { x: number, y: number }
 ): Promise<void> {
+  if (liveKitClient.isConnecting) return
   const me = getCurrentEmployee()
   const currentPerson = await getPersonByPersonRef(me)
   if (currentPerson == null) return


### PR DESCRIPTION
When trying to join a meeting from outside the office (for example, while in the chat, join via the room button in the upper left corner), two connections to the livekit are created at once and both fail, which prevents you from connecting on the first try. The real cause of the problem is somewhat deeper in the logic of the components. Therefore, for now, as a quick solution to the problem, we exclude the second connection using a temporary flag