### PR TITLE
fix: use auto image aspect ratio in text editor

### DIFF
--- a/packages/theme/styles/_text-editor.scss
+++ b/packages/theme/styles/_text-editor.scss
@@ -303,6 +303,7 @@
 .text-editor-image-container {
   img {
     max-width: 100%;
+    height: auto;
   }
 }
 


### PR DESCRIPTION
prevent image shrink on small screens