### PR TITLE
Fix layout for new card from message popup

### DIFF
--- a/packages/theme/styles/components.scss
+++ b/packages/theme/styles/components.scss
@@ -642,6 +642,7 @@
     border: 1px solid var(--theme-popup-divider); // var(--global-surface-02-BorderColor);
     border-radius: var(--large-BorderRadius);
     box-shadow: var(--global-modal-ShadowX) var(--global-modal-ShadowY) var(--global-modal-ShadowBlur) var(--global-modal-ShadowSpread) var(--global-popover-ShadowColor);
+    max-width: 90vw;
 
     &.large {
       min-width: unset;

--- a/plugins/card-resources/src/components/CreateCardPopup.svelte
+++ b/plugins/card-resources/src/components/CreateCardPopup.svelte
@@ -172,7 +172,7 @@
       bind:content={description}
       placeholder={core.string.Description}
       kind="indented"
-      isScrollable={false}
+      isScrollable={true}
       kitOptions={{ reference: true }}
       enableAttachments={false}
     />


### PR DESCRIPTION
Before:
<img width="2047" height="683" src="https://github.com/user-attachments/assets/23d32d71-aa88-49a0-9899-b530525f9981" alt="createCard">
After:
<img width="1435" height="643" src="https://github.com/user-attachments/assets/aaee0325-7819-4013-a669-e352d38be0f4" alt="Screenshot 2025-09-29 at 09 12 48">