### PR TITLE
fix(account): handle single-word names in OIDC and GitHub auth providers

### DIFF
--- a/pods/authProviders/src/github.ts
+++ b/pods/authProviders/src/github.ts
@@ -57,7 +57,9 @@ export function registerGithub (
     },
     async (ctx, next) => {
       const email = ctx.state.user.emails?.[0]?.value
-      const [first, last] = ctx.state.user.displayName?.split(' ') ?? [ctx.state.user.username, '']
+      const nameParts = (ctx.state.user.displayName ?? ctx.state.user.username ?? '').split(' ')
+      const first: string = nameParts[0] ?? ''
+      const last: string = nameParts.slice(1).join(' ')
       const db = await dbPromise
 
       const redirectUrl = await handleProviderAuth(

--- a/pods/authProviders/src/openid.ts
+++ b/pods/authProviders/src/openid.ts
@@ -87,7 +87,9 @@ export function registerOpenid (
     async (ctx, next) => {
       const email = ctx.state.user.email
       const verifiedEmail = (ctx.state.user.email_verified as boolean) ? email : ''
-      const [first, last] = ctx.state.user.name?.split(' ') ?? [ctx.state.user.username, '']
+      const nameParts = (ctx.state.user.name ?? ctx.state.user.username ?? '').split(' ')
+      const first: string = ctx.state.user.given_name ?? nameParts[0] ?? ''
+      const last: string = ctx.state.user.family_name ?? nameParts.slice(1).join(' ')
 
       const db = await dbPromise
       const redirectUrl = await handleProviderAuth(

--- a/server/account/src/utils.ts
+++ b/server/account/src/utils.ts
@@ -1547,7 +1547,7 @@ export async function loginOrSignUpWithProvider (
         return null
       }
 
-      personUuid = await db.person.insertOne({ firstName: first, lastName: last })
+      personUuid = await db.person.insertOne({ firstName: first, lastName: last ?? '' })
     }
 
     if (personUuid == null) {


### PR DESCRIPTION
## Summary

Fixes #10628

When a user's display name contains no spaces (common for CJK names like `"西门吹雪"`), `name.split(' ')` returns a single-element array, so the last name destructures as `undefined`. This gets passed directly to the DB insert, causing a PostgreSQL `NOT NULL` constraint violation on `last_name` and a silent auth failure ("Not Found" page for the user).

### Changes

- **`pods/authProviders/src/openid.ts`**: Prefer standard OIDC `given_name`/`family_name` claims (available when `profile` scope is requested) when available; fall back to splitting `name` using `parts[0]` / `parts.slice(1).join(' ')` so last name is always a `string`
- **`pods/authProviders/src/github.ts`**: Same `slice(1).join(' ')` fix for GitHub's `displayName`
- **`server/account/src/utils.ts`**: Add `?? ''` defensive fallback in `loginOrSignUpWithProvider` at the `insertOne` call — mirrors the existing pattern in `signUpByGrant` (line 720)

### Test plan

- [x] OIDC login with a single-word CJK name (e.g. `"西门吹雪"`) creates user with `first_name="西门吹雪"`, `last_name=""`
- [x] OIDC login with a multi-word Western name (e.g. `"Jean Claude"`) still splits correctly: `first="Jean"`, `last="Claude"`
- [x] OIDC login with an IdP that provides `given_name`/`family_name` claims uses those directly
- [ ] GitHub login with a single-word username/display name creates user correctly
- [ ] Existing OIDC and GitHub auth flows unaffected