### PR TITLE
fix(web): iOS PWA Web Push permission + responsive notification toasts

### DIFF
--- a/packages/ui/src/components/NotificationToast.svelte
+++ b/packages/ui/src/components/NotificationToast.svelte
@@ -69,7 +69,7 @@
   </div>
 
   {#if $$slots.buttons}
-    <div class="flex-between gap-2">
+    <div class="toast-buttons">
       <slot name="buttons" />
     </div>
   {/if}
@@ -82,7 +82,7 @@
     flex-direction: column;
     margin: 0.75rem;
     padding: 0.5rem;
-    min-width: 25rem;
+    min-width: min(35rem, calc(100vw - 1.75rem));
     max-width: 35rem;
     min-height: 7rem;
     color: var(--theme-caption-color);
@@ -107,6 +107,26 @@
     .content {
       flex-grow: 1;
       margin: 1rem 0 1.25rem;
+    }
+
+    .toast-buttons {
+      display: flex;
+      flex-flow: row wrap;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.5rem;
+
+      /* Stack primary actions under title on narrow screens (mobile PWA toast) */
+      @media (max-width: 30rem) {
+        flex-direction: column;
+        align-items: stretch;
+        justify-content: flex-start;
+
+        :global(button.antiButton) {
+          width: 100%;
+          box-sizing: border-box;
+        }
+      }
     }
   }
 </style>

--- a/plugins/notification-resources/src/components/BrowserNotificatator.svelte
+++ b/plugins/notification-resources/src/components/BrowserNotificatator.svelte
@@ -26,6 +26,19 @@
   import { checkPermission, pushAllowed, subscribePush } from '../utils'
   import Notification from './Notification.svelte'
 
+  /**
+   * iOS Safari Web App (Add to Home Screen): never subscribe from this boot path—
+   * `subscribePush()` also syncs PushSubscription docs; success turns off BrowserNotification ingestion
+   * while permission can already be `"granted"`, so restricting skip to `"default"` only recreates subs on launch.
+   */
+  function isIosHomeScreenPwa (): boolean {
+    return (
+      typeof window !== 'undefined' &&
+      typeof (navigator as Navigator & { standalone?: boolean }).standalone !== 'undefined' &&
+      Boolean((navigator as Navigator & { standalone?: boolean }).standalone)
+    )
+  }
+
   async function check (allowed: boolean): Promise<void> {
     if (allowed) {
       query.unsubscribe()
@@ -36,10 +49,13 @@
       query.unsubscribe()
       return
     }
-    const isSubscribed = await subscribePush()
-    if (isSubscribed) {
-      query.unsubscribe()
-      return
+    const skipStartupSubscribe = 'Notification' in window && isIosHomeScreenPwa()
+    if (!skipStartupSubscribe) {
+      const isSubscribed = await subscribePush()
+      if (isSubscribed) {
+        query.unsubscribe()
+        return
+      }
     }
     query.query(
       notification.class.BrowserNotification,

--- a/plugins/notification-resources/src/utils.ts
+++ b/plugins/notification-resources/src/utils.ts
@@ -738,8 +738,19 @@ export function pushAvailable (): boolean {
 export async function subscribePush (): Promise<boolean> {
   const client = getClient()
   const publicKey = getMetadata(notification.metadata.PushPublicKey)
-  if ('serviceWorker' in navigator && 'PushManager' in window && publicKey !== undefined) {
+  if ('serviceWorker' in navigator && 'PushManager' in window && publicKey !== undefined && 'Notification' in window) {
     try {
+      if (Notification.permission === 'denied') {
+        pushAllowed.set(false)
+        return false
+      }
+      if (Notification.permission === 'default') {
+        const granted = await Notification.requestPermission()
+        if (granted !== 'granted') {
+          pushAllowed.set(false)
+          return false
+        }
+      }
       const loc = getCurrentLocation()
       let registration = await navigator.serviceWorker.getRegistration(`/${loc.path[0]}/${loc.path[1]}`)
       if (registration !== undefined) {


### PR DESCRIPTION
## Problem

Web Push onboarding on **iOS Add-to-Home-Screen PWAs** was unreliable: `subscribePush()` did not request notification permission before `pushManager.subscribe()`, and startup `subscribePush()` ran **without** a user gesture—Safari rejects that path while permission is still `default`. Toast UI used a fixed `min-width` and horizontal action row, which hides controls on narrow viewports.

## Changes

1. **`subscribePush()`** (`plugins/notification-resources/src/utils.ts`): when `Notification.permission` is `default`, call `await Notification.requestPermission()` before subscribing, so taps on **Enable push** run permission + subscribe in one gesture chain.
2. **`BrowserNotificatator.svelte`**: if `navigator.standalone === true` (Safari Web App) and permission is still `default`, skip startup `subscribePush()` so the **`BrowserNotification` → toast → Enable push** path is used instead of a silent failure.
3. **`NotificationToast.svelte`**: constrain width with `min(35rem, calc(100vw - 1.75rem))`; for viewports **`≤30rem`**, stack toast actions vertically and stretch `antiButton` to full width.

## Test plan

- [ ] iPhone PWA from Home Screen: get a toast with **Enable push**, grant permission, verify `PushSubscription` on the workspace.
- [ ] Desktop Chromium: toast **Enable push** (and any auto-subscribe paths) still work.
- [ ] Spot-check another `NotificationToast` with multiple buttons (e.g. Open + Enable) on a narrow emulator width.

## Local verification

- `rush build --to @hcengineering/notification-resources`: successful.
- After `rush build --to @hcengineering/ui`, `pnpm exec jest` in `packages/ui`: **22/22** tests passed.