### PR TITLE
fix(ci): emit TypeScript declarations in tag npm publish workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -968,6 +968,8 @@ jobs:
         run: node common/scripts/install-run-rush.js install
       - name: Building...
         run: node common/scripts/install-run-rush.js build
+      - name: Emit TypeScript declarations
+        run: node common/scripts/install-run-rush.js validate
       - name: Publish to npm
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Follow-up to #10768.

#10768 fixed the manual npm publish workflow (`.github/workflows/publish-npm.yml`) by running `rush validate` before `safe-publish.js`, but there is a second npm publication path in `.github/workflows/main.yml`: the tag-release `publish-npm` job.

That job still runs:

```yaml
- name: Building...
  run: node common/scripts/install-run-rush.js build
- name: Publish to npm
  run: node common/scripts/safe-publish.js
```

So tag releases can still publish packages after `rush build` only. `rush build` emits `lib/`; declarations are emitted by `rush validate`. This appears to be why `0.7.423` was published without declarations again.

## Evidence

Previous report and fix:

- #10767 reported `0.7.413` packages advertising `types/index.d.ts` while omitting `types/`.
- #10768 fixed that for `.github/workflows/publish-npm.yml`.

Current regression:

```bash
pnpm view @hcengineering/core@0.7.423 types
# types/index.d.ts

tmp=$(mktemp -d)
url=$(pnpm view @hcengineering/core@0.7.423 dist.tarball)
curl -fsSL "$url" -o "$tmp/core.tgz"
tar -tzf "$tmp/core.tgz" | grep '^package/types/'
# no output
```

`@hcengineering/core@0.7.423` and `@hcengineering/client@0.7.423` npm metadata point at git head `a00c01352d8ca78cf4a1367d57d136c7908d2dcb`.

The tag workflow run for `v0.7.423` is:

https://github.com/hcengineering/platform/actions/runs/25616518363

That publish path comes from `.github/workflows/main.yml`, not the workflow fixed in #10768.

## Local before/after

On tag `v0.7.423`, after clearing generated output for `@hcengineering/core`:

| Step | `lib/index.js` packed | `types/index.d.ts` packed | `types/` entries |
| --- | --- | --- | ---: |
| `rush build --to @hcengineering/core` | yes | no | 0 |
| `rush validate --to @hcengineering/core` after build | yes | yes | 94 |

So adding `rush validate` before publish fixes the packed artifact contents.

## Change

Add the same declaration-emission step to `.github/workflows/main.yml`'s `publish-npm` job that #10768 added to `.github/workflows/publish-npm.yml`.
