### PR TITLE
fix(client): downgrade slow query diagnostics

### DIFF
--- a/foundations/core/packages/client-resources/src/connection.ts
+++ b/foundations/core/packages/client-resources/src/connection.ts
@@ -777,7 +777,7 @@ class Connection implements ClientConnection {
       params: [_class, query, options],
       measure: (time, result, serverTime, queue, toReceive) => {
         if (typeof window !== 'undefined' && (time > 1000 || serverTime > 500)) {
-          console.error(
+          console.warn(
             'measure slow findAll',
             time,
             serverTime,


### PR DESCRIPTION
## Summary

- Change slow client `findAll` measurements from `console.error` to `console.warn`.
- Keep the existing slow-query thresholds, log message, payload, and timing details unchanged.
- Clarify that successful-but-slow client queries are performance diagnostics rather than query errors.

## Testing

- `git diff --check upstream/develop...HEAD`
- `git diff --check`
- `node common/scripts/install-run-rush.js build --to @hcengineering/client-resources`

## Notes

- This only changes the browser console severity for slow-query diagnostics. It does not change query execution, thresholds, or diagnostic payloads.