### PR TITLE
fix(notification): ignore blank browser push keys

### DIFF
--- a/plugins/notification-resources/src/utils.ts
+++ b/plugins/notification-resources/src/utils.ts
@@ -731,7 +731,7 @@ function addWorkerListener (): void {
 
 export function pushAvailable (): boolean {
   if (isDesktopClient()) return false
-  const publicKey = getMetadata(notification.metadata.PushPublicKey)
+  const publicKey = getPushPublicKey()
   return (
     'serviceWorker' in navigator &&
     'PushManager' in window &&
@@ -747,7 +747,7 @@ export async function subscribePush (): Promise<boolean> {
     return false
   }
   const client = getClient()
-  const publicKey = getMetadata(notification.metadata.PushPublicKey)
+  const publicKey = getPushPublicKey()
   if ('serviceWorker' in navigator && 'PushManager' in window && publicKey !== undefined) {
     try {
       const loc = getCurrentLocation()
@@ -800,6 +800,12 @@ export async function subscribePush (): Promise<boolean> {
   }
   pushAllowed.set(false)
   return false
+}
+
+function getPushPublicKey (): string | undefined {
+  const publicKey = getMetadata(notification.metadata.PushPublicKey)
+  if (publicKey === undefined) return undefined
+  return publicKey.trim() !== '' ? publicKey : undefined
 }
 
 async function cleanTag (_id: Ref<Doc>): Promise<void> {


### PR DESCRIPTION
## Summary

- Treat an unset or blank browser push public key as disabled browser push support.
- Reuse a normalized push-key accessor in both browser push availability checks and push subscription setup.
- Preserve existing behavior when a valid VAPID public key is configured.

## Testing

- `git diff --check`
- `git diff --check upstream/develop..HEAD`
- `node common/scripts/install-run-rush.js build --to @hcengineering/notification-resources`

## Notes

- Browser push remains disabled when the configured public key is missing or whitespace-only.
- Desktop-client push guards from upstream were preserved while porting the change.