### PR TITLE
fix(contact): allow resending invites to active employees

### DIFF
--- a/plugins/contact-resources/src/visibilityTester.ts
+++ b/plugins/contact-resources/src/visibilityTester.ts
@@ -15,10 +15,17 @@
 //
 
 import contact, { type Person, type Employee } from '@hcengineering/contact'
+import { SocialIdType } from '@hcengineering/core'
 import { getClient } from '@hcengineering/presentation'
 
 export async function canResendInvitation (employee: Employee): Promise<boolean> {
-  return !employee.active
+  const client = getClient()
+  const emailSocialId = await client.findOne(contact.class.SocialIdentity, {
+    attachedTo: employee._id,
+    type: SocialIdType.EMAIL
+  })
+
+  return emailSocialId !== undefined
 }
 
 export async function canMergePersons (person: Person): Promise<boolean> {


### PR DESCRIPTION
## Summary

- Updates the employee Resend Invite visibility check to look for an email social identity instead of requiring the employee to be inactive.
- Allows active employees with an email identity to have their invitation email resent from contact resources.
- Keeps the action hidden when no email social identity is attached to the employee.

## Testing

- `git diff --check upstream/develop...HEAD`
- `node ../../common/scripts/install-run-rushx.js build` from `plugins/contact-resources`
- `node common/scripts/install-run-rush.js build --to @hcengineering/contact-resources --verbose`

## Notes

- The behavior now depends on the presence of an attached email social identity. Employees without an email identity will continue not to show Resend Invite.