### PR TITLE
feat(telegram-bot): route notifications into a per-channel forum topic

### DIFF
--- a/services/telegram-bot/pod-telegram-bot/src/account.ts
+++ b/services/telegram-bot/pod-telegram-bot/src/account.ts
@@ -200,3 +200,17 @@ export async function enableIntegration (integration: IntegrationInfo): Promise<
     }
   })
 }
+
+export async function updateIntegrationData (
+  integration: IntegrationInfo,
+  dataPatch: Record<string, unknown>
+): Promise<void> {
+  const client = getAccountClient(serviceToken())
+  await client.updateIntegration({
+    ...integration,
+    data: {
+      ...(integration.data ?? {}),
+      ...dataPatch
+    }
+  })
+}

--- a/services/telegram-bot/pod-telegram-bot/src/db.ts
+++ b/services/telegram-bot/pod-telegram-bot/src/db.ts
@@ -15,10 +15,11 @@
 
 import postgres from 'postgres'
 import { AccountUuid, Ref, WorkspaceUuid } from '@hcengineering/core'
+import { ChunterSpace } from '@hcengineering/chunter'
 import { ActivityMessage } from '@hcengineering/activity'
 
 import config from './config'
-import { ChannelId, ChannelRecord, MessageRecord, OtpRecord, ReplyRecord } from './types'
+import { ChannelId, ChannelRecord, ForumTopicRecord, MessageRecord, OtpRecord, ReplyRecord } from './types'
 
 export async function getDb (): Promise<PostgresDB> {
   const sql = postgres(config.DbUrl, {
@@ -36,6 +37,7 @@ const otpTable = 'telegram_bot.otp'
 const messagesTable = 'telegram_bot.messages'
 const channelsTable = 'telegram_bot.channels'
 const repliesTable = 'telegram_bot.replies'
+const forumTopicsTable = 'telegram_bot.forum_topics'
 
 type DBFlavor = 'cockroach' | 'postgres' | 'unknown'
 
@@ -73,7 +75,7 @@ export class PostgresDB {
 
     const sql = `
         CREATE SCHEMA IF NOT EXISTS telegram_bot;
-        
+
         CREATE TABLE IF NOT EXISTS ${otpTable} (
           telegram_id INT8 NOT NULL,
           telegram_username TEXT NOT NULL,
@@ -82,7 +84,7 @@ export class PostgresDB {
           created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
           PRIMARY KEY (code)
         );
-        
+
         CREATE TABLE IF NOT EXISTS ${messagesTable} (
           message_id VARCHAR(255) NOT NULL,
           workspace UUID NOT NULL,
@@ -107,6 +109,17 @@ export class PostgresDB {
           telegram_user_id INT8 NOT NULL,
           reply_id INT8 NOT NULL,
           PRIMARY KEY (message_id, telegram_user_id, reply_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS ${forumTopicsTable} (
+          workspace UUID NOT NULL,
+          account UUID NOT NULL,
+          channel_id VARCHAR(255) NOT NULL,
+          forum_chat_id INT8 NOT NULL,
+          topic_id INT8 NOT NULL,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          PRIMARY KEY (workspace, account, channel_id),
+          UNIQUE (forum_chat_id, topic_id)
         );
   `
 
@@ -217,6 +230,44 @@ export class PostgresDB {
     return res.map(toReplyRecord)[0]
   }
 
+  async getForumTopic (
+    workspace: WorkspaceUuid,
+    account: AccountUuid,
+    channelId: Ref<ChunterSpace>
+  ): Promise<ForumTopicRecord | undefined> {
+    const sql = `
+      SELECT * FROM ${forumTopicsTable}
+      WHERE workspace = $1::uuid AND account = $2::uuid AND channel_id = $3::varchar
+      LIMIT 1`
+    const res = await this.client.unsafe(sql, [workspace, account, channelId])
+    return res.map(toForumTopicRecord)[0]
+  }
+
+  async insertForumTopic (record: Omit<ForumTopicRecord, 'createdAt'>): Promise<void> {
+    const sql = `
+      INSERT INTO ${forumTopicsTable} (
+        workspace, account, channel_id, forum_chat_id, topic_id
+      )
+      VALUES ($1::uuid, $2::uuid, $3::varchar, $4::int8, $5::int8)
+      ON CONFLICT (workspace, account, channel_id) DO NOTHING`
+    await this.client.unsafe(sql, [
+      record.workspace,
+      record.account,
+      record.channelId,
+      record.forumChatId,
+      record.topicId
+    ])
+  }
+
+  async getForumTopicByThread (forumChatId: number, topicId: number): Promise<ForumTopicRecord | undefined> {
+    const sql = `
+      SELECT * FROM ${forumTopicsTable}
+      WHERE forum_chat_id = $1::int8 AND topic_id = $2::int8
+      LIMIT 1`
+    const res = await this.client.unsafe(sql, [forumChatId, topicId])
+    return res.map(toForumTopicRecord)[0]
+  }
+
   async close (): Promise<void> {
     await this.client.end({ timeout: 0 })
   }
@@ -257,5 +308,16 @@ function toMessageRecord (raw: any): MessageRecord {
     workspace: raw.workspace,
     account: raw.account,
     telegramMessageId: Number(raw.telegram_message_id)
+  }
+}
+
+function toForumTopicRecord (raw: any): ForumTopicRecord {
+  return {
+    workspace: raw.workspace,
+    account: raw.account,
+    channelId: raw.channel_id,
+    forumChatId: Number(raw.forum_chat_id),
+    topicId: Number(raw.topic_id),
+    createdAt: new Date(raw.created_at)
   }
 }

--- a/services/telegram-bot/pod-telegram-bot/src/telegraf/bot.ts
+++ b/services/telegram-bot/pod-telegram-bot/src/telegraf/bot.ts
@@ -100,6 +100,52 @@ async function onReply (
   return await worker.reply(integration, messageRecord, htmlToMarkup(toHTML(message)), files)
 }
 
+/**
+ * Routes a non-reply message that arrived inside a Telegram forum topic to the matching
+ * Huly channel (via the forum_topics table). Returns true if the message was successfully
+ * routed; false if the topic is not registered (caller should fall back to legacy flow).
+ */
+async function handleForumTopicMessage (
+  ctx: Context,
+  worker: PlatformWorker,
+  chatId: number,
+  threadId: number,
+  fromId: number
+): Promise<boolean> {
+  const topic = await worker.getForumTopicByThread(chatId, threadId)
+  if (topic === undefined) return false
+
+  const integration = await getAnyIntegrationByTelegramId(fromId, topic.workspace)
+  if (integration === undefined) return false
+
+  const channel = await worker.resolveChannelByRef(topic.workspace, topic.account, topic.channelId)
+  if (channel === undefined) return false
+
+  const ctxMessage = ctx.message as Message | undefined
+  if (ctxMessage === undefined) return false
+
+  const file = await toTelegramFileInfo(ctx as TgContext, ctxMessage)
+  let text = htmlToMarkup(toHTML(ctxMessage as Message.TextMessage))
+
+  if (isEmptyMarkup(text) && 'caption' in ctxMessage && ctxMessage.caption !== undefined) {
+    text = jsonToMarkup({
+      type: MarkupNodeType.text,
+      text: ctxMessage.caption
+    })
+  }
+
+  if (isEmptyMarkup(text) && file === undefined) return false
+
+  return await worker.sendMessage(
+    channel,
+    integration.account,
+    integration.socialId,
+    ctxMessage.message_id,
+    text,
+    file
+  )
+}
+
 async function handleSelectChannel (
   ctx: Context<Update.CallbackQueryUpdate<CallbackQuery>>,
   worker: PlatformWorker,
@@ -217,17 +263,32 @@ export async function setUpBot (worker: PlatformWorker): Promise<Telegraf<TgCont
   await defineCommands(bot, worker)
 
   bot.on(message('reply_to_message'), async (ctx) => {
-    const id = ctx.chat?.id
+    const chatId = ctx.chat?.id
     const message = ctx.message
 
-    if (id === undefined || message.reply_to_message === undefined) {
+    if (chatId === undefined || message.reply_to_message === undefined) {
       return
+    }
+
+    const fromId = ctx.from?.id
+    const threadId = (message as Message & { message_thread_id?: number }).message_thread_id
+
+    // Inside a forum-enabled DM, "replying" to the topic's own first system message is
+    // really the user opening the topic to type into it. Treat it as a fresh forum-routed
+    // message instead of trying to thread-link it to the synthetic topic head.
+    if (fromId !== undefined && threadId !== undefined && ctx.chat?.type === 'private') {
+      const replyToId = message.reply_to_message.message_id
+      const isTopicHead = replyToId === threadId
+      if (isTopicHead) {
+        const routed = await handleForumTopicMessage(ctx, worker, chatId, threadId, fromId)
+        if (routed) return
+      }
     }
 
     const replyTo = message.reply_to_message
     const isReplied = await onReply(
       ctx,
-      id,
+      chatId,
       message as ReplyMessage,
       message.message_id,
       replyTo.message_id,
@@ -241,11 +302,38 @@ export async function setUpBot (worker: PlatformWorker): Promise<Telegraf<TgCont
   })
 
   bot.on(message(), async (ctx) => {
-    const id = ctx.chat?.id
-    if (id === undefined) return
+    const chatId = ctx.chat?.id
+    if (chatId === undefined) return
     if ('reply_to_message' in ctx.message) return
 
-    const integrations = await listIntegrationsByTelegramId(id)
+    // Skip Telegram forum service messages (topic created/edited/closed/reopened, etc.).
+    // They carry message_thread_id but represent system events, not user input — answering
+    // them with reply_parameters tied to a transient probe topic causes 400 "message thread not found".
+    const m = ctx.message as Record<string, unknown>
+    if (
+      m.forum_topic_created !== undefined ||
+      m.forum_topic_edited !== undefined ||
+      m.forum_topic_closed !== undefined ||
+      m.forum_topic_reopened !== undefined ||
+      m.general_forum_topic_hidden !== undefined ||
+      m.general_forum_topic_unhidden !== undefined
+    ) {
+      return
+    }
+
+    const fromId = ctx.from?.id
+    const threadId = (ctx.message as Message.TextMessage & { message_thread_id?: number }).message_thread_id
+
+    if (fromId !== undefined && threadId !== undefined && ctx.chat?.type === 'private') {
+      const routed = await handleForumTopicMessage(ctx, worker, chatId, threadId, fromId)
+      if (routed) return
+      // Inside a topic but the topic is not in our table (stale topic, manual user
+      // creation, etc). Skip the workspace/channel keyboard fallback so Telegraf does
+      // not echo back into a thread id that may not exist anymore.
+      return
+    }
+
+    const integrations = await listIntegrationsByTelegramId(chatId)
     if (integrations === undefined) return
 
     const workspaces: WorkspaceUuid[] = integrations

--- a/services/telegram-bot/pod-telegram-bot/src/telegraf/commands.ts
+++ b/services/telegram-bot/pod-telegram-bot/src/telegraf/commands.ts
@@ -25,7 +25,8 @@ import {
   listIntegrationsByTelegramId,
   getAccountPerson,
   removeIntegrationsByTg,
-  getAnyIntegrationByTelegramId
+  getAnyIntegrationByTelegramId,
+  updateIntegrationData
 } from '../account'
 import { WorkspaceUuid } from '@hcengineering/core'
 
@@ -34,6 +35,8 @@ export enum Command {
   Connect = 'connect',
   SyncAllChannels = 'sync_all_channels',
   SyncStarredChannels = 'sync_starred_channels',
+  SetForum = 'setforum',
+  UnsetForum = 'unsetforum',
   Help = 'help',
   Stop = 'stop'
 }
@@ -55,6 +58,14 @@ export async function getBotCommands (lang: string = 'en'): Promise<BotCommand[]
     {
       command: Command.SyncStarredChannels,
       description: await translate(telegram.string.SyncStarredChannels, { app: config.App }, lang)
+    },
+    {
+      command: Command.SetForum,
+      description: 'Route notifications into a forum topic per Huly channel (one topic per channel)'
+    },
+    {
+      command: Command.UnsetForum,
+      description: 'Disable forum routing and send notifications back to this DM'
     },
     {
       command: Command.Help,
@@ -142,6 +153,56 @@ async function onSyncChannels (ctx: Context, worker: PlatformWorker, onlyStarred
   await ctx.reply('List of channels updated')
 }
 
+async function onSetForum (ctx: Context, worker: PlatformWorker): Promise<void> {
+  const id = ctx.from?.id
+  if (id === undefined) return
+
+  // Bot API 9.4 surfaces the Threaded Mode bit via getMe().has_topics_enabled.
+  // Without it, createForumTopic will fail with 400, so refuse early with a
+  // helpful pointer to @BotFather. Using getMe instead of a probe createForumTopic
+  // avoids polluting the DM with a "topic created" service message.
+  const me = (await ctx.telegram.getMe()) as { username?: string, has_topics_enabled?: boolean }
+  if (me.has_topics_enabled !== true) {
+    await ctx.reply(
+      'Topic creation is not allowed in this DM. The bot administrator must enable Threaded Mode via @BotFather: ' +
+        `/mybots -> @${me.username ?? 'bot'} -> press Open (Mini App) -> Threads -> toggle ON, then retry /setforum.`
+    )
+    return
+  }
+
+  const integrations = await listIntegrationsByTelegramId(id)
+  if (integrations.length === 0) {
+    await ctx.reply('No Huly integration found. Connect a workspace first via /connect.')
+    return
+  }
+
+  for (const integration of integrations) {
+    await updateIntegrationData(integration, { forumChatId: id })
+  }
+
+  await ctx.reply(
+    'Forum routing enabled. Every Huly channel will become its own topic in this DM. ' +
+      'Use /unsetforum to turn it off.'
+  )
+}
+
+async function onUnsetForum (ctx: Context, worker: PlatformWorker): Promise<void> {
+  const id = ctx.from?.id
+  if (id === undefined) return
+
+  const integrations = await listIntegrationsByTelegramId(id)
+  if (integrations.length === 0) {
+    await ctx.reply('No Huly integration found.')
+    return
+  }
+
+  for (const integration of integrations) {
+    await updateIntegrationData(integration, { forumChatId: null })
+  }
+
+  await ctx.reply('Forum routing disabled. Notifications will return to this DM.')
+}
+
 async function onConnect (ctx: Context, worker: PlatformWorker): Promise<void> {
   const id = ctx.from?.id
   const lang = ctx.from?.language_code ?? 'en'
@@ -178,4 +239,6 @@ export async function defineCommands (bot: Telegraf<TgContext>, worker: Platform
   bot.command(Command.Connect, (ctx) => onConnect(ctx, worker))
   bot.command(Command.SyncAllChannels, (ctx) => onSyncChannels(ctx, worker, false))
   bot.command(Command.SyncStarredChannels, (ctx) => onSyncChannels(ctx, worker, true))
+  bot.command(Command.SetForum, (ctx) => onSetForum(ctx, worker))
+  bot.command(Command.UnsetForum, (ctx) => onUnsetForum(ctx, worker))
 }

--- a/services/telegram-bot/pod-telegram-bot/src/types.ts
+++ b/services/telegram-bot/pod-telegram-bot/src/types.ts
@@ -42,6 +42,15 @@ export interface ReplyRecord {
   replyId: number
 }
 
+export interface ForumTopicRecord {
+  workspace: WorkspaceUuid
+  account: AccountUuid
+  channelId: Ref<ChunterSpace>
+  forumChatId: number
+  topicId: number
+  createdAt: Date
+}
+
 export interface OtpRecord {
   telegramId: number
   telegramUsername: string

--- a/services/telegram-bot/pod-telegram-bot/src/worker.ts
+++ b/services/telegram-bot/pod-telegram-bot/src/worker.ts
@@ -23,6 +23,7 @@ import { ActivityMessage } from '@hcengineering/activity'
 import {
   ChannelId,
   ChannelRecord,
+  ForumTopicRecord,
   IntegrationInfo,
   MessageRecord,
   PlatformFileInfo,
@@ -143,6 +144,34 @@ export class PlatformWorker {
     return await wsClient.getFiles(message)
   }
 
+  async getChannelInfoForMessage (
+    workspace: WorkspaceUuid,
+    account: AccountUuid,
+    messageId: Ref<ActivityMessage>
+  ): Promise<{ channelId: Ref<ChunterSpace>, channelName: string } | undefined> {
+    const wsClient = await WorkspaceClient.create(workspace, account, this.ctx, this.storage)
+    const channel = await wsClient.getChannelForActivityMessage(messageId)
+    if (channel === undefined) return undefined
+    const channelName = await this.getChannelName(wsClient, channel, account)
+    return { channelId: channel._id, channelName }
+  }
+
+  async getForumTopic (
+    workspace: WorkspaceUuid,
+    account: AccountUuid,
+    channelId: Ref<ChunterSpace>
+  ): Promise<ForumTopicRecord | undefined> {
+    return await this.db.getForumTopic(workspace, account, channelId)
+  }
+
+  async saveForumTopic (record: Omit<ForumTopicRecord, 'createdAt'>): Promise<void> {
+    await this.db.insertForumTopic(record)
+  }
+
+  async getForumTopicByThread (forumChatId: number, topicId: number): Promise<ForumTopicRecord | undefined> {
+    return await this.db.getForumTopicByThread(forumChatId, topicId)
+  }
+
   async updateTelegramUsername (personId: PersonId, telegramUsername: string): Promise<void> {
     await getAccountClient(serviceToken()).updateSocialId(personId, telegramUsername)
   }
@@ -243,6 +272,37 @@ export class PlatformWorker {
     })
 
     return true
+  }
+
+  /**
+   * Looks up a channel by its Huly Ref (not the internal rowid), used by the forum-topic
+   * outbound path where we know the channel ref from the forum_topics table but don't
+   * have the corresponding channelsTable row cached.
+   */
+  async resolveChannelByRef (
+    workspace: WorkspaceUuid,
+    account: AccountUuid,
+    channelRef: Ref<ChunterSpace>
+  ): Promise<ChannelRecord | undefined> {
+    for (const cached of this.channelByRowId.values()) {
+      if (cached.workspace === workspace && cached.account === account && cached._id === channelRef) {
+        return cached
+      }
+    }
+
+    const client = await WorkspaceClient.create(workspace, account, this.ctx, this.storage)
+    const space = await client.findChunterSpace(channelRef)
+    if (space === undefined) return undefined
+
+    const name = await this.getChannelName(client, space, account)
+    return {
+      rowId: `forum:${channelRef}` as ChannelId,
+      workspace,
+      _id: space._id,
+      _class: space._class,
+      name,
+      account
+    }
   }
 
   async syncChannels (account: AccountUuid, workspace: WorkspaceUuid, onlyStarred: boolean): Promise<void> {
@@ -371,6 +431,7 @@ export class PlatformWorker {
     }
 
     const integration = integrations[0]
+    const forumChatId = this.getForumChatId(integrations)
 
     void this.limiter.add(integration.telegramId, async () => {
       const { full: fullMessage, short: shortMessage } = toTelegramHtml(record)
@@ -380,16 +441,36 @@ export class PlatformWorker {
           : []
       const tgMessageIds: number[] = []
 
-      if (files.length === 0) {
-        const message = await bot.telegram.sendMessage(integration.telegramId, fullMessage, {
-          parse_mode: 'HTML'
-        })
+      let targetChatId: number = integration.telegramId
+      let threadId: number | undefined
+      if (forumChatId !== undefined && record.messageId != null) {
+        const routed = await this.resolveForumTopic(
+          bot,
+          forumChatId,
+          workspace,
+          record.account,
+          record.messageId
+        )
+        if (routed !== undefined) {
+          targetChatId = forumChatId
+          threadId = routed
+        }
+      }
 
+      const baseExtra: Record<string, unknown> = { parse_mode: 'HTML' }
+      if (threadId !== undefined) baseExtra.message_thread_id = threadId
+
+      if (files.length === 0) {
+        const message = await bot.telegram.sendMessage(targetChatId, fullMessage, baseExtra as any)
         tgMessageIds.push(message.message_id)
       } else {
         const groups = toMediaGroups(files, fullMessage, shortMessage)
         for (const group of groups) {
-          const mediaGroup = await bot.telegram.sendMediaGroup(integration.telegramId, group)
+          const mediaGroup = await bot.telegram.sendMediaGroup(
+            targetChatId,
+            group,
+            threadId !== undefined ? ({ message_thread_id: threadId } as any) : undefined
+          )
           tgMessageIds.push(...mediaGroup.map((it) => it.message_id))
         }
       }
@@ -404,6 +485,63 @@ export class PlatformWorker {
         })
       }
     })
+  }
+
+  /**
+   * Returns the forum chat id stored on any of the user's integrations, or undefined
+   * if forum routing has not been configured via /setforum. Cleared values (null)
+   * are treated the same as unset.
+   */
+  getForumChatId (integrations: IntegrationInfo[]): number | undefined {
+    for (const integration of integrations) {
+      const raw = integration.data?.forumChatId
+      if (typeof raw === 'number' && Number.isFinite(raw)) return raw
+    }
+    return undefined
+  }
+
+  /**
+   * Looks up (or lazily creates) the Telegram forum topic that mirrors the Huly channel
+   * that owns this activity message. Returns the topic message_thread_id, or undefined
+   * if the channel cannot be resolved or topic creation fails.
+   */
+  async resolveForumTopic (
+    bot: Telegraf<TgContext>,
+    forumChatId: number,
+    workspace: WorkspaceUuid,
+    account: AccountUuid,
+    messageId: Ref<ActivityMessage>
+  ): Promise<number | undefined> {
+    let channelInfo: { channelId: Ref<ChunterSpace>, channelName: string } | undefined
+    try {
+      channelInfo = await this.getChannelInfoForMessage(workspace, account, messageId)
+    } catch (e) {
+      this.ctx.warn('Failed to resolve channel for forum topic', { error: e, messageId })
+      return undefined
+    }
+    if (channelInfo === undefined) return undefined
+
+    const existing = await this.db.getForumTopic(workspace, account, channelInfo.channelId)
+    if (existing !== undefined) return existing.topicId
+
+    try {
+      const created = await bot.telegram.createForumTopic(forumChatId, channelInfo.channelName)
+      await this.db.insertForumTopic({
+        workspace,
+        account,
+        channelId: channelInfo.channelId,
+        forumChatId,
+        topicId: created.message_thread_id
+      })
+      return created.message_thread_id
+    } catch (e) {
+      this.ctx.warn('Failed to create forum topic, falling back to DM', {
+        error: e,
+        forumChatId,
+        channelName: channelInfo.channelName
+      })
+      return undefined
+    }
   }
 
   async processWorkspaceSubscription (

--- a/services/telegram-bot/pod-telegram-bot/src/workspace.ts
+++ b/services/telegram-bot/pod-telegram-bot/src/workspace.ts
@@ -258,6 +258,33 @@ export class WorkspaceClient {
     return res
   }
 
+  /**
+   * Resolves the chunter space (Channel or DirectMessage) that owns the activity
+   * message identified by `messageId`. For thread messages we walk to the parent
+   * object rather than the comment itself. Returns undefined when the message is
+   * not attached to a chunter space, so the caller can fall back to a plain DM.
+   */
+  async getChannelForActivityMessage (
+    messageId: Ref<ActivityMessage>
+  ): Promise<ChunterSpace | undefined> {
+    const message = await this.client.findOne(activity.class.ActivityMessage, { _id: messageId })
+    if (message === undefined) return undefined
+
+    let channelId: Ref<ChunterSpace>
+    if (this.hierarchy.isDerived(message._class, chunter.class.ThreadMessage)) {
+      const thread = message as ThreadMessage
+      channelId = thread.objectId as Ref<ChunterSpace>
+    } else {
+      channelId = message.attachedTo as Ref<ChunterSpace>
+    }
+
+    return await this.client.findOne(chunter.class.ChunterSpace, { _id: channelId })
+  }
+
+  async findChunterSpace (channelRef: Ref<ChunterSpace>): Promise<ChunterSpace | undefined> {
+    return await this.client.findOne(chunter.class.ChunterSpace, { _id: channelRef })
+  }
+
   async getChannels (account: AccountUuid, onlyStarred: boolean): Promise<ChunterSpace[]> {
     if (!onlyStarred) {
       return await this.client.findAll(chunter.class.ChunterSpace, {


### PR DESCRIPTION
## Summary

Adds an opt-in `/setforum` command that turns the telegram-bot's linear DM
inbox into a forum-topic layout, one topic per Huly chunter channel.
Top-level posts inside a topic become new Huly chat messages, and replies
to specific notifications still thread through to Huly as before.

The new flow is fully backwards-compatible: users that never run
`/setforum` see the existing single-thread DM unchanged.

## What changes

- `/setforum` (DM-only in this iteration) stores the user's Telegram id
  as `forumChatId` on their integration. Uses `getMe().has_topics_enabled`
  (Bot API 9.4) to refuse early if Threaded Mode is not enabled, instead
  of probing with `createForumTopic` + `deleteForumTopic` which leaves a
  service message in the chat.
- `/unsetforum` clears the routing and reverts to the legacy DM layout.
- `processNotification` calls `resolveForumTopic` whenever `forumChatId`
  is set on any of the user's integrations. The first notification for a
  Huly channel lazily creates a topic named `#channel-name` (or the DM
  peer's display name) via `createForumTopic`. The mapping is persisted
  in a new `telegram_bot.forum_topics` table.
- `handleForumTopicMessage` routes top-level Telegram posts inside a
  known topic to `sendMessage` on the matching ChunterSpace, so users
  can start fresh threads from Telegram. Reply-to-message inside a topic
  still flows through `onReply` for thread linking.
- Replies that target the topic's first system message (i.e. the user is
  "replying" to the synthetic topic head when they open it to type) are
  treated as fresh forum-routed posts instead of attempting to thread
  them back to a non-existent activity message.
- Telegram forum service messages (forum_topic_created/_edited/_closed/
  _reopened/general_forum_topic_hidden/_unhidden) are skipped at the top
  of bot.on(message()) because they carry a message_thread_id but should
  not trigger the workspace/channel keyboard fallback.

## Testing

- git diff --check upstream/develop..HEAD
- Manually verified end-to-end on a self-hosted Huly deployment
  (v0.7.423): /setforum, notification to a channel produces a topic
  named #channel-name, top-level reply lands as a new ChatMessage,
  reply-to-notification threads via the existing onReply path.

## Notes

- DM-only in this iteration. Routing into a forum supergroup with
  multiple users sharing one chat is a natural follow-up but requires a
  PK change on forum_topics for per-chat dedup and is intentionally
  deferred to a separate PR.
- Only chunter sources (Channel, DirectMessage) are routed. Other
  activity message kinds fall back to the legacy DM so unknown sources
  are not silently dropped.
- The new forum_topics table uses CREATE TABLE IF NOT EXISTS; no data
  migration is required to upgrade an existing deployment.