### PR TITLE
feat: print fixes and improvements

### DIFF
--- a/packages/panel/src/components/Panel.svelte
+++ b/packages/panel/src/components/Panel.svelte
@@ -22,6 +22,7 @@
   import {
     Component,
     deviceOptionsStore as deviceInfo,
+    printModeStore,
     Panel,
     Scroller,
     resizeObserver,
@@ -122,6 +123,8 @@
       startScrollHeightCheck()
     }
   })
+
+  $: max = useMaxWidth === true || $printModeStore
 </script>
 
 <Panel
@@ -250,7 +253,7 @@
   </svelte:fragment>
 
   {#if $deviceInfo.isMobile}
-    <div bind:this={content} class="popupPanel-body__mobile-content clear-mins" class:max={useMaxWidth}>
+    <div bind:this={content} class="popupPanel-body__mobile-content clear-mins" class:max>
       <slot />
       {#if showActivity}
         {#key object._id}
@@ -265,7 +268,7 @@
     <div
       bind:this={content}
       class={contentClasses ?? 'popupPanel-body__main-content py-8 clear-mins'}
-      class:max={useMaxWidth}
+      class:max
       class:side-content-space={sideContentSpace > 0}
       style:--side-content-space={`${sideContentSpace}px`}
     >
@@ -296,7 +299,7 @@
     >
       <div
         class={contentClasses ?? 'popupPanel-body__main-content py-8'}
-        class:max={useMaxWidth}
+        class:max
         class:side-content-space={sideContentSpace > 0}
         style:--side-content-space={`${sideContentSpace}px`}
         use:resizeObserver={(element) => {

--- a/packages/presentation/src/components/PDFViewer.svelte
+++ b/packages/presentation/src/components/PDFViewer.svelte
@@ -72,6 +72,7 @@
   </svelte:fragment>
 
   <svelte:fragment slot="utils">
+    <slot name="utils" />
     {#if !isLoading && src !== ''}
       <a class="no-line" href={src} download={name} bind:this={download}>
         <Button

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -52,6 +52,7 @@ export type {
 export { themeStore, languageStore } from '@hcengineering/theme'
 // export { applicationShortcutKey } from './utils'
 export { getCurrentLocation, locationToUrl, navigate, location, setLocationStorageKey } from './location'
+export { isAppFocusedStore, printModeStore } from './stores'
 
 export { default as EditBox } from './components/EditBox.svelte'
 export { default as Label } from './components/Label.svelte'

--- a/packages/ui/src/stores.ts
+++ b/packages/ui/src/stores.ts
@@ -1,4 +1,4 @@
-// Copyright © 2025 Hardcore Engineering Inc.
+// Copyright © 2026 Hardcore Engineering Inc.
 //
 // Licensed under the Eclipse Public License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License. You may
@@ -11,6 +11,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { writable } from 'svelte/store'
+import { readable, writable } from 'svelte/store'
 
 export const isAppFocusedStore = writable(true)
+
+export const printModeStore = readable(false, (set) => {
+  if (globalThis.window?.matchMedia === undefined) {
+    return
+  }
+
+  const printMedia = globalThis.window.matchMedia('print')
+
+  const update = (): void => {
+    set(printMedia.matches)
+  }
+
+  update()
+  printMedia.addEventListener('change', update)
+
+  return () => {
+    printMedia.removeEventListener('change', update)
+  }
+})

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -150,7 +150,7 @@ export interface RadioItem {
 
 export type ButtonBaseType = 'type-button' | 'type-button-icon'
 
-export type ButtonBaseKind = 'primary' | 'secondary' | 'tertiary' | 'negative'
+export type ButtonBaseKind = 'primary' | 'secondary' | 'tertiary' | 'negative' | 'ghost'
 
 export type ButtonBaseSize = 'large' | 'medium' | 'small' | 'extra-small' | 'min'
 

--- a/plugins/document-resources/src/components/EditDoc.svelte
+++ b/plugins/document-resources/src/components/EditDoc.svelte
@@ -72,7 +72,7 @@
   export let embedded: boolean = false
 
   $: locked = doc?.lockedBy != null
-  $: readonly = $restrictionStore.readonly || locked
+  $: effectiveReadonly = readonly || $restrictionStore.readonly || locked
 
   let useMaxWidth = getUseMaxWidth()
   $: saveUseMaxWidth(useMaxWidth)
@@ -308,7 +308,14 @@
       {#if doc}
         <ComponentExtensions
           extension={view.extensions.EditDocTitleExtension}
-          props={{ size: 'medium', kind: 'ghost', _id: doc._id, _class: doc._class, value: doc, readonly }}
+          props={{
+            size: 'medium',
+            kind: 'ghost',
+            _id: doc._id,
+            _class: doc._class,
+            value: doc,
+            readonly: effectiveReadonly
+          }}
         />
       {/if}
       {#if !$restrictionStore.disableActions}
@@ -349,7 +356,7 @@
                       ? getPlatformColorDef(doc.color, $themeStore.dark).icon
                       : 'currentColor'
                 }}
-            disabled={readonly}
+            disabled={effectiveReadonly}
             showTooltip={{ label: document.string.Icon, direction: 'bottom' }}
             on:click={chooseIcon}
           />
@@ -359,7 +366,7 @@
           focusIndex={1}
           fill
           bind:value={title}
-          {readonly}
+          readonly={effectiveReadonly}
           placeholder={document.string.DocumentNamePlaceholder}
           on:blur={(evt) => saveTitle(evt)}
           on:keydown={(evt) => {
@@ -388,7 +395,7 @@
           <DocumentEditor
             focusIndex={30}
             object={doc}
-            {readonly}
+            readonly={effectiveReadonly}
             boundary={content}
             overflow={'none'}
             editorAttributes={{ style: 'padding: 0 2em 2em; margin: 0 -2em; min-height: 30vh' }}
@@ -408,19 +415,25 @@
       </div>
     </div>
 
-    <RelationsEditor object={doc} {readonly} />
+    <RelationsEditor object={doc} readonly={effectiveReadonly} />
 
     <svelte:fragment slot="aside">
       {#if selectedAside === 'references'}
         <References doc={doc._id} />
       {:else if selectedAside === 'history'}
-        <History value={doc} {readonly} />
+        <History value={doc} readonly={effectiveReadonly} />
       {/if}
     </svelte:fragment>
 
     <svelte:fragment slot="custom-attributes">
       <!-- TODO show other properties -->
-      <ClassAttributeBar object={doc} _class={doc._class} to={core.class.Doc} ignoreKeys={['name']} {readonly} />
+      <ClassAttributeBar
+        object={doc}
+        _class={doc._class}
+        to={core.class.Doc}
+        ignoreKeys={['name']}
+        readonly={effectiveReadonly}
+      />
 
       <div class="doc-divider" />
 
@@ -438,7 +451,7 @@
         <div class="flex">
           <Component
             is={tags.component.TagsAttributeEditor}
-            props={{ object: doc, label: document.string.AddLabel, readonly }}
+            props={{ object: doc, label: document.string.AddLabel, readonly: effectiveReadonly }}
           />
         </div>
         <div class="divider" />

--- a/plugins/guest-resources/src/components/Guest.svelte
+++ b/plugins/guest-resources/src/components/Guest.svelte
@@ -25,6 +25,7 @@
     PanelInstance,
     Popup,
     PopupAlignment,
+    printModeStore,
     ResolvedLocation,
     TooltipInstance,
     areLocationsEqual,
@@ -287,7 +288,12 @@
     </div>
     <div bind:this={cover} class="cover" />
     <TooltipInstance />
-    <PanelInstance bind:this={panelInstance} {contentPanel} readonly={$restrictionStore.readonly} embedded>
+    <PanelInstance
+      bind:this={panelInstance}
+      {contentPanel}
+      readonly={$restrictionStore.readonly || $printModeStore}
+      embedded
+    >
       <svelte:fragment slot="panel-header">
         <ActionContext context={{ mode: 'panel' }} />
       </svelte:fragment>

--- a/plugins/print-assets/lang/cs.json
+++ b/plugins/print-assets/lang/cs.json
@@ -3,6 +3,8 @@
     "PrintToPDF": "Tisk do PDF",
     "PrintingDocumentOf": "Tisk dokumentu {current} z {total}",
     "DownloadAll": "Stáhnout vše",
-    "PrintFailed": "Tisk se nezdařil"
+    "PrintFailed": "Tisk se nezdařil",
+    "PrintSettings": "Print settings",
+    "LandscapeMode": "Landscape mode"
   }
 }

--- a/plugins/print-assets/lang/de.json
+++ b/plugins/print-assets/lang/de.json
@@ -3,6 +3,8 @@
     "PrintToPDF": "Als PDF drucken",
     "PrintingDocumentOf": "Dokument {current} von {total} wird gedruckt",
     "DownloadAll": "Alle herunterladen",
-    "PrintFailed": "Druck fehlgeschlagen"
+    "PrintFailed": "Druck fehlgeschlagen",
+    "PrintSettings": "Print settings",
+    "LandscapeMode": "Landscape mode"
   }
 }

--- a/plugins/print-assets/lang/en.json
+++ b/plugins/print-assets/lang/en.json
@@ -3,6 +3,8 @@
     "PrintToPDF": "Print to PDF",
     "PrintingDocumentOf": "Printing document {current} of {total}",
     "DownloadAll": "Download all",
-    "PrintFailed": "Print failed"
+    "PrintFailed": "Print failed",
+    "PrintSettings": "Print settings",
+    "LandscapeMode": "Landscape mode"
   }
 }

--- a/plugins/print-assets/lang/es.json
+++ b/plugins/print-assets/lang/es.json
@@ -3,6 +3,8 @@
     "PrintToPDF": "Imprimir en PDF",
     "PrintingDocumentOf": "Imprimiendo documento {current} de {total}",
     "DownloadAll": "Descargar todo",
-    "PrintFailed": "Error al imprimir"
+    "PrintFailed": "Error al imprimir",
+    "PrintSettings": "Print settings",
+    "LandscapeMode": "Landscape mode"
   }
 }

--- a/plugins/print-assets/lang/fr.json
+++ b/plugins/print-assets/lang/fr.json
@@ -3,6 +3,8 @@
     "PrintToPDF": "Imprimer en PDF",
     "PrintingDocumentOf": "Impression du document {current} sur {total}",
     "DownloadAll": "Tout télécharger",
-    "PrintFailed": "Échec de l'impression"
+    "PrintFailed": "Échec de l'impression",
+    "PrintSettings": "Print settings",
+    "LandscapeMode": "Landscape mode"
   }
 }

--- a/plugins/print-assets/lang/it.json
+++ b/plugins/print-assets/lang/it.json
@@ -3,6 +3,8 @@
     "PrintToPDF": "Stampa in PDF",
     "PrintingDocumentOf": "Stampa documento {current} di {total}",
     "DownloadAll": "Scarica tutto",
-    "PrintFailed": "Stampa non riuscita"
+    "PrintFailed": "Stampa non riuscita",
+    "PrintSettings": "Print settings",
+    "LandscapeMode": "Landscape mode"
   }
 }

--- a/plugins/print-assets/lang/ja.json
+++ b/plugins/print-assets/lang/ja.json
@@ -3,6 +3,8 @@
     "PrintToPDF": "PDFとして印刷",
     "PrintingDocumentOf": "ドキュメント {current} / {total} を印刷中",
     "DownloadAll": "すべてダウンロード",
-    "PrintFailed": "印刷に失敗しました"
+    "PrintFailed": "印刷に失敗しました",
+    "PrintSettings": "Print settings",
+    "LandscapeMode": "Landscape mode"
   }
 }

--- a/plugins/print-assets/lang/ko.json
+++ b/plugins/print-assets/lang/ko.json
@@ -3,6 +3,8 @@
         "PrintToPDF": "PDF로 인쇄",
         "PrintingDocumentOf": "문서 {current} / {total} 인쇄 중",
         "DownloadAll": "모두 다운로드",
-        "PrintFailed": "인쇄 실패"
+        "PrintFailed": "인쇄 실패",
+        "PrintSettings": "Print settings",
+        "LandscapeMode": "Landscape mode"
     }
 }

--- a/plugins/print-assets/lang/pt-br.json
+++ b/plugins/print-assets/lang/pt-br.json
@@ -3,6 +3,8 @@
     "PrintToPDF": "Imprimir em PDF",
     "PrintingDocumentOf": "Imprimindo documento {current} de {total}",
     "DownloadAll": "Baixar tudo",
-    "PrintFailed": "Falha na impressão"
+    "PrintFailed": "Falha na impressão",
+    "PrintSettings": "Print settings",
+    "LandscapeMode": "Landscape mode"
   }
 }

--- a/plugins/print-assets/lang/pt.json
+++ b/plugins/print-assets/lang/pt.json
@@ -3,6 +3,8 @@
     "PrintToPDF": "Imprimir em PDF",
     "PrintingDocumentOf": "Imprimindo documento {current} de {total}",
     "DownloadAll": "Descarregar tudo",
-    "PrintFailed": "Falha na impressão"
+    "PrintFailed": "Falha na impressão",
+    "PrintSettings": "Print settings",
+    "LandscapeMode": "Landscape mode"
   }
 }

--- a/plugins/print-assets/lang/ru.json
+++ b/plugins/print-assets/lang/ru.json
@@ -3,6 +3,8 @@
     "PrintToPDF": "Печать в PDF",
     "PrintingDocumentOf": "Печать документа {current} из {total}",
     "DownloadAll": "Скачать все",
-    "PrintFailed": "Ошибка печати"
+    "PrintFailed": "Ошибка печати",
+    "PrintSettings": "Настройки печати",
+    "LandscapeMode": "Ландшафтный режим"
   }
 }

--- a/plugins/print-assets/lang/tr.json
+++ b/plugins/print-assets/lang/tr.json
@@ -3,6 +3,8 @@
     "PrintToPDF": "PDF'e yazdır",
     "PrintingDocumentOf": "Belge yazdırılıyor {current} / {total}",
     "DownloadAll": "Tümünü indir",
-    "PrintFailed": "Yazdırma başarısız"
+    "PrintFailed": "Yazdırma başarısız",
+    "PrintSettings": "Print settings",
+    "LandscapeMode": "Landscape mode"
   }
 }

--- a/plugins/print-assets/lang/zh.json
+++ b/plugins/print-assets/lang/zh.json
@@ -3,6 +3,8 @@
     "PrintToPDF": "打印为 PDF",
     "PrintingDocumentOf": "正在打印文档 {current} / {total}",
     "DownloadAll": "全部下载",
-    "PrintFailed": "打印失败"
+    "PrintFailed": "打印失败",
+    "PrintSettings": "Print settings",
+    "LandscapeMode": "Landscape mode"
   }
 }

--- a/plugins/print-resources/src/components/PrintToPDF.svelte
+++ b/plugins/print-resources/src/components/PrintToPDF.svelte
@@ -9,11 +9,22 @@
   import presentation, { PDFViewer, createQuery, getClient } from '@hcengineering/presentation'
   import guest, { PublicLink, createPublicLink } from '@hcengineering/guest'
   import view from '@hcengineering/view'
-  import { Location } from '@hcengineering/ui'
+  import {
+    Button,
+    DropdownIntlItem,
+    eventToHTMLElement,
+    IconCheck,
+    IconMoreH,
+    Location,
+    ModernPopup,
+    showPopup
+  } from '@hcengineering/ui'
   import { getDocTitle, getObjectLinkFragment } from '@hcengineering/view-resources'
-  import { printToPDF } from '@hcengineering/print'
+  import { printToPDF, type PrintPageOrientation } from '@hcengineering/print'
   import { signPDF } from '@hcengineering/sign'
   import { getMetadata } from '@hcengineering/platform'
+
+  import print from '../plugin'
 
   export let object: Doc
   export let signed: boolean = false
@@ -25,11 +36,26 @@
   let link: PublicLink | undefined = undefined
   let file: Ref<Blob> | undefined = undefined
   let title = ''
+  let orientation: PrintPageOrientation = 'portrait'
+  let printRequest = 0
 
   $: objId = object?._id
+  $: printSettingsItems = [
+    {
+      id: 'landscape',
+      label: print.string.LandscapeMode,
+      icon: orientation === 'landscape' ? IconCheck : undefined
+    }
+  ] satisfies DropdownIntlItem[]
+
+  function nextPrintRequest (): number {
+    printRequest += 1
+    return printRequest
+  }
 
   const linkQuery = createQuery()
   $: {
+    nextPrintRequest()
     link = undefined
     file = undefined
     isLoading = true
@@ -47,16 +73,26 @@
 
   $: if (link?.url !== undefined && link.url !== '' && file === undefined) {
     const token = getMetadata(presentation.metadata.Token) ?? ''
+    const request = nextPrintRequest()
 
-    printToPDF(link.url, token).then(
+    printToPDF(link.url, token, { orientation }).then(
       (res) => {
+        if (request !== printRequest) {
+          return
+        }
         if (signed) {
           signPDF(res, token).then(
             (signedRes) => {
+              if (request !== printRequest) {
+                return
+              }
               file = signedRes as Ref<Blob>
               isLoading = false
             },
             (err) => {
+              if (request !== printRequest) {
+                return
+              }
               Analytics.handleError(err)
               isLoading = false
             }
@@ -67,6 +103,9 @@
         }
       },
       (err) => {
+        if (request !== printRequest) {
+          return
+        }
         Analytics.handleError(err)
         isLoading = false
       }
@@ -101,7 +140,43 @@
     title = value !== '' ? value + '.pdf' : ''
   }
 
+  function toggleOrientation (): void {
+    nextPrintRequest()
+    orientation = orientation === 'landscape' ? 'portrait' : 'landscape'
+    file = undefined
+    isLoading = true
+  }
+
+  function handlePrintSetting (id: 'landscape' | 'contentOnly'): void {
+    if (id === 'landscape') {
+      toggleOrientation()
+    }
+  }
+
+  function openPrintSettings (event: MouseEvent): void {
+    showPopup(
+      ModernPopup,
+      { items: printSettingsItems },
+      eventToHTMLElement(event),
+      (result: 'landscape' | 'contentOnly' | undefined) => {
+        if (result !== undefined) {
+          handlePrintSetting(result)
+        }
+      }
+    )
+  }
+
   $: void updateDocTitle(object)
 </script>
 
-<PDFViewer {file} name={title} contentType="application/pdf" showIcon={false} {isLoading} on:close on:fullsize />
+<PDFViewer {file} name={title} contentType="application/pdf" showIcon={false} {isLoading} on:close on:fullsize>
+  <svelte:fragment slot="utils">
+    <Button
+      icon={IconMoreH}
+      kind="ghost"
+      disabled={isLinkLoading}
+      showTooltip={{ label: print.string.PrintSettings, direction: 'bottom' }}
+      on:click={openPrintSettings}
+    />
+  </svelte:fragment>
+</PDFViewer>

--- a/plugins/print/src/plugin.ts
+++ b/plugins/print/src/plugin.ts
@@ -13,7 +13,9 @@ export const print = plugin(printId, {
     PrintToPDF: '' as IntlString,
     PrintingDocumentOf: '' as IntlString,
     DownloadAll: '' as IntlString,
-    PrintFailed: '' as IntlString
+    PrintFailed: '' as IntlString,
+    PrintSettings: '' as IntlString,
+    LandscapeMode: '' as IntlString
   },
   component: {
     PrintToPDF: '' as AnyComponent,

--- a/plugins/print/src/utils.ts
+++ b/plugins/print/src/utils.ts
@@ -16,7 +16,13 @@ export function getPrintBaseURL (): string {
   return endpoint
 }
 
-export async function printToPDF (link: string, token: string): Promise<string> {
+export type PrintPageOrientation = 'portrait' | 'landscape'
+
+export interface PrintToPDFOptions {
+  orientation?: PrintPageOrientation
+}
+
+export async function printToPDF (link: string, token: string, options?: PrintToPDFOptions): Promise<string> {
   if (token === '') {
     return ''
   }
@@ -24,6 +30,9 @@ export async function printToPDF (link: string, token: string): Promise<string> 
   const url: URL = new URL(`${getPrintBaseURL()}/print`)
   url.searchParams.append('link', encodeURIComponent(link))
   url.searchParams.append('kind', 'pdf')
+  if (options?.orientation !== undefined) {
+    url.searchParams.append('orientation', options.orientation)
+  }
 
   const response = await fetch(url, {
     method: 'GET',

--- a/plugins/workbench-resources/src/components/Workbench.svelte
+++ b/plugins/workbench-resources/src/components/Workbench.svelte
@@ -72,6 +72,7 @@
     PopupPosAlignment,
     PopupResult,
     popupstore,
+    printModeStore,
     pushRootBarComponent,
     resizeObserver,
     ResolvedLocation,
@@ -1119,7 +1120,7 @@
   <Dock />
   <div bind:this={cover} class="cover" />
   <TooltipInstance />
-  <PanelInstance bind:this={panelInstance} contentPanel={elementPanel}>
+  <PanelInstance bind:this={panelInstance} contentPanel={elementPanel} readonly={$printModeStore}>
     <svelte:fragment slot="panel-header">
       <ActionContext context={{ mode: 'panel' }} />
     </svelte:fragment>

--- a/services/print/pod-print/src/print.ts
+++ b/services/print/pod-print/src/print.ts
@@ -8,12 +8,15 @@ import config from './config'
 
 export interface PrintOptions {
   kind?: ExportKind
+  orientation?: PageOrientation
   viewport?: Viewport
 }
 
 export const validKinds = ['pdf', 'jpeg', 'png', 'webp'] as const
+export const validPageOrientations = ['portrait', 'landscape'] as const
 
 export type ExportKind = (typeof validKinds)[number]
+export type PageOrientation = (typeof validPageOrientations)[number]
 
 /**
  * Prints a webpage with the specified options
@@ -24,9 +27,10 @@ export type ExportKind = (typeof validKinds)[number]
  */
 export async function print (ctx: MeasureContext, url: string, options?: PrintOptions): Promise<Buffer | undefined> {
   const kind = options?.kind ?? 'pdf'
+  const orientation = options?.orientation ?? 'portrait'
   const viewport = options?.viewport ?? { width: 1440, height: 900 }
 
-  ctx.info('print', { url, kind, viewport })
+  ctx.info('print', { url, kind, orientation, viewport })
 
   // TODO: think of having a "hot" browser instance to avoid the overhead of launching a new one every time
   const browser = await puppeteer.launch({
@@ -84,7 +88,7 @@ export async function print (ctx: MeasureContext, url: string, options?: PrintOp
     res = await ctx.with('pdf', {}, () =>
       page.pdf({
         format: 'A4',
-        landscape: false,
+        landscape: orientation === 'landscape',
         timeout: 0,
         headerTemplate: pageHeader,
         footerTemplate: pageFooter,

--- a/services/print/pod-print/src/server.ts
+++ b/services/print/pod-print/src/server.ts
@@ -34,7 +34,7 @@ import { join } from 'path'
 import config from './config'
 import { convertToHtml } from './convert'
 import { ApiError } from './error'
-import { PrintOptions, print, validKinds } from './print'
+import { PrintOptions, print, validKinds, validPageOrientations } from './print'
 import { withMeasureContext } from './middleware'
 
 function getAccountClient (token: string): AccountClient {
@@ -142,9 +142,14 @@ const wrapRequest = (fn: AsyncRequestHandler) => (req: Request, res: Response, n
 
 function parsePrintOptions (query: Request['query']): PrintOptions {
   const kind = query.kind as PrintOptions['kind']
+  const orientation = query.orientation as PrintOptions['orientation']
 
   if (kind !== undefined && !validKinds.includes(kind as any)) {
     throw new ApiError(400, `Invalid print kind: ${kind}`)
+  }
+
+  if (orientation !== undefined && !validPageOrientations.includes(orientation as any)) {
+    throw new ApiError(400, `Invalid page orientation: ${orientation}`)
   }
 
   const rawWidth = (query.width ?? '') as string
@@ -164,7 +169,7 @@ function parsePrintOptions (query: Request['query']): PrintOptions {
     throw new ApiError(400, 'Both width and height must be provided')
   }
 
-  return { kind, viewport }
+  return { kind, orientation, viewport }
 }
 
 export function createServer (
@@ -211,10 +216,15 @@ export function createServer (
 
       const options = parsePrintOptions(req.query)
 
-      const printRes = await ctx.with('print', { kind: options.kind }, (ctx) => print(ctx, link, options), {
-        url,
-        viewport: options.viewport
-      })
+      const printRes = await ctx.with(
+        'print',
+        { kind: options.kind, orientation: options.orientation },
+        (ctx) => print(ctx, link, options),
+        {
+          url,
+          viewport: options.viewport
+        }
+      )
 
       if (printRes === undefined) {
         throw new ApiError(400, 'Failed to print')
@@ -290,10 +300,15 @@ export function createServer (
 
         const link = await getPublicLink(doc, client, wsIds, true, null)
 
-        const printRes = await ctx.with('print', { kind: options.kind }, (ctx) => print(ctx, link, options), {
-          link,
-          viewport: options.viewport
-        })
+        const printRes = await ctx.with(
+          'print',
+          { kind: options.kind, orientation: options.orientation },
+          (ctx) => print(ctx, link, options),
+          {
+            link,
+            viewport: options.viewport
+          }
+        )
 
         if (printRes === undefined) {
           throw new ApiError(400, 'Failed to print')


### PR DESCRIPTION
1. Mark page as readonly in print mode
2. Fix readonly state in documents
3. Always print documents in max width
4. Provide landscape page orientation