### PR TITLE
test: assert recruiting locators are visible instead of defined

### DIFF
--- a/tests/sanity/tests/model/recruiting/recruiting-page.ts
+++ b/tests/sanity/tests/model/recruiting/recruiting-page.ts
@@ -118,7 +118,7 @@ export class RecruitingPage {
   async checkApplicationsVisibility (): Promise<void> {
     await this.applicationsLink().click()
     await expect(this.page.locator('text=Applications >> nth=1')).toBeVisible()
-    expect(this.page.locator('text="APP-1"')).toBeDefined()
+    await expect(this.page.locator('text="APP-1"')).toBeVisible()
   }
 
   async verifyTalentSection (): Promise<void> {
@@ -129,8 +129,8 @@ export class RecruitingPage {
   async navigateToVacanciesAndCheckSoftwareEngineer (): Promise<void> {
     await this.vacanciesLink().click()
     await this.softwareEngineerLink().click()
-    expect(this.page.locator('text=Software Engineer')).toBeDefined()
-    expect(this.page.locator('text="APP-1"')).toBeDefined()
+    await expect(this.page.locator('text=Software Engineer')).toBeVisible()
+    await expect(this.page.locator('text="APP-1"')).toBeVisible()
   }
 
   async navigateToGeneralChatAndContacts (): Promise<void> {


### PR DESCRIPTION
## What

`tests/sanity/tests/model/recruiting/recruiting-page.ts` asserted recruiting text with `expect(locator).toBeDefined()` in two page-object methods. A Playwright `Locator` is always defined, so all three checks passed regardless of what the page rendered. This switches them to web-first `toBeVisible()`, which auto-waits for and verifies the element each method name claims to check.

## Why

`navigateToVacanciesAndCheckSoftwareEngineer` had no other assertion, so its two `toBeDefined()` calls were the method's entire verification. The `navigator` sanity test in `tests/sanity/tests/workbench.spec.ts` calls it, so a missing "Software Engineer" vacancy or "APP-1" applicant would still pass green. A `toBeDefined()` on a Locator can never fail, so the check was dead weight.

`checkApplicationsVisibility` already had a real `await expect(...).toBeVisible()` above its `toBeDefined()` line, so only the always-true line changed there.

## Tests

I could not run the sanity Playwright suite locally: it needs GitHub Packages auth and a deployed Huly stack. Disclosing that rather than claiming a green run. The change is a three-line assertion swap with no new imports, selectors, or test-title changes, and `git diff --check` is clean.

## Out of scope

No other assertions or methods were touched. The selectors are unchanged; only the matcher and the missing `await` were corrected.

---

Found while reviewing the test suite with [`e2e-skills/e2e-reviewer`](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).