### PR TITLE
feat: per-branding disabledFeatures

### DIFF
--- a/desktop/src/ui/platform.ts
+++ b/desktop/src/ui/platform.ts
@@ -361,7 +361,9 @@ export async function configurePlatform (onWorkbenchConnect?: () => Promise<void
   setMetadata(presentation.metadata.HulylakeUrl, config.HULYLAKE_URL ?? '')
   setMetadata(presentation.metadata.PulseUrl, config.PULSE_URL ?? '')
 
-  const disabledFeatures = (config.DISABLED_FEATURES ?? '').split(',').map(it => it.trim()).filter(it => it.length > 0)
+  const disabledFeatures = [...(config.DISABLED_FEATURES ?? '').split(','), ...(myBranding.disabledFeatures ?? '').split(',')]
+    .map(it => it.trim())
+    .filter(it => it.length > 0)
   setMetadata(presentation.metadata.DisabledFeatures, new Set(disabledFeatures))
 
   setMetadata(textEditor.metadata.Collaborator, config.COLLABORATOR ?? '')

--- a/desktop/src/ui/types.ts
+++ b/desktop/src/ui/types.ts
@@ -90,6 +90,7 @@ export interface Branding {
   languages?: string
   lastNameFirst?: string
   defaultLanguage?: string
+  disabledFeatures?: string
   defaultApplication?: string
   defaultSpace?: string
   defaultSpecial?: string

--- a/dev/prod/src/platform.ts
+++ b/dev/prod/src/platform.ts
@@ -223,6 +223,7 @@ export interface Branding {
   languages?: string
   lastNameFirst?: string
   defaultLanguage?: string
+  disabledFeatures?: string
   defaultApplication?: string
   defaultSpace?: string
   defaultSpecial?: string
@@ -492,7 +493,9 @@ export async function configurePlatform() {
   setMetadata(presentation.metadata.MailUrl, config.MAIL_URL)
   setMetadata(presentation.metadata.SignupUrl, config.SIGNUP_URL ?? 'https://huly.io/signup')
 
-  const disabledFeatures = (config.DISABLED_FEATURES ??'').split(',').map(it => it.trim()).filter(it => it.length > 0)
+  const disabledFeatures = [...(config.DISABLED_FEATURES ?? '').split(','), ...(myBranding.disabledFeatures ?? '').split(',')]
+    .map(it => it.trim())
+    .filter(it => it.length > 0)
   setMetadata(presentation.metadata.DisabledFeatures, new Set(disabledFeatures))
 
   setMetadata(recorder.metadata.StreamUrl, config.STREAM_URL)

--- a/docs/disableFeatures.md
+++ b/docs/disableFeatures.md
@@ -26,3 +26,21 @@ Please set a DISABLED_FEATURES environment variable for front service container,
 - testManagement - Will disable test management
 - process - Will disable process module
 - cards - Will disable cards
+
+## Per-branding disabled features
+
+When serving multiple brands/hosts from one installation (see `BRANDING_URL`),
+features can also be disabled per host by adding a `disabledFeatures` key
+(same comma-separated format) to a branding entry. The lists from
+`DISABLED_FEATURES` and the matched branding are merged, so the environment
+variable acts as the installation-wide baseline and brandings can only extend
+it:
+
+```json
+{
+  "tracker.example-client.com": {
+    "title": "Example Client Tracker",
+    "disabledFeatures": "recruit,lead,inventory,training"
+  }
+}
+```


### PR DESCRIPTION
## What

Allows multi-host (branded) installations to disable features **per branding entry**, in addition to the installation-wide `DISABLED_FEATURES` env var.

A branding entry (the JSON served at `BRANDING_URL`, keyed by host) may now carry a `disabledFeatures` key using the same comma-separated format:

```json
{
  "tracker.example-client.com": {
    "title": "Example Client Tracker",
    "disabledFeatures": "recruit,lead,inventory,training"
  }
}
```

At client bootstrap (web and desktop) the branding list is merged with `DISABLED_FEATURES`, feeding both `presentation.metadata.DisabledFeatures` and the model `ExtraFilter` — so the env var remains the installation-wide baseline and brandings can only extend it, never re-enable.

## Why

Self-hosters serving multiple clients/brands from one installation (one workspace per client, one entry host per client) often want different feature surfaces per client — e.g. a lean tracker-only experience for one client while another uses recruiting. Today `DISABLED_FEATURES` is all-or-nothing per installation.

This reuses the existing branding mechanism (already per-host and already consulted at the same bootstrap points), so the change is small and purely additive: no schema, server, or behavior changes for installations that don't set the key.

## Changes

- `dev/prod/src/platform.ts` — `disabledFeatures?: string` on `Branding`; merge with `config.DISABLED_FEATURES`
- `desktop/src/ui/types.ts` — same field on desktop `Branding`
- `desktop/src/ui/platform.ts` — same merge
- `docs/disableFeatures.md` — documentation

## Testing

Verified on a self-hosted v0.7.426 installation serving two hosts (two brands, one deployment) with the web bundle built from this branch:

- Both hosts load the identical patched bundle; per-host branding resolves by `window.location.host` as before (titles verified in the UI).
- With `"disabledFeatures": "calendar"` on one host's branding entry only, CDP-captured bootstrap on that host logs `loaded branding {key, title, disabledFeatures: "calendar"}` while the other host's branding loads without the key — same bundle, host-differentiated feature list feeding the existing `DisabledFeatures`/`ExtraFilter` path.
- Installations without the key see no change (field is optional; merge is a no-op on empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)