### PR TITLE
docs: add 4C Shade product docs + HH Shade instance memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,6 @@
 # Project Instructions
 
+This repository is **HH Shade** — the Hardscape House deployment of **4C Shade**, a fork of the Huly Platform. See [`CLAUDE.md`](CLAUDE.md) for the primary agent guidance and [`docs/4c-shade/`](docs/4c-shade/) for product docs; `CLAUDE.md` takes precedence for Shade work.
+
 - Do not run build commands automatically for verification.
 - When finishing work, state that the task is complete and ask the user to verify it manually.

--- a/ARCHITECTURE_OVERVIEW.md
+++ b/ARCHITECTURE_OVERVIEW.md
@@ -1,8 +1,10 @@
-# Huly Platform Architecture Overview
+# HH Shade / 4C Shade Architecture Overview
+
+> HH Shade is a fork of the Huly Platform; this document describes the shared platform backbone that HH Shade / 4C Shade runs on. The service map, ports, and env vars below are the upstream Huly architecture and remain accurate for this fork.
 
 ## Service Overview
 
-The Huly platform consists of **30+ microservices** working together in a distributed architecture. Services are organized into functional layers for core business logic, data storage, real-time communication, media processing, and supporting features.
+The platform consists of **30+ microservices** working together in a distributed architecture. Services are organized into functional layers for core business logic, data storage, real-time communication, media processing, and supporting features.
 
 ### Core Backend Services
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Guidance for Claude Code sessions working in this repository.
 
+> **▶ CURRENT WORK — start here:** [`docs/4c-shade/HANDOFF.md`](docs/4c-shade/HANDOFF.md). Two active tracks: (A, primary) map + prototype the **4C Shade console UI/UX** (design-first, via Stitch/Miro/local HTML); (B, parallel) **Huly fork cleanup** (baseline + branding + runtime-hide). Read the handoff before starting.
+
 ## What this repo is
 
 This is **HH Shade** — the **Hardscape House** deployment of **4C Shade**, an owned, self-hosted, QMS-gated, agent-native software-delivery platform built by **4C Digital**. The repo currently holds an upstream **Huly platform fork** being repurposed into the Shade backbone (alpha).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# CLAUDE.md — HH Shade (project memory)
+
+Guidance for Claude Code sessions working in this repository.
+
+## What this repo is
+
+This is **HH Shade** — the **Hardscape House** deployment of **4C Shade**, an owned, self-hosted, QMS-gated, agent-native software-delivery platform built by **4C Digital**. The repo currently holds an upstream **Huly platform fork** being repurposed into the Shade backbone (alpha).
+
+- **Product docs:** [`docs/4c-shade/`](docs/4c-shade/) — start with [`VISION-BRIEF.md`](docs/4c-shade/VISION-BRIEF.md).
+- **This instance's context:** [`docs/hh-shade/CONTEXT.md`](docs/hh-shade/CONTEXT.md).
+- **Note:** the existing root `AGENTS.md` is upstream Huly's, not Shade's — this `CLAUDE.md` is the Shade project memory and takes precedence for Shade work.
+
+## Identity stack
+
+**4C Digital** (owner) · **Shade** (platform) · **4C Shade** (product) · **`<Org> Shade`** (this = **HH Shade**; also FB Shade, Dibbits Shade…) · **Prism** (native OSS coordinator agent) · **ShadeOS** (doctrine/heritage) · **4CDAI** (optional AI-division banner).
+
+## Development
+
+- **Branch:** develop on `claude/dibbits-workspace-consolidation-69sqj8`. Commit with clear messages; push with `git push -u origin <branch>`. Do **not** push to other branches without explicit permission.
+- **Repo rename:** slated to become `hh-shade` (GitHub slugs can't contain spaces; display "HH Shade"). Done via GitHub Settings.
+
+## Build guardrails (from the vision brief)
+
+- **Agent skills = quality over quantity.** The 26 ShadeOS crew ops are *source material, not a port list*. Curate a lean, high-value skill set; add capabilities deliberately as each earns its place. Do **not** overbloat the Claude-facing agent tooling.
+- **Most-permissive licensing.** Prefer MIT/Apache/BSD for anything forked/embedded/shipped/hosted-for-others; EPL/MPL acceptable (weak, file-level); **avoid AGPL** for shipped/hosted components. Tools you merely *run* are unconstrained. See [`docs/4c-shade/LICENSING-AND-ENTITY.md`](docs/4c-shade/LICENSING-AND-ENTITY.md).
+- **Subscription-first agents.** Run the official `claude` CLI on the subscription (interactive in a terminal, or headless via `CLAUDE_CODE_OAUTH_TOKEN`); avoid `ANTHROPIC_API_KEY`/`--bare` metered paths except for deliberate bursts.
+- **The 5 gates** (human sign-offs, first-class): G-DESIGN, G-LOCK, G-PUSH, G-CLIENT, G-MONEY.
+
+## Scope discipline
+
+The full plan spans a **product build** (4C Shade: backbone + console) and the **Dibbits consolidation** (running the Dibbits/HardscapeOS build on this HH Shade instance). Confirm which layer a task belongs to before large changes. Deferred (not current): fork-source archival, the custom MCP server, migration scripts, the custom console — unless a task explicitly calls for them.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,28 @@
-# Huly Platform
+# HH Shade
 
-[![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/huly_io?style=for-the-badge)](https://x.com/huly_io)
-![GitHub License](https://img.shields.io/github/license/hcengineering/platform?style=for-the-badge)
+**HH Shade** is the Hardscape House deployment of **4C Shade** — a repurposed **Huly platform** fork. See [`docs/4c-shade/`](docs/4c-shade/) for product docs and [`CLAUDE.md`](CLAUDE.md) for agent guidance.
 
-⭐️ Your star shines on us. Star us on GitHub!
-
-> [!IMPORTANT]
-> **Hosted Huly is shutting down — please migrate your data.**
->
-> The hosted Huly service is being discontinued because its hosting is no longer being funded. If you keep important data on the hosted platform, export and back it up, and migrate as soon as possible — we can help you move to either a [self-hosted setup](https://github.com/hcengineering/huly-selfhost) or a hosted option.
->
-> Not sure how? Follow the [backup & restore guide](docs/guides/backup-restore.en.md) for step-by-step instructions on downloading your backup and restoring it elsewhere.
->
-> The service shutdown is expected on **July 20**. Please make sure to export and migrate your data before then rather than wait until the last day.
->
-> Have questions or want updates? Join the [Huly community](https://link.huly.io/slack) to discuss migration and stay informed, or email us at [artem@hardcoreeng.com](mailto:artem@hardcoreeng.com) with any questions. This affects only the hosted **Huly** service — self-hosted deployments are not affected.
+This repository is a fork of the open-source [Huly Platform](https://github.com/hcengineering/platform) by Hardcore Engineering, being adapted into the Shade backbone. Under the hood it remains the Huly codebase, so the upstream build, setup, and test workflows below still apply to this fork.
 
 ## About
 
-The Huly Platform is a robust framework designed to accelerate the development of business applications, such as CRM systems.
-This repository includes several applications, such as Chat, Project Management, CRM, HRM, and ATS.
-Various teams are building products on top of the Platform, including [Huly](https://huly.io) and [TraceX](https://tracex.co).
-
-![Huly](https://repository-images.githubusercontent.com/392073243/6d27d5cc-38cd-4d88-affe-bb88b393180c)
+The platform is a TypeScript/Svelte framework designed to accelerate the development of business applications (Project Management, CRM, Chat, HRM, ATS, QMS, and more). HH Shade rebrands this framework for the Hardscape House deployment; curating the visible app set down to the Shade spine (tracker, documents, controlled documents, test management, and their supporting framework) is planned but not yet applied — all upstream plugins remain compiled, so nothing is removed. See [`docs/4c-shade/VISION-BRIEF.md`](docs/4c-shade/VISION-BRIEF.md) for what 4C Shade is and [`docs/4c-shade/FORK-CLEANUP-NOTES.md`](docs/4c-shade/FORK-CLEANUP-NOTES.md) for what was changed relative to the upstream fork and what remains deferred.
 
 ## Self-Hosting
 
-If you're primarily interested in self-hosting Huly without the intention to modify or contribute to its development, please use [huly-selfhost](https://github.com/hcengineering/huly-selfhost).
-This project offers a convenient method to host Huly using `docker`, designed for ease of use and quick setup. Explore this option to effortlessly enjoy Huly on your own server.
-
-## Activity
-
-![Alt](https://repobeats.axiom.co/api/embed/c42c99e21691fa60ea61b5cdf11c2e0647621534.svg 'Repobeats analytics image')
+This fork is intended to be self-hosted. The upstream project also publishes [huly-selfhost](https://github.com/hcengineering/huly-selfhost), a convenient `docker`-based method to host the vanilla Huly Platform, which is a useful reference for production deployment topology.
 
 ## API Client
 
-If you want to interact with Huly programmatically, check out our [API Client](https://github.com/hcengineering/huly.core/tree/main/packages/api-client) documentation. The API client provides a typed interface for all Huly operations and can be used to build integrations and custom applications.
-
-You can find API usage examples in the [Huly examples](https://github.com/hcengineering/huly-examples) repository.
+To interact with the platform programmatically, the upstream [API Client](https://github.com/hcengineering/huly.core/tree/main/packages/api-client) provides a typed interface for platform operations and can be used to build integrations and custom applications. Usage examples live in the upstream [examples](https://github.com/hcengineering/huly-examples) repository.
 
 ## Changelog
 
-For detailed information about changes, improvements, and bug fixes in each version, see our [Changelog](./changelog.md).
+For detailed information about upstream changes, improvements, and bug fixes in each version, see the [Changelog](./changelog.md).
 
 ## Versions
 
-The Huly Platform uses two types of version tags to distinguish between production-ready and development releases:
+The upstream platform uses two types of version tags to distinguish between production-ready and development releases:
 
 - **Production Versions (`v*`)** - Stable releases for end users
   - Example: `v0.7.310`, `v0.7.307`, `v0.6.501`
@@ -61,14 +38,13 @@ The Huly Platform uses two types of version tags to distinguish between producti
 
 ## Architecture
 
-For detailed information about the platform architecture, services, and their interactions, see our [Architecture Overview](./ARCHITECTURE_OVERVIEW.md).
+For detailed information about the platform architecture, services, and their interactions, see the [Architecture Overview](./ARCHITECTURE_OVERVIEW.md).
 
 ## Table of Contents
 
-- [Huly Platform](#huly-platform)
+- [HH Shade](#hh-shade)
   - [About](#about)
   - [Self-Hosting](#self-hosting)
-  - [Activity](#activity)
   - [API Client](#api-client)
   - [Changelog](#changelog)
   - [Versions](#versions)
@@ -118,6 +94,8 @@ docker compose version
 
 ## Branches & Contributing
 
+This fork develops on feature branches based off `develop` (see [`CLAUDE.md`](CLAUDE.md) for the active branch). The upstream release-flow branches are:
+
 - The `main` branch is the default branch used for production deployments.
   Changes to this branch are made from the `staging` branch once a version is ready for community use.
 
@@ -126,7 +104,7 @@ docker compose version
 
 - The `develop` branch is used for development and is the default branch for contributions.
 
-We periodically merge `develop` into `staging` to perform testing builds. Once we are satisfied with the build quality in our pre-release deployment, we merge changes into `main` and release a new version to the community.
+Upstream periodically merges `develop` into `staging` to perform testing builds. Once satisfied with the build quality in pre-release deployment, changes are merged into `main` and a new version is released to the community.
 
 ## Setup dev environment
 
@@ -395,4 +373,4 @@ When starting the application (`rush docker:up`), some network ports in Windows 
 1. Find what's using that port
 2. Update the new address in the corresponding service configuration
 
-<sub><sup>&copy; 2025 <a href="https://hardcoreeng.com">Hardcore Engineering Inc</a>.</sup></sub>
+<sub><sup>HH Shade / 4C Shade is a fork of the Huly Platform. Upstream platform &copy; 2025 <a href="https://hardcoreeng.com">Hardcore Engineering Inc</a>.</sup></sub>

--- a/dev/branding.json
+++ b/dev/branding.json
@@ -1,40 +1,40 @@
 {
   "huly.local:8080": {
     "key": "huly-dev",
-    "title": "Huly",
+    "title": "HH Shade",
     "protocol": "http",
     "language": "en",
     "lastNameFirst": "true"
   },
   "huly.local:8087": {
     "key": "huly",
-    "title": "Huly",
+    "title": "HH Shade",
     "protocol": "http",
     "language": "en",
     "lastNameFirst": "true"
   },
   "host.docker.internal:8087": {
     "key": "huly-docker",
-    "title": "Huly",
+    "title": "HH Shade",
     "protocol": "http",
     "language": "en",
     "lastNameFirst": "true"
   },
   "huly.local:8081": {
     "key": "tracex-dev",
-    "title": "TraceX",
+    "title": "HH Shade",
     "protocol": "http",
     "language": "en"
   },
   "huly.local:8088": {
     "key": "tracex",
-    "title": "TraceX",
+    "title": "HH Shade",
     "protocol": "http",
     "language": "en"
   },
   "host.docker.internal:8088": {
     "key": "tracex-docker",
-    "title": "Huly",
+    "title": "HH Shade",
     "protocol": "http",
     "language": "en",
     "lastNameFirst": "true"

--- a/dev/prod/public/branding.json
+++ b/dev/prod/public/branding.json
@@ -1,6 +1,6 @@
 {
   "huly.local:8080": {
-    "title": "Huly",
+    "title": "HH Shade",
     "languages": "en,ru,pl,pt,pt-br,es,zh,fr,de,ja,ko,tr",
     "defaultLanguage": "en",
     "defaultApplication": "tracker",
@@ -29,7 +29,7 @@
     ]
   },
   "huly.local:8087": {
-    "title": "Huly",
+    "title": "HH Shade",
     "languages": "en,ru,pl,pt,pt-br,es,zh,fr,de,ja,ko,tr",
     "defaultLanguage": "en",
     "defaultApplication": "tracker",
@@ -58,7 +58,7 @@
     ]
   },
   "huly.local:8081": {
-    "title": "TraceX",
+    "title": "HH Shade",
     "languages": "en",
     "defaultLanguage": "en",
     "defaultApplication": "documents",
@@ -98,7 +98,7 @@
     ]
   },
   "huly.local:8088": {
-    "title": "TraceX",
+    "title": "HH Shade",
     "languages": "en",
     "defaultLanguage": "en",
     "defaultApplication": "documents",

--- a/docs/4c-shade/DECISION-LOG.md
+++ b/docs/4c-shade/DECISION-LOG.md
@@ -1,0 +1,47 @@
+# 4C Shade — Decision Log
+
+*Condensed record of decisions made during the 4C Shade discovery/vision sessions. Newest context wins; this is the reference companion to `VISION-BRIEF.md`.*
+
+---
+
+## Locked decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **Backbone = self-hosted Huly (EPL-2.0)** | Licensing-validated as the most-permissive *genuinely-capable* PM+KB+QMS+multi-workspace platform; every all-in-one alternative is AGPL or source-available. Unique controlled-docs/QMS. |
+| D2 | **Product = "4C Shade"** (by 4C Digital) | Keeps the `Shade` family (ShadeOS heritage, `<Org> Shade` instances); leaves "Prism" free as the coordinator agent. |
+| D3 | **Naming = `<Org> Shade` convention** | White-label native — every deployment carries the customer's name (FB Shade, HH Shade, Dibbits Shade…). |
+| D4 | **Cockpit (interim) = standard Claude CLI + MCP, hosted in Zed** | Minimum complexity; subscription-preserving; MCP is the integration bus. Orchestrators (Conductor/Claude Squad) deferred, no rework to adopt later. |
+| D5 | **Console + backbone BOTH in scope** | Console (embedded terminal/browser, agent-manager) is the product's face; built demo-first, single cutover. |
+| D6 | **"Most permissive possible" licensing driver** | Permissive inputs (EPL-Huly + Apache/MIT models), 4C-owned controlled output. AGPL disqualifying for anything forked/hosted-for-others. |
+| D7 | **Local coordinator model = gpt-oss-120b or Qwen3-30B-A3B (Apache-2.0)** | Best tool-calling per VRAM-dollar; permissive; test-via-API (OpenRouter) → self-host on ≤$5k Linux box. |
+| D8 | **`dibbits_workspace` = harvest-then-archive** | Its machinery (crew ops, gates, second-brain) productizes into 4C Shade; repo freezes read-only. |
+| D9 | **Entity structure: 4C Digital owns; FutureBuild commercializes** | 4C builds/owns the IP; FutureBuild gets a free perpetual license + is the channel; revenue = license-as-a-service + managed inference. |
+| D10 | **Rollout: demo → HH Shade alpha (Dibbits build) → FB Shade → dealers** | De-risk on a throwaway before migrating the live client build. |
+| D11 | **Agent skills = quality over quantity** | The 26 crew ops are source material, not a port list. Curate; add incrementally. |
+| D12 | **Sequencing: build the customized platform, keep current setup until ready, migrate once** | Avoids a throwaway interim + double migration. |
+
+## The moat (four-legged flywheel)
+
+1. **Second brain** — conversations → cited scope/work-items + domain grounding.
+2. **QMS-gated, auditable delivery** — controlled-docs + gates-as-objects + full traceability (regulatory tailwind: EU AI Act Aug 2026, ISO 42001).
+3. **Owned + vertical + brandable** — self-hosted `<Org> Shade` instances.
+4. **Flat economics** — subscription CLI + local OSS Prism; ~nothing metered (SaaS structurally can't copy).
+
+## The 5 gates
+
+G-DESIGN (UI/UX approved before build) · G-LOCK (spec → Effective) · G-PUSH (push/deploy) · G-CLIENT (client-visible) · G-MONEY (hours/invoice/payments).
+
+## Auth / billing rule (load-bearing)
+
+- **Subscription:** the interactive `claude` CLI in a real terminal, or headless via `CLAUDE_CODE_OAUTH_TOKEN` (draws from subscription limits; watch the `-p` misbilling bug #43333). Rate-limit is the ceiling → subscription-first, API-burst.
+- **Metered API:** explicit `ANTHROPIC_API_KEY` / `--bare`, or third-party API-key tools.
+- **Gemini/OSS models:** own auth/harness; reached as peers or tools via MCP.
+
+## Open questions
+
+**For counsel:** free-perpetual-license scope (does it cover the HH JV?); HH Shade's license path; IP assignment into 4C (incl. Dibbits-engagement work); channel exclusivity (FutureBuild-only vs 4C direct/other channels).
+
+**Product/technical:** "ready to migrate" = backbone-ready vs full-console-ready; hardware pick (DGX Spark + gpt-oss-120b vs RTX 5090 + Qwen3); demo-project definition; internal-only vs eventual client access.
+
+**Not yet specced:** crew-ops → skills build spec; GTM / pricing math.

--- a/docs/4c-shade/FORK-CLEANUP-NOTES.md
+++ b/docs/4c-shade/FORK-CLEANUP-NOTES.md
@@ -48,30 +48,30 @@ Because the `DISABLED_FEATURES=…,recruit,lead,inventory,calendar,telegram,gith
 
 *(Doc bugs noted for later: `docs/disableFeatures.md` lists `integration` but the settings category uses `integrations`; `cards` vs plugin id `card`; `training` vs feature `trainings`. Singular/plural mismatches mean those documented tokens silently match nothing.)*
 
-## 3. Which HIDE-list apps are actually launcher tiles
+## 3. Which HIDE-list apps are actually visible tiles (source-verified)
 
-Only **6** of the handoff's HIDE list register a top-level `workbench.class.Application` with `hidden: false` (i.e. are shown-by-default tiles):
+A tile shows in the launcher only if it **both** registers a `workbench.class.Application` with `hidden: false` **and** its `PluginConfiguration.enabled` is `true` in `models/all/src/index.ts` (an `enabled: false` plugin has its `Application` create-tx pruned by `pluginFilterTx`, since `defaultFilter` includes `workbench.class.Application`). Against both conditions, only **3** HIDE-list apps are actually shown by default:
 
-| App | Registration | Shown by default |
-|---|---|---|
-| `recruit` | `models/recruit/src/index.ts` | yes |
-| `hr` | `models/hr/src/index.ts` | yes |
-| `lead` | `models/lead/src/index.ts` | yes |
-| `inventory` | `models/inventory/src/index.ts` | yes |
-| `board` | `models/board/src/index.ts` | yes |
-| `love` (Office) | `models/love/src/index.ts` | yes |
+| App | `Application.hidden` | `PluginConfiguration.enabled` | Shown by default? |
+|---|---|---|---|
+| `recruit` | false (`models/recruit/src/index.ts:129`) | true (`models/all/src/index.ts:234`) | **yes — needs hiding** |
+| `hr` | false (`models/hr/src/index.ts:192`) | true (`models/all/src/index.ts:304`) | **yes — needs hiding** |
+| `love` (Office) | false (`models/love/src/index.ts:255`) | true (`models/all/src/index.ts:395`) | **yes — needs hiding** |
+| `lead` | false | **false** (`models/all/src/index.ts:259`) | no — already pruned |
+| `inventory` | false | **false** (`models/all/src/index.ts:283`) | no — already pruned |
+| `board` | false / `hidden:true` cfg | **false** (`models/all/src/index.ts:340`) | no — already pruned |
 
-The rest of the HIDE list register **no launcher Application** and therefore need no hiding: `calendar` (the tile users see is Time/Planner + Team), `telegram`, `github` (injects a "Pull Requests" special *inside* Tracker), `gmail`, `mail`, `huly-mail`, `billing`, `payment`, `achievement`, `rating`, `support`, `recorder`, `bitrix`, `ai-assistant`, `ai-bot`, `openai`, `analytics-collector`.
+The remaining HIDE-list apps register **no launcher Application** and need no hiding: `calendar` (the tile users see is Time/Planner + Team), `telegram`, `github` (injects a "Pull Requests" special *inside* Tracker), `gmail`, `mail`, `huly-mail`, `billing`, `payment`, `achievement`, `rating`, `support`, `recorder`, `bitrix`, `ai-assistant`, `ai-bot`, `openai`, `analytics-collector`.
 
-So the real runtime-hide scope is just those **6 tiles**.
+**So the real app-hide scope is just 3 tiles — `recruit`, `hr`, `love`.** Most of the handoff's HIDE list is already handled by upstream defaults (`enabled:false`) or was never a launcher app. (Note: this corrects an earlier draft of this doc that listed 6 "shown by default" tiles — `lead`/`inventory`/`board` register apps but are already off.)
 
-## 4. Recommended next pass — how to actually hide the 6 tiles (choose one)
+## 4. Recommended next pass — how to actually hide the 3 tiles (choose one)
 
 **Option A — `ExcludedApplications` config plumbing (reversible, all-users, small code add).**
-`Workbench.svelte` already excludes `workbench.metadata.ExcludedApplications`, but **nothing sets it** — only `ExcludedApplicationsForAnonymous` is wired to config (`EXCLUDED_APPLICATIONS_FOR_ANONYMOUS` in `dev/prod/src/platform.ts` + `pods/front/src/__start.ts`). Mirror that wiring: add an `EXCLUDED_APPLICATIONS` config key that `setMetadata(workbench.metadata.ExcludedApplications, [...])` with the Refs of the 6 apps. ~3 small edits (platform.ts, front `__start.ts`, desktop), fully reversible via config, hides tiles for all logged-in users. *Slightly beyond "config-only" (adds plumbing), but no model/migration change.*
+`Workbench.svelte` already excludes `workbench.metadata.ExcludedApplications`, but **nothing sets it** — only `ExcludedApplicationsForAnonymous` is wired to config (`EXCLUDED_APPLICATIONS_FOR_ANONYMOUS` in `dev/prod/src/platform.ts` + `pods/front/src/__start.ts`). Mirror that wiring: add an `EXCLUDED_APPLICATIONS` config key that `setMetadata(workbench.metadata.ExcludedApplications, [...])` with the Refs of the 3 apps (`recruit.app.Recruit`, `hr.app.HR`, `love.app.Love`). ~3 small edits (platform.ts, front `__start.ts`, desktop), fully reversible via config, hides tiles for all logged-in users. *Slightly beyond "config-only" (adds plumbing), but no model/migration change.*
 
 **Option B — `PluginConfiguration.enabled=false` (the handoff's deferred build-time path).**
-Set `enabled: false` for the 6 plugins in `models/all/src/index.ts` (+ handle `migration.ts`). This is the upstream-intended way to remove apps and also drops their model txs. It's a model/build-time change → matches the handoff's "Defer: build-time stripping until the app set is validated running."
+Flip `enabled: false` for just `recruit`/`hr`/`love` in `models/all/src/index.ts` (lines 234/304/395) — the same one-word change upstream already applies to `lead`/`inventory`/`board`. This is the upstream-intended way and also drops their model txs; a model/build-time change → matches the handoff's "Defer: build-time stripping until the app set is validated running." Lowest-footprint option and consistent with how the codebase already gates optional apps.
 
 **Not recommended:** per-user `HiddenApplication` (not global); `branding.json` (cannot hide apps).
 

--- a/docs/4c-shade/FORK-CLEANUP-NOTES.md
+++ b/docs/4c-shade/FORK-CLEANUP-NOTES.md
@@ -1,0 +1,84 @@
+# HH Shade — Fork Cleanup Notes (Track B)
+
+*What was changed relative to the pristine upstream fork (`origin/develop` @ `293bc91`), and — importantly — what was investigated and deliberately **not** done. Companion to `HANDOFF.md` "TRACK B". Everything here is reversible; no build-time stripping was performed.*
+
+---
+
+## TL;DR
+
+- ✅ **Branding hygiene is done** and is the substance of this pass (README, AGENTS, ARCHITECTURE, both `branding.json` files → "HH Shade"; upstream "hosted Huly shutting down" notice + marketing removed; attribution to upstream Huly preserved; build/setup/test docs preserved).
+- ↩️ **Runtime app lean-down was attempted via `DISABLED_FEATURES` and reverted** — because a code trace proved `DISABLED_FEATURES` does **not** hide launcher apps. The handoff's suggested Track B mechanism was inaccurate. `DISABLED_FEATURES` is back at its baseline value (`auto-translate,mailboxes`).
+- 📌 **Actually hiding the app tiles is deferred** — it requires either a small config-plumbing addition (`ExcludedApplications`) or the model/build-time change the handoff already defers (`PluginConfiguration.enabled=false`). Details below.
+
+---
+
+## 1. What changed (the committed diff vs `origin/develop`)
+
+| File | Change |
+|---|---|
+| `README.md` | Rebranded Huly → HH Shade / 4C Shade. Removed the "hosted Huly is shutting down" notice, social/marketing badges, and Repobeats activity image. **Kept** all build/setup/test instructions (they still apply to the fork) and **kept** honest upstream attribution + links. |
+| `AGENTS.md` | Added a one-line context note pointing to `CLAUDE.md` / `docs/4c-shade/`. The two behavioral rules ("Do not run build commands…", "When finishing work, state the task is complete…") are **preserved verbatim**. |
+| `ARCHITECTURE_OVERVIEW.md` | Title → "HH Shade / 4C Shade Architecture Overview" + a note that the service map is the upstream Huly architecture and remains accurate. Service tables unchanged. |
+| `dev/branding.json` | `title` fields "Huly"/"TraceX" → "HH Shade" for the huly/tracex host entries. **`key` identifier fields unchanged** (changing them would break config lookups). |
+| `dev/prod/public/branding.json` | Same `title` → "HH Shade" rebrand; `key` fields unchanged. |
+
+Net diff is **branding + docs only** — no code, model, or migration files touched.
+
+## 2. The `DISABLED_FEATURES` correction (why the runtime-hide was reverted)
+
+The handoff proposed hiding non-Shade apps at runtime "via `dev/branding.json` app preset and/or `models/workbench` `HiddenApplication`." A full trace of the front-end showed **all three assumed levers are wrong for a global, all-users, config-only app hide:**
+
+- **`Branding` type** (`foundations/core/packages/core/src/server.ts`) has only `key/front/title/language/initWorkspace/lastNameFirst/protocol` — **no app field**. `branding.json` can rebrand the title; it cannot hide apps.
+- **`workbench.class.HiddenApplication`** is a **per-user `Preference`** (`models/workbench/src/index.ts`) — not a global lever.
+- **`DISABLED_FEATURES`** (env → `presentation` metadata `DisabledFeatures` → `isDisabled(feature)`) — despite `docs/disableFeatures.md` saying e.g. "recruit — Will disable Recruit", it does **not** hide any launcher app. It gates exactly four surfaces: the invite UI, account-settings sections (`SettingsCategory.feature`), workspace-settings sections (`WorkspaceSettingCategory.feature`), and **plugin cards in Settings → Configuration** (`Configure.svelte` via `PluginConfiguration.pluginId`). For a token like `recruit`, the only visible effect is hiding the Recruit *card in the admin Configuration grid* — the Recruit app tile in the launcher stays.
+
+**Proof — the launcher filter never consults `DisabledFeatures`:**
+
+```ts
+// plugins/workbench-resources/src/components/Workbench.svelte:156-164
+const excludedApps = getMetadata(workbench.metadata.ExcludedApplications) ?? []
+const apps = client.getModel()
+  .findAllSync<Application>(workbench.class.Application, { hidden: false, _id: { $nin: excludedApps } })
+  .filter((it) => isAllowedToRole(it.accessLevel, account))
+```
+
+Apps are filtered by `Application.hidden`, `workbench.metadata.ExcludedApplications`, per-user `HiddenApplication`, and role — never by `DisabledFeatures`. To actually remove a tile you must set `PluginConfiguration.enabled=false` (`models/all/src/index.ts`), which makes `pluginFilterTx` drop the plugin's `Application` create-tx. `DISABLED_FEATURES` never sets `enabled`.
+
+Because the `DISABLED_FEATURES=…,recruit,lead,inventory,calendar,telegram,github` edit achieved nothing toward the goal (and only hid some admin config cards), it was **reverted** to the baseline `auto-translate,mailboxes` in both resolution points (`dev/docker-compose.yaml`, `dev/prod/public/config.json`).
+
+*(Doc bugs noted for later: `docs/disableFeatures.md` lists `integration` but the settings category uses `integrations`; `cards` vs plugin id `card`; `training` vs feature `trainings`. Singular/plural mismatches mean those documented tokens silently match nothing.)*
+
+## 3. Which HIDE-list apps are actually launcher tiles
+
+Only **6** of the handoff's HIDE list register a top-level `workbench.class.Application` with `hidden: false` (i.e. are shown-by-default tiles):
+
+| App | Registration | Shown by default |
+|---|---|---|
+| `recruit` | `models/recruit/src/index.ts` | yes |
+| `hr` | `models/hr/src/index.ts` | yes |
+| `lead` | `models/lead/src/index.ts` | yes |
+| `inventory` | `models/inventory/src/index.ts` | yes |
+| `board` | `models/board/src/index.ts` | yes |
+| `love` (Office) | `models/love/src/index.ts` | yes |
+
+The rest of the HIDE list register **no launcher Application** and therefore need no hiding: `calendar` (the tile users see is Time/Planner + Team), `telegram`, `github` (injects a "Pull Requests" special *inside* Tracker), `gmail`, `mail`, `huly-mail`, `billing`, `payment`, `achievement`, `rating`, `support`, `recorder`, `bitrix`, `ai-assistant`, `ai-bot`, `openai`, `analytics-collector`.
+
+So the real runtime-hide scope is just those **6 tiles**.
+
+## 4. Recommended next pass — how to actually hide the 6 tiles (choose one)
+
+**Option A — `ExcludedApplications` config plumbing (reversible, all-users, small code add).**
+`Workbench.svelte` already excludes `workbench.metadata.ExcludedApplications`, but **nothing sets it** — only `ExcludedApplicationsForAnonymous` is wired to config (`EXCLUDED_APPLICATIONS_FOR_ANONYMOUS` in `dev/prod/src/platform.ts` + `pods/front/src/__start.ts`). Mirror that wiring: add an `EXCLUDED_APPLICATIONS` config key that `setMetadata(workbench.metadata.ExcludedApplications, [...])` with the Refs of the 6 apps. ~3 small edits (platform.ts, front `__start.ts`, desktop), fully reversible via config, hides tiles for all logged-in users. *Slightly beyond "config-only" (adds plumbing), but no model/migration change.*
+
+**Option B — `PluginConfiguration.enabled=false` (the handoff's deferred build-time path).**
+Set `enabled: false` for the 6 plugins in `models/all/src/index.ts` (+ handle `migration.ts`). This is the upstream-intended way to remove apps and also drops their model txs. It's a model/build-time change → matches the handoff's "Defer: build-time stripping until the app set is validated running."
+
+**Not recommended:** per-user `HiddenApplication` (not global); `branding.json` (cannot hide apps).
+
+## 5. Manual verification checklist (no build was run — per project rule)
+
+- [ ] `git diff origin/develop` shows **only** branding + docs (README, AGENTS, ARCHITECTURE, both branding.json, this notes file) — `DISABLED_FEATURES` back to baseline, no code/model diffs.
+- [ ] `dev/branding.json` + `dev/prod/public/branding.json`: `key` fields unchanged; only `title` → "HH Shade".
+- [ ] `AGENTS.md` still contains both behavioral rules verbatim.
+- [ ] After `rush docker:up` (when you build): app launcher still shows the full Huly set (app-hiding is intentionally deferred — see §4); branding reads "HH Shade".
+- [ ] No secrets/tokens introduced.

--- a/docs/4c-shade/HANDOFF.md
+++ b/docs/4c-shade/HANDOFF.md
@@ -1,0 +1,69 @@
+# HH Shade — Work Handoff
+
+*For a fresh Claude Code session scoped to the `hh-shade` repo. Read this + the files it references, then continue the two tracks below. The repo is already renamed to `hh-shade`; develop on branch `claude/dibbits-workspace-consolidation-69sqj8` — **the only branch this environment can push to.***
+
+## Read first (context base — already committed in this repo)
+
+- `CLAUDE.md` — project memory (identity, guardrails, branch).
+- `docs/4c-shade/VISION-BRIEF.md` — what 4C Shade is (product, four-legged-flywheel moat, architecture, rollout, v1-vs-roadmap, open questions). **Start here.**
+- `docs/4c-shade/DECISION-LOG.md` — locked decisions + open questions.
+- `docs/4c-shade/LICENSING-AND-ENTITY.md` — permissive-licensing framework + 4C Digital / FutureBuild / Hardscape House entity & IP structure.
+- `docs/hh-shade/CONTEXT.md` — this instance (delivers the Dibbits/HardscapeOS build; sibling repos; alpha status).
+
+## Working principle — DESIGN-FIRST (the G-DESIGN gate)
+
+Map and prototype the UI/UX, get it **human-approved**, *then* build. Prototype before implementation. Tools:
+- **Stitch** (human-led) — generates screens + a design system; exports tokens / `DESIGN.md` that build agents later consume via its MCP.
+- **Miro** (MCP available in-session) — flow maps, architecture/system diagrams, design boards; readable back as reference.
+- **Local HTML generation** — fast clickable HTML/CSS prototypes for iteration before any real build.
+
+---
+
+## TRACK A (primary) — 4C Shade console UI/UX map + prototypes
+
+**Target = the 4C Shade console/platform UI** (product option 1) — the product's own interface. **Spend the design effort on the differentiating surfaces nobody else has; do NOT try to out-polish generic agent-manager UIs (Cursor/GitHub/Antigravity).**
+
+**Differentiating surfaces to design (the product's face):**
+1. **Agent fleet / mission-control view** — see + steer parallel agent threads (Prism coordinator + Claude engineering + Gemini design), grouped by state; artifact-first review (plans, diffs, test evidence).
+2. **Gate + traceability cockpit** — the 5 gates (G-DESIGN / G-LOCK / G-PUSH / G-CLIENT / G-MONEY) as first-class objects wired into review; the **requirement ↔ spec ↔ code ↔ test ↔ deploy traceability view**; the audit "who-approved-what" ledger; the **domain-expert sign-off** flow (approve at the spec/gate/artifact level, not only senior-eng diff review).
+3. **Second-brain intake view** — expert conversation → cited scope / work-items / specs; the conversation→requirement provenance trail.
+4. **Backbone screens it wraps** (mostly Huly's existing UI): tracker (PM), documents (KB), controlled-doc specs (QMS lifecycle). Design the Shade overlays/branding on these.
+
+**Approach:**
+1. Produce a **UI/UX map** — the screen inventory + primary user flows (as a Miro board and/or an outline doc).
+2. **Prototype** the priority screens — Stitch for high-fidelity + design system; local HTML for clickable flows.
+3. Capture approved designs + tokens (`DESIGN.md`) for the eventual build → the **G-DESIGN** sign-off.
+
+**Outputs:** `docs/4c-shade/design/` (UI/UX map, wireframe notes, exported tokens) and `prototypes/` (local HTML). This is the **product console**, not the HardscapeOS ERP — keep client-confidential specifics out.
+
+---
+
+## TRACK B (parallel) — Huly fork cleanup
+
+**Baseline preserved:** the pristine upstream fork is `origin/develop` (`293bc91`) — always diff cleanup against it. (A separate `upstream-mirror` branch was unnecessary and is push-restricted here; `develop` is the baseline.)
+
+**Chosen approach: baseline + branding + runtime-hide — all reversible; NO build-time stripping this pass.**
+
+1. **Identity / branding hygiene:** rewrite `README.md` (Huly → HH Shade / 4C Shade); update root `AGENTS.md` / `ARCHITECTURE_OVERVIEW.md` as needed; update `dev/branding.json` (title / name / logo → HH Shade). Remove the upstream "hosted Huly shutting down" notice + Huly marketing.
+2. **Runtime app lean-down:** via `dev/branding.json` app preset and/or `models/workbench` `HiddenApplication`, surface only the Shade app set. **Keep all plugins compiled (reversible).**
+   - **KEEP (Shade spine):** `tracker`, `document`, `controlled-documents`, `test-management`, `activity` (+ `task`, `products`, `questions`, `training`, `survey`).
+   - **KEEP (framework):** `workbench`, `view`, `text-editor`, `attachment`, `contact`, `setting`, `notification`, `preference`, `tags`, `templates`, `card`, `drive`, `login`/`onboard`/`guest`/`client`.
+   - **HIDE (other Huly products):** `recruit`, `hr`, `lead`, `board`, `inventory`, `love`, `calendar`, `achievement`, `rating`, `support`, `recorder`, `bitrix`.
+   - **HIDE (integrations we replace via MCP):** `ai-assistant`, `ai-bot`, `openai`, `gmail`, `telegram`, `mail`, `huly-mail`, `billing`, `payment`, `analytics-collector`. (`chunter`/`chat`, `process` = borderline — hold.)
+3. **Defer:** build-time stripping (removing from `models/all/src/index.ts` + `migration.ts`) until the app set is validated running.
+
+**Verify:** after runtime-hide, the app launcher shows only the Shade set; nothing build-breaking; `git diff origin/develop` is only config/branding.
+
+**Fork facts (from the audit — don't re-audit):** ~250 MB; ~64 logical apps (each = `x` / `x-assets` / `x-resources` triad → 192 dirs); 22 services; customization levers present (`models/all/src/index.ts`, `models/all/src/migration.ts`, `dev/branding.json`).
+
+---
+
+## Guardrails
+
+- **Agent skills = quality over quantity** — the 26 ShadeOS crew ops are *source material, not a port list*. Curate; add deliberately.
+- **Most-permissive components** for anything forked/embedded/shipped (MIT/Apache; EPL/MPL ok; **avoid AGPL**). Tools you only run are unconstrained.
+- **Subscription-first** Claude (official CLI on the subscription); the **5 gates**; branch discipline (push only `claude/dibbits-workspace-consolidation-69sqj8`).
+
+## Open questions (still pending — see `VISION-BRIEF.md` §12)
+
+Counsel: license scope / HH path, IP assignment into 4C, channel exclusivity. Technical: "ready to migrate" = backbone-ready vs full-console-ready; hardware pick; the demo-project definition; client-access policy. Unspecced: crew-ops → skills build spec; GTM / pricing.

--- a/docs/4c-shade/LICENSING-AND-ENTITY.md
+++ b/docs/4c-shade/LICENSING-AND-ENTITY.md
@@ -1,0 +1,57 @@
+# 4C Shade — Licensing Framework & Entity / IP Structure
+
+*Companion to `VISION-BRIEF.md`. Two parts: (A) the permissive-licensing framework that governs component selection, and (B) the entity/IP/commercial structure.*
+
+---
+
+## A · Permissive-licensing framework
+
+**Core rule:** licensing obligations attach to what you **distribute / fork / host-for-others** — NOT to what you merely **use** to build your own, separately-licensed product.
+
+Three buckets:
+
+1. **Dependencies you fork / embed / ship / host-for-dealers** → want most-permissive (MIT/Apache/BSD). Copyleft bites here. **The Shade backbone + custom MCP live here.**
+2. **Your own product** (4C Shade, the ShadeOS kit) → your choice; owner-controlled. Goal = **permissive inputs, controlled output.**
+3. **Tools you only run** (editor, Claude CLI, terminal, orchestrator) → license ~irrelevant; using GPL/AGPL tools to build never touches your product.
+
+**Ladder (most → least permissive for a closed commercial product):** MIT/Apache/BSD → MPL/EPL/LGPL (weak, file-level) → GPL (on distribution) → **AGPL (on network use — disqualifying for anything forked/hosted-for-others).**
+
+### Verdict: keep EPL-Huly
+
+A more-permissive *and* genuinely-capable backbone does not exist. Every all-in-one alternative is *less* permissive for the fork-and-host model (Plane/Taiga/AppFlowy/Twenty/Docmost/Cal.com = **AGPL**; Outline/NocoDB/Planka/AFFiNE-server = **source-available with host-for-others bars**). The genuinely permissive options (Wekan/Kanboard/Baserow, all MIT) aren't backbones. **Huly's controlled-docs/QMS is ~unique.** EPL fits perfectly: fork + host for dealers = zero disclosure; ship a modified build = release only modified EPL files; proprietary customizations/MCP/config stay yours.
+
+### Component license map (action items)
+
+| Component | License | Note for the fork-and-host build |
+|---|---|---|
+| Huly platform / `@hcengineering/api-client` | **EPL-2.0** | Host for others = no disclosure. Importing api-client does NOT make your MCP EPL. |
+| Custom MCP base | prefer **MIT** community servers (`dearlordylord/huly-mcp`, `oculairmedia/huly-mcp-server`) | Avoid the EPL one (`varaprasadreddy9676`) → copyleft-free MCP layer. |
+| Infisical | **MIT core** (EE features proprietary) | Self-host core safe; EE = dynamic secrets, approval workflows, SSO-beyond-Google/GitHub. |
+| Coordinator model | **gpt-oss (Apache-2.0), Qwen3 (Apache-2.0), GLM-4.5/4.6 (MIT)** | Unconditional — resell inference cleanly. Avoid Gemma/Llama (use-restrictions). |
+| Console editor component (if embedded/shipped) | use **Neovim/Lapce (Apache), Ghostty (MIT), tmux (ISC), Terminus (MIT)** | Avoid embedding GPL Zed / AGPL Zed-collab into a *shipped* console. Zed as a *tool you use* is fine. |
+| Orchestrators (if embedded/shipped) | **opencode (MIT), Vibe Kanban (Apache)** OK | Claude Squad (AGPL) + Crush (FSL) = use-only; Conductor = proprietary, use-only. |
+| SaaS (Stitch, Miro, Workspace, Xero, Mercury, Antigravity) | ToS, not code license | Sharpest: **Xero prohibits training AI/ML on its API data** → design hours→invoice as read-and-act only. |
+
+---
+
+## B · Entity / IP / commercial structure
+
+**Pattern:** IP-lab + commercial-partner, services-led ("commercial open-source / open-core + services").
+
+| Entity | Role | License / revenue |
+|---|---|---|
+| **4C Digital** (AI/systems R&D lab + dev co) | **Builds + OWNS 4C Shade (the IP)** | Grants FutureBuild a **free perpetual license**; monetizes **license-as-a-service** (customize + implement + maintain) downstream + optional managed-inference tier |
+| **FutureBuild** | Commercial / client-facing partner (delivery channel) | Free perpetual Shade license for its own client work |
+| **Hardscape House** | Vertical JV (FutureBuild + Dibbits) | Runs **HH Shade** (alpha instance) — license path TBD (via FB's license vs its own from 4C) |
+| **Dibbits / dealers / clients** | End customers | Licensed + serviced `<Org> Shade` instances |
+
+- **Revenue model:** platform **free to the partner (FutureBuild)**; 4C earns from **services** (customization/implementation/maintenance) on end-client deployments + **managed inference**. Not platform-license fees to FB.
+- **Reconciles with the framework:** permissive inputs (EPL-Huly + Apache/MIT models) are *why* 4C can own + freely license + resell with no upstream copyleft snag.
+- **Branding:** the `Shade` line = "4C Shade by 4C Digital"; FutureBuild = commercial partner; each deployment = `<Org> Shade`.
+
+### Open items (for Colton + counsel — flags, not decisions)
+
+1. **Free-perpetual-license scope** — does "FutureBuild's client work" cover the **Hardscape House JV** (separate entity)? Define HH Shade's license path.
+2. **License-as-a-service contract** terms (4C-charged vs FB-bundled).
+3. **IP assignment** — everything built (incl. during the Dibbits engagement / HH JV) lands in 4C cleanly.
+4. **Channel exclusivity** — Shade downstream **only via FutureBuild**, or can 4C also license direct / to other verticals & channels?

--- a/docs/4c-shade/README.md
+++ b/docs/4c-shade/README.md
@@ -1,0 +1,19 @@
+# 4C Shade — Product Docs
+
+This folder captures the **4C Shade** product work. 4C Shade is an **owned, self-hosted, QMS-gated, agent-native software-delivery platform for verticals**, built by **4C Digital**. This repository (`HH Shade`) is the first deployment — the **Hardscape House** instance — currently a repurposed Huly platform fork.
+
+## Contents
+
+| Doc | What's in it |
+|---|---|
+| [`VISION-BRIEF.md`](./VISION-BRIEF.md) | The v1 vision brief — one-liner, positioning, the four-legged-flywheel moat, product contents, architecture, rollout, v1-vs-roadmap, open questions. **Start here.** |
+| [`DECISION-LOG.md`](./DECISION-LOG.md) | Condensed record of locked decisions, the moat, the 5 gates, the auth/billing rule, and open questions. |
+| [`LICENSING-AND-ENTITY.md`](./LICENSING-AND-ENTITY.md) | The permissive-licensing framework + component license map + the 4C Digital / FutureBuild / Hardscape House entity & IP structure. |
+
+## Identity stack
+
+**4C Digital** (owner/lab) · **Shade** (platform) · **4C Shade** (product) · **`<Org> Shade`** (FB Shade, HH Shade, Dibbits Shade…) · **Prism** (native OSS coordinator agent) · **ShadeOS** (doctrine/heritage) · **4CDAI** (optional AI-division banner).
+
+## Status
+
+Discovery / vision consolidated. This is a **review-and-build draft** — see `VISION-BRIEF.md` §12 for open questions. Instance-specific context for this deployment lives in [`../hh-shade/CONTEXT.md`](../hh-shade/CONTEXT.md); repo-level agent memory is in the root [`CLAUDE.md`](../../CLAUDE.md).

--- a/docs/4c-shade/VISION-BRIEF.md
+++ b/docs/4c-shade/VISION-BRIEF.md
@@ -1,0 +1,93 @@
+# 4C Shade — v1 Vision Brief
+
+*by 4C Digital · consolidation draft (review-and-build)*
+
+---
+
+## 1 · One-liner
+
+**4C Shade is an owned, self-hosted, QMS-gated, agent-native software-delivery platform for verticals.** Autonomous agents build the software; every deliverable carries an immutable, auditable **conversation → requirement → spec → code → test → deploy** trail with human sign-off gates as first-class objects. It runs on flat-rate economics (subscription CLI agents + a local OSS coordinator), and each customer gets a branded instance (`<Org> Shade`). Built by **4C Digital**, taken to market through **FutureBuild**, first proven on the **HardscapeOS** ERP (HH Shade).
+
+## 2 · Why now
+
+- **Origin:** the Dibbits ERP engagement produced the "ShadeOS" command-center (agent crew ops, gates, a conversation-driven second brain). 4C Shade productizes that into an owned delivery OS.
+- **Market timing:** generation is solved; **verification / "review debt" is the industry's unsolved bottleneck** (studies show AI ships ~2× the security bugs it fixes). Regulation is arriving — **EU AI Act high-risk enforcement (Aug 2, 2026)** and **ISO 42001** mandate immutable audit logs + "blocking approval gates." 4C Shade's gated, traceable model is early to exactly where the market is being pushed.
+
+## 3 · Positioning
+
+**"Autonomous delivery you can prove and stand behind"** — not "delivery, faster." Compete on **provable, accountable, domain-correct** delivery; **ride** the commoditizing agent architecture (Claude/Gemini), **own** the governance + vertical layer.
+
+## 4 · The moat — a four-legged flywheel
+
+| Leg | What it is | Why it's defensible |
+|---|---|---|
+| **Second brain** | Expert conversations (client/prospect calls) → cited scope/work-items/specs + domain grounding for agents | Owns the *upstream* of the loop; compounds with every conversation; extends traceability to origin |
+| **QMS-gated delivery** | Controlled-doc specs + 5 gates-as-objects + requirement→…→deploy traceability | Uncontested white space; regulatory tailwind |
+| **Owned · vertical · brandable** | Self-hosted per-org `<Org> Shade` instances; domain expertise encoded | Combination uncontested; "vertical *delivery* OS" is empty space |
+| **Flat economics** | Subscription CLI agents (Claude Max) + local OSS coordinator (Prism); ~nothing metered | Structurally uncopyable by SaaS (ToS blocks 3rd-party subscription use) |
+
+**The loop:** conversations → domain knowledge → domain-correct specs → gated autonomous build → traceable delivery → (outcomes + new conversations) → richer knowledge. *Each turn makes the agents more expert and the delivery more provable — on flat cost.*
+
+## 5 · What's in the product
+
+- **Backbone (EPL-Huly, self-hosted):** tracker/PM + docs knowledge base + **controlled-documents QMS** (spec lifecycle) + gates-as-objects + multi-workspace. System of record.
+- **Console (custom):** agent-native cockpit — fleet view, artifact-first review, and the differentiating surface: **gates + requirement↔spec↔code↔test↔deploy traceability + audit "who-approved-what" ledger + domain-expert sign-off.**
+- **Agents:** **Claude CLI** (subscription) for engineering; **Gemini** via MCP for design/planning/multimodal; **Prism** — a local OSS coordinator for always-on PM/scheduling/doc-upkeep.
+- **Second brain:** the `intake` / `ingest` / knowledge-graph engine turning conversations into structured, cited work + agent grounding.
+- **5 gates:** G-DESIGN, G-LOCK, G-PUSH, G-CLIENT, G-MONEY — human sign-offs as first-class, ISO-42001-aligned objects.
+- **Integration (MCP):** GitHub, Infisical (runtime secrets), Stitch + Miro (design / G-DESIGN), Google Workspace/Drive (ingestion + drafts), Xero/Mercury (billing / G-MONEY).
+
+## 6 · Architecture — two-tier model economy
+
+- **Prism (local OSS, owned hardware):** always-on coordinator/router — cheap, flat, does run-of-the-mill PM/oversight and (eventually) fronts a single chat UI over the fleet.
+- **Claude CLI (subscription):** on-demand heavy engineering, real CLI in a terminal (subscription-billed, not metered).
+- **Gemini / product tools (MCP):** design, multimodal, and SaaS tools as needed.
+- **Coordination bus = the backbone (Shade/Huly):** agents meet in Shade, not via fragile in-IDE plumbing.
+- **Hardware:** a ≤$5k Linux box runs Prism's OSS model — validated via cloud API first, then self-hosted; **doubles as a managed-inference revenue line.**
+
+## 7 · Entity, IP & commercial model
+
+- **4C Digital** builds and **owns** 4C Shade (the IP).
+- **FutureBuild** = commercial partner: **free perpetual license** for its client-facing work; the delivery channel.
+- **Revenue:** **license-as-a-service** (customize + implement + maintain) on downstream `<Org> Shade` deployments + **managed inference**. Platform free to the partner; money in services.
+- **Permissive-inputs discipline** (EPL-Huly + Apache/MIT models) is what lets 4C own, license, and resell cleanly.
+- **White-label native:** every deployment is `<Org> Shade` — the customer's name is on it.
+
+*(Detail in `LICENSING-AND-ENTITY.md`.)*
+
+## 8 · Identity stack
+
+**4C Digital** (owner) · **Shade** (platform) · **4C Shade** (product / reference build) · **`<Org> Shade`** (FB Shade, HH Shade, Dibbits Shade…) · **Prism** (coordinator agent) · **ShadeOS** (doctrine) · **4CDAI** (optional AI-division banner).
+
+## 9 · Rollout
+
+1. **Demo project** — prove the flywheel on a small throwaway (de-risk the console).
+2. **HH Shade (alpha)** — run the live **Dibbits/HardscapeOS build** on it; the flagship reference instance.
+3. **FB Shade** — FutureBuild's branded instance; migrate FutureBuild's projects.
+4. **Dealer / other-vertical instances** — the commercial product.
+
+- **Interim:** keep the current setup (Obsidian + lean-terminal + Plane) until HH Shade is ready; single clean cutover.
+
+## 10 · v1 scope vs roadmap
+
+- **v1 (build first):** self-hosted Shade backbone (PM/KB/QMS-specs/gates) + MCP integration + a lean cockpit (Claude CLI + MCP, Zed-hosted) + second-brain intake + the demo project → then the Dibbits migration. **Prism v1 = light** (scheduled routines + doc-upkeep, possibly on a cloud OSS API).
+- **Roadmap (not v1):** the forked **custom console** (embedded terminal/browser); **Prism** as full fleet-conduit / single-chat-UI; local self-hosted inference on the $5k box; multi-instance productization + brandable provisioning; the managed-inference offering; commercial GTM to dealers/verticals.
+
+> **Build guardrail — agent skills = quality over quantity.** Do NOT overbloat the Claude-facing agent tooling. The 26 crew ops are *source material, not a port list* — curate a lean set of high-value skills and add capabilities deliberately/incrementally as each earns its place.
+
+## 11 · Key decisions locked
+
+- Backbone = **EPL-Huly self-hosted** (validated as the most-permissive *capable* option).
+- Cockpit (interim) = **Claude CLI + MCP, hosted in Zed**; permissive components for anything shipped.
+- **Console + backbone both** in scope (console is the product's face); demo-first, single cutover.
+- **Most-permissive licensing** driver: permissive inputs, 4C-owned controlled output.
+- Model path: **gpt-oss-120b or Qwen3-30B-A3B (Apache-2.0)**, test-via-API → self-host; ≤$5k Linux.
+- Old `dibbits_workspace` = **harvest-then-archive** (productized into Shade).
+
+*(Full decision log in `DECISION-LOG.md`.)*
+
+## 12 · Open questions to resolve
+
+- **For counsel:** free-perpetual-license scope (does it cover the HH JV?); HH Shade's license path; **IP assignment** into 4C (incl. Dibbits-engagement work); **channel exclusivity** (FutureBuild-only downstream, or 4C direct / other channels too).
+- **Product/technical:** "ready to migrate" = backbone-ready vs full-console-ready; hardware pick (DGX Spark + gpt-oss-120b vs RTX 5090 + Qwen3); the **demo project** definition; internal-only vs eventual client access to instances.
+- **Not yet specced:** crew-ops → skills (concrete build requirements for what Shade must implement); GTM / pricing math.

--- a/docs/4c-shade/design/DESIGN.md
+++ b/docs/4c-shade/design/DESIGN.md
@@ -1,0 +1,265 @@
+# 4C Shade — Console Design System (`DESIGN.md`)
+
+*Track A / G-DESIGN deliverable. This is the proposed token set + component spec for the **product console** (not the HardscapeOS ERP — that is "Hardscape Dark", a separate system). Build agents consume this file; the local HTML prototypes in `/prototypes` are its first realization.*
+
+**Status:** proposal for G-DESIGN sign-off. Nothing here is locked until a human approves the gate.
+
+---
+
+## 1 · Design thesis
+
+The product is named **Shade** and its positioning is *"autonomous delivery you can prove and stand behind."* The interface is therefore an **instrument, not a hype surface**: calm, dense, evidence-first, and dark-committed. Two subject-native ideas drive the visual language:
+
+- **Refraction / Prism.** The coordinator agent is *Prism* — it splits one stream of work across a fleet. A single **spectral gradient** (violet → cyan → teal) is the product's one bold motif, reserved for exactly two places: the Prism coordinator and the requirement→…→deploy **traceability spine**. Everywhere else is quiet.
+- **Chain-of-custody.** Every traceable object (requirement, spec, commit, test run, gate approval) carries an **ID rendered in monospace**. Monospace is not just for code here — it is the typographic signal of *"this thing has provenance"*. That is the console's typographic character.
+
+### Scoping rule (load-bearing — repeated from the Track A brief)
+
+> Spend fidelity on the **differentiating surfaces** (fleet/mission-control, gate + traceability cockpit, second-brain intake). The **backbone screens** (tracker, docs, controlled-doc QMS) are **Huly's existing UI + a Shade overlay** — do *not* redesign them, and do not try to out-polish generic agent-manager UIs (Cursor / GitHub / Antigravity). The tokens below define the *overlay* (top bar, rail, accent, status chips, gate ribbon) that makes a backbone screen read as Shade.
+
+---
+
+## 2 · Color tokens
+
+Semantic tokens are the contract — components reference these, never raw hex. **Dark is primary** (the name *Shade* commits to it). A full light ramp is specified so build agents can ship a light mode; the prototypes render dark only, by deliberate choice (see §9, open question OQ-1).
+
+### 2.1 Neutrals — cool blue-slate (chosen, not defaulted)
+
+The neutral carries a slight blue-cyan hue bias toward the accent, so it reads as selected rather than a generic grey.
+
+| Token | Dark (primary) | Light | Role |
+|---|---|---|---|
+| `--bg` | `#0A0D13` | `#F4F7FA` | App canvas (near-black blue-slate) |
+| `--surface-1` | `#0F131B` | `#FFFFFF` | Left rail, base panels |
+| `--surface-2` | `#151A24` | `#FFFFFF` | Cards, list rows |
+| `--surface-3` | `#1C2230` | `#EDF1F6` | Inputs, hover, raised |
+| `--surface-4` | `#232B3B` | `#E4EAF2` | Popovers, active row, drawer |
+| `--border` | `#242C3A` | `#E2E7EF` | Hairline dividers |
+| `--border-2` | `#313B4D` | `#CBD4E1` | Stronger borders, focus outer |
+| `--overlay` | `rgba(5,7,11,.62)` | `rgba(30,40,55,.32)` | Scrim behind modals/drawers |
+
+### 2.2 Ink (text)
+
+| Token | Dark | Light | Role |
+|---|---|---|---|
+| `--ink-1` | `#EAEEF6` | `#141922` | Primary text, headings |
+| `--ink-2` | `#AEB8CC` | `#47536A` | Secondary text, values |
+| `--ink-3` | `#727E93` | `#6C7891` | Muted, captions, labels |
+| `--ink-4` | `#4B5567` | `#98A2B4` | Faint, disabled, placeholder |
+
+### 2.3 Brand accent — "Shade signal" (cyan-teal)
+
+One accent, used sparingly: primary buttons, focus rings, the active/in-review gate, key links, selection.
+
+| Token | Dark | Light |
+|---|---|---|
+| `--accent` | `#37CFBD` | `#12A594` |
+| `--accent-hover` | `#4ADED0` | `#159A8B` |
+| `--accent-press` | `#28B4A3` | `#0E8577` |
+| `--accent-fg` | `#04120F` | `#FFFFFF` |
+| `--accent-weak` | `rgba(55,207,189,.14)` | `rgba(18,165,148,.12)` |
+| `--accent-line` | `rgba(55,207,189,.38)` | `rgba(18,165,148,.34)` |
+
+### 2.4 Spectral signature (the one bold motif)
+
+Reserved for the **Prism coordinator badge** and the **traceability spine rail** only. Never a full-page hero gradient (that is the AI cliché we avoid).
+
+```
+--spectral: linear-gradient(90deg, #8B7CF0 0%, #4EC5E0 52%, #37CFBD 100%);
+--spectral-soft: linear-gradient(90deg, rgba(139,124,240,.16), rgba(78,197,224,.14), rgba(55,207,189,.16));
+```
+
+### 2.5 Agent identities
+
+Each agent chip **always** shows a monogram + name, so color is secondary encoding (colorblind-safe by construction).
+
+| Token | Dark | Weak tint | Agent |
+|---|---|---|---|
+| `--prism` | `#8B7CF0` (iris) | `rgba(139,124,240,.14)` | **Prism** — local OSS coordinator |
+| `--claude` | `#E0785B` (clay) | `rgba(224,120,91,.14)` | **Claude** — engineering (subscription CLI) |
+| `--gemini` | `#5B9DF9` (azure) | `rgba(91,157,249,.14)` | **Gemini** — design / multimodal (MCP) |
+| `--human` | `#AEB8CC` (steel) | `rgba(174,184,204,.12)` | **Human** — expert / reviewer / approver |
+
+Light-mode agent hues: prism `#6D57E0`, claude `#C15A3B`, gemini `#2E6FD6`, human `#5A6478`.
+
+### 2.6 Status ramp (reserved — never reused as an agent/series color)
+
+Always paired with an icon **and** a text label; never color-alone.
+
+| Token | Dark | Weak | Meaning |
+|---|---|---|---|
+| `--ok` | `#46C98A` | `rgba(70,201,138,.14)` | Passed · approved · effective · green tests |
+| `--warn` | `#E7B54B` | `rgba(231,181,75,.14)` | Awaiting sign-off · pending · needs human |
+| `--risk` | `#E8894A` | `rgba(232,137,74,.14)` | At-risk · stale · partial |
+| `--crit` | `#E86A6A` | `rgba(232,106,106,.14)` | Failed · rejected · blocked |
+| `--info` | `#5B9DF9` | `rgba(91,157,249,.14)` | Running · neutral in-progress |
+
+### 2.7 Gate-state mapping
+
+| Gate state | Token | Chip |
+|---|---|---|
+| Approved / passed | `--ok` | ● Passed |
+| In review (current focus) | `--accent` | ◆ In review |
+| Awaiting human sign-off | `--warn` | ◐ Awaiting |
+| Rejected / changes requested | `--crit` | ✕ Rejected |
+| Locked / not started | `--ink-3` | ○ Locked |
+
+---
+
+## 3 · Typography
+
+CSP / offline `file://` constraint: prototypes use the **native system stack** (no webfont fetch, no multi-MB data-URI embeds). Character comes from the scale, weights, spacing, and the monospace-for-identity rule — not from a novelty face. When the real console builds, a licensed grotesque (e.g. a variable sans) may be embedded via `@font-face`; the token names stay.
+
+```css
+--font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI Variable Display",
+             "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+--font-mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code",
+             "Roboto Mono", Menlo, Consolas, monospace;
+```
+
+### Type scale
+
+| Token | Size / line | Weight | Tracking | Use |
+|---|---|---|---|---|
+| `--fs-display` | 26 / 32 | 600 | -0.01em | Screen title (rare) |
+| `--fs-h1` | 20 / 26 | 600 | -0.005em | Panel / section title |
+| `--fs-h2` | 16 / 22 | 600 | 0 | Card title, gate name |
+| `--fs-h3` | 14 / 20 | 600 | 0 | Sub-head, list group |
+| `--fs-body` | 13.5 / 20 | 400 | 0 | Default UI text |
+| `--fs-sm` | 12.5 / 18 | 400 | 0 | Secondary / dense |
+| `--fs-label` | 11 / 14 | 600 | 0.07em, UPPERCASE | Eyebrows, column heads, chip labels |
+| `--fs-mono` | 12.5 / 18 | 450 | 0 | **IDs, hashes, timestamps, code, evidence** |
+| `--fs-mono-sm` | 11.5 / 16 | 450 | 0 | Dense mono (ledger, diff gutter) |
+
+**Rules.** Headings get `text-wrap: balance`. Any column of digits gets `font-variant-numeric: tabular-nums`. Uppercase labels always carry ≥0.07em tracking. Every object ID (`REQ-014`, `G-DESIGN`, `a1b9f3c`, ISO timestamps) is `--font-mono`.
+
+---
+
+## 4 · Spacing, radius, elevation
+
+```css
+/* 4px base spacing scale */
+--sp-1:2px; --sp-2:4px; --sp-3:6px; --sp-4:8px; --sp-5:12px;
+--sp-6:16px; --sp-7:20px; --sp-8:24px; --sp-9:32px; --sp-10:40px; --sp-11:48px;
+
+/* radii */
+--r-1:6px;   /* chips, inputs, buttons */
+--r-2:10px;  /* cards */
+--r-3:14px;  /* panels, drawers */
+--r-pill:999px;
+
+/* elevation — instrument-grade: prefer surface-step + hairline over heavy shadow */
+--shadow-1: 0 1px 2px rgba(0,0,0,.40);
+--shadow-2: 0 8px 28px -10px rgba(0,0,0,.62);
+--shadow-pop: 0 16px 48px -14px rgba(0,0,0,.72);
+
+/* focus ring (accessibility — visible in both themes) */
+--focus: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
+```
+
+Layout uses flex/grid + `gap`, never per-element margins for sibling spacing. Wide content (diffs, tables, the traceability spine) lives in an `overflow-x:auto` container so the page body never scrolls sideways.
+
+---
+
+## 5 · App shell (chrome common to every screen)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Top context bar  ·  workspace switcher · breadcrumb · gate    │  48px
+│                      ribbon · global search · actor menu       │
+├───────┬──────────────────────────────────────────┬────────────┤
+│ Left  │              Main work area               │  Inspector │
+│ rail  │  (fleet board / gate cockpit / intake)    │  drawer    │
+│ 60/   │                                           │  (context, │
+│ 232px │                                           │  artifact) │
+└───────┴──────────────────────────────────────────┴────────────┘
+```
+
+- **Left rail** — collapsible (icon-only 60px ↔ labelled 232px). Groups: **Console** (Fleet, Gates, Second Brain, Activity) above the hairline; **Backbone** (Tracker, Documents, Specs/QMS, Test Mgmt) below — the backbone group is the Huly apps under a Shade overlay.
+- **Top context bar** — workspace switcher (`<Org> Shade`), breadcrumb, a compact **gate ribbon** (5 gate dots showing global state), search, actor/agent menu. `--surface-1`, hairline bottom border.
+- **Inspector drawer** — right, `--surface-1`, opens on selection to show the artifact / provenance / audit context. This is where *artifact-first review* happens.
+
+---
+
+## 6 · Component specs (the differentiating pieces)
+
+### 6.1 Agent-thread card (`.agent-card`)
+The unit of the fleet board. `--surface-2`, `--r-2`, 1px `--border`; left **2px identity stripe** in the agent color.
+- **Header:** agent monogram avatar (agent-color weak bg, agent-color ring) · agent name · a monospace **thread id** (`TH-2043`) · a status chip.
+- **Body:** the work-item title + linked `REQ`/issue id (mono) · a one-line current-activity string.
+- **Artifact row (artifact-first):** up to 3 artifact chips — `◫ Plan`, `⌥ Diff +142/−31`, `✓ Tests 18/18` — each opens that artifact in the inspector. Counts in tabular mono.
+- **Footer:** elapsed time · model/tier tag · a "needs review" flag when awaiting a gate.
+- **States:** hover raises to `--surface-3`; selected gets `--accent-line` ring + `--accent-weak` wash.
+
+### 6.2 Fleet column (`.fleet-col`)
+Kanban-style column grouped by **thread state**: Planning · Working · Awaiting review · Blocked · Done. Column header = uppercase `--fs-label` + a count. A thread awaiting a human gate shows a `--warn` left edge on its column header.
+
+### 6.3 Gate object (`.gate`)
+A gate is a first-class object, not a checkbox. Card or ribbon-node form.
+- **Identity:** gate id in mono (`G-DESIGN`) + human name ("Design approved before build").
+- **State chip** (§2.7) + progress ("3 of 4 items signed").
+- **Required approvers:** stacked actor avatars incl. a **domain-expert** slot (`--human`).
+- **Wired to review:** clicking a gate opens the items awaiting it + their traceability + the sign-off action. Gates never auto-pass; a gate stores *who / when / what-hash*.
+
+### 6.4 Traceability node + edge (`.trace-node`, `.trace-edge`)
+The requirement ↔ spec ↔ code ↔ test ↔ deploy spine.
+- **Node:** pill with a stage glyph, a stage label (`--fs-label`), and the object id in mono. Node border encodes coverage: solid `--accent-line` = linked & fresh; dashed `--risk` = stale/partial; `--crit` = missing/broken link.
+- **Edge:** 2px connector painted with `--spectral` when the whole chain is intact (the one place the spectral motif earns its keep); greyed `--border-2` where the chain is broken. Hovering a node highlights its in/out edges.
+- **Node detail:** clicking expands the node inline — source excerpt, author (agent or human), timestamp, content hash — the evidence.
+
+### 6.5 Artifact-review panel (`.artifact-panel`) — inspector drawer content
+Tabbed: **Plan · Diff · Tests · Provenance**.
+- **Plan:** rendered markdown of the agent's plan; approve/request-changes footer.
+- **Diff:** unified diff, mono, `--ok`/`--crit` gutter tints for +/−, file tree on the left.
+- **Tests:** pass/fail summary tiles + a run log; a small pass-rate bar.
+- **Provenance:** the mini traceability chain for this artifact + the audit trail of who touched it.
+- **Footer action bar:** `Approve` (accent), `Request changes` (ghost, `--crit` text), `Reassign`. Every action writes to the audit ledger.
+
+### 6.6 Audit-ledger row (`.ledger-row`)
+Immutable "who-approved-what". Monospace-forward: `timestamp · actor · action · object-id · content-hash`. Rows are append-only, hash-chained (each row shows a truncated `prev←` hash). Expandable to reveal the full signed payload. Icon + label for the action type; `--ok`/`--crit`/`--warn` accent on the action verb only.
+
+### 6.7 Provenance / citation card (`.cite-card`) — second brain
+Links an extracted work-item back to its origin conversation span.
+- **Extracted object:** type badge (Requirement / Work-item / Spec / Risk) + generated id (mono) + one-line statement.
+- **Cited source:** a quoted span with speaker + timestamp + source (call / doc), and a **confidence** meter. A "view in conversation" jump scrolls the transcript to the highlighted span.
+- **Grounding:** which domain-knowledge nodes this drew on (chips).
+
+### 6.8 Shared atoms
+- **Chip / pill** — `--r-pill`, `--fs-label`, weak-tint bg + full-color text/glyph. Variants: status, agent, gate-state, artifact.
+- **Button** — primary (accent bg, `--accent-fg`), ghost (transparent, `--border` ring), danger-ghost (`--crit` text). 32px default height, `--r-1`, `--fs-body` 600.
+- **Stat tile** — big tabular number + `--fs-label` caption + optional inline sparkline; used in the fleet summary strip.
+- **Meter / bar** — 6px track `--surface-3`, fill in status or accent; pass-rate, confidence, gate progress.
+
+---
+
+## 7 · Data-visualization rules (from the `dataviz` method)
+
+- **One axis, ever.** No dual-scale charts.
+- **Categorical = fixed agent order** (Prism, Claude, Gemini, Human) — never cycled; a colored mark always sits beside a text label.
+- **Sequential** (e.g. coverage heat): single hue, light→dark off the accent ramp.
+- **Status colors are reserved** (§2.6) and never used as a data series.
+- Charts stay small and inline (fleet throughput sparkline, pass-rate bar, gate-progress meter). Grid/axes recessive; endpoints emphasized; text wears ink tokens, not the series color.
+
+---
+
+## 8 · Accessibility & motion
+
+- Contrast: body text ≥ 4.5:1 on its surface; large text/labels ≥ 3:1. Accent text (`--accent-fg` on `--accent`) verified for buttons.
+- Never color-alone: status, agent, and gate identity always carry an icon/monogram + label.
+- Visible keyboard focus (`--focus`) on every interactive element.
+- Respect `prefers-reduced-motion`: no non-essential transitions; the spectral motif is static (no animated gradient) under reduced-motion.
+- Motion budget is tiny by design — hover elevation, drawer slide, expand/collapse. No ambient animation (this is an instrument).
+
+---
+
+## 9 · Open design questions for G-DESIGN
+
+- **OQ-1 — Light mode in v1?** The prototypes commit to dark (the *Shade* thesis). Tokens support light. Decide: dark-only v1, or ship both? (Recommendation: dark-primary, light as fast-follow.)
+- **OQ-2 — Rail scope.** How many backbone apps surface in the rail by default vs. under a "more" affordance? (Ties to the Track-B lean-down set.)
+- **OQ-3 — Single-chat-over-fleet (Prism front).** Roadmap says Prism eventually fronts one chat UI over the whole fleet. Do we design that conversational surface now, or keep the board-first model for v1?
+- **OQ-4 — Gate rigidity.** Are all 5 gates mandatory per work-item, or configurable per workspace/project? Affects whether the gate ribbon is fixed or authored.
+- **OQ-5 — Embedded font.** Ship a licensed variable grotesque via `@font-face` for the real build, or stay on the native stack? (Prototypes stay native for offline fidelity.)
+
+---
+
+*Token source of truth for the prototypes: this file. If a prototype and this file disagree, this file wins and the prototype is the bug.*

--- a/docs/4c-shade/design/UI-UX-MAP.md
+++ b/docs/4c-shade/design/UI-UX-MAP.md
@@ -1,0 +1,209 @@
+# 4C Shade — Console UI/UX Map (`UI-UX-MAP.md`)
+
+*Track A / G-DESIGN deliverable. Screen inventory + primary user flows for the **product console** (the 4C Shade / `<Org> Shade` interface). Companion to `DESIGN.md` (tokens) and the clickable prototypes in `/prototypes`. Keeps client-confidential HardscapeOS/Dibbits specifics out — examples are generic software-delivery.*
+
+---
+
+## 1 · Design principles
+
+1. **Agent-native, not human-CRUD.** The primary operators are agents (Prism / Claude / Gemini); the human's job is to **steer and sign off**, not to type every field. The default view is a *fleet of work in motion*, not an empty form.
+2. **Artifact-first review.** You review the **thing produced** — a plan, a diff, test evidence, a spec — not a status label about it. Every state in the console is one click from the artifact that justifies it.
+3. **Gates & traceability are first-class objects.** The 5 gates and the requirement→spec→code→test→deploy chain are navigable objects with their own state, approvers, and audit history — not metadata hidden in a sidebar. This is the moat surface; it gets the fidelity.
+4. **Provable delivery over faster delivery.** When "show more evidence" competes with "fewer clicks", evidence wins. Immutable audit, content hashes, and who-approved-what are visible by default because the product's promise is *"delivery you can stand behind."*
+5. **Provenance runs to the origin.** Nothing is a floating assertion: a work-item traces up to the **conversation span** that created it (second brain) and down to the **deploy** that satisfied it. The chain is the product.
+6. **Scoping discipline — differentiate, don't out-polish.** High fidelity goes to the surfaces **nobody else has**: fleet/mission-control, the gate + traceability cockpit, and second-brain intake. The **backbone screens** (tracker, docs, controlled-doc QMS) are **Huly's existing UI + a Shade overlay** (top bar, rail, accent, gate ribbon, status chips) — we do **not** redesign them and we do **not** try to beat Cursor / GitHub / Antigravity at generic agent-manager UX.
+
+---
+
+## 2 · Screen inventory
+
+Priority: **P0** = differentiating (build & prototype first) · **P1** = supporting console · **P2** = backbone overlay (Huly UI + Shade skin, minimal net-new design).
+
+| # | Screen | Purpose | Priority | Primary artifacts shown |
+|---|---|---|---|---|
+| S1 | **Fleet / Mission Control** | See + steer all parallel agent threads, grouped by state | **P0** | Agent-thread cards; plan / diff / test-evidence chips; fleet summary tiles |
+| S2 | **Agent Thread detail** | Drill into one agent's run: transcript, plan, artifacts, hand-offs | **P0** | Plan doc, unified diff, test run log, tool calls, provenance chain |
+| S3 | **Gate Cockpit** | The 5 gates as objects; queue of items awaiting each gate | **P0** | Gate objects; items-awaiting list; approver roster |
+| S4 | **Traceability view** | requirement ↔ spec ↔ code ↔ test ↔ deploy spine for a work-item | **P0** | Trace nodes/edges; per-node evidence; coverage state |
+| S5 | **Audit Ledger** | Immutable who-approved-what, hash-chained | **P0** | Ledger rows (actor · action · object · hash · time) |
+| S6 | **Domain-expert sign-off** | Approve at spec/gate/artifact level (not only eng diff review) | **P0** | Spec/artifact under review; sign-off action; expert notes |
+| S7 | **Second-Brain Intake** | Expert conversation → cited scope / work-items / specs | **P0** | Transcript with highlighted spans; extracted item cards; citations |
+| S8 | **Knowledge Graph** | Browse domain-knowledge nodes agents are grounded on | P1 | Concept nodes, sources, links to specs/items |
+| S9 | **Artifact Review drawer** | Shared inspector: Plan / Diff / Tests / Provenance tabs | **P0** | Whatever artifact is selected, + its audit + trace |
+| S10 | **Global search / command** | Jump to any object by id (REQ-, G-, TH-, hash) | P1 | Ranked objects across all types |
+| S11 | **Workspace / instance switch** | Switch `<Org> Shade` workspace + settings | P1 | Workspace list, members, agent roster, gate config |
+| S12 | **Activity feed** | Chronological cross-object event stream | P1 | Activity items (Huly `activity` overlay) |
+| S13 | **Tracker (PM)** | Issues / cycles / modules | **P2** | Huly tracker + Shade overlay |
+| S14 | **Documents (KB)** | Knowledge base docs | **P2** | Huly documents + Shade overlay |
+| S15 | **Controlled Docs (QMS specs)** | Spec lifecycle Draft→Review→Effective | **P2** | Huly controlled-documents + Shade overlay + gate wiring |
+| S16 | **Test Management** | Test suites / runs | **P2** | Huly test-management + Shade overlay |
+
+**Prototyped this pass (highest-value P0):** S1 (`agent-fleet.html`), S3+S4+S5+S6 combined (`gate-traceability.html`), S7 (`second-brain.html`). S2 and S9 appear as the inspector drawer inside those.
+
+---
+
+## 3 · The 4 differentiating surfaces (prototype-grade detail)
+
+### Surface A — Agent fleet / mission control (S1, S2, S9)
+
+**Goal:** one screen to see everything the fleet is doing and to intervene, review, or approve — artifact-first.
+
+- **Fleet summary strip** (top): stat tiles — *Active threads · Awaiting your review · Blocked · Merged today* — plus a tiny throughput sparkline (threads reaching "Done" over the last N hours). Reserved status colors; tabular numerics.
+- **Board:** columns by **thread state** — Planning · Working · Awaiting review · Blocked · Done. Each column header shows a count; an "Awaiting review" column carries a `--warn` edge because it is the human's queue.
+- **Agent-thread card** (§6.1 of DESIGN.md): identity stripe in agent color, monogram avatar, thread id (mono), work-item + `REQ` link, one-line current activity, **artifact chips** (`Plan`, `Diff +142/−31`, `Tests 18/18`), elapsed time, model/tier tag. A card awaiting a gate shows a gate badge.
+- **Steer actions on a card:** Approve plan · Request changes · Reassign (Prism↔Claude↔Gemini) · Pause · Open thread. Selecting a card opens the **inspector drawer** (S9) with Plan / Diff / Tests / Provenance tabs.
+- **Grouping toggle:** by state (default) · by agent · by work-item / epic · by gate.
+- **Why it differentiates:** it is *fleet* mission-control (many parallel threads across three agent types) with **review built into the card**, not a single-agent chat log. The artifact-first chip row is the wedge.
+
+### Surface B — Gate + traceability cockpit (S3, S4, S5, S6)
+
+**Goal:** make the QMS-gated, fully-traceable delivery loop *operable* — the uncontested white space.
+
+- **Gate ribbon / board:** the 5 gates — **G-DESIGN · G-LOCK · G-PUSH · G-CLIENT · G-MONEY** — as objects, each with state chip, progress ("3 of 4 signed"), and required approvers (including a **domain-expert** slot). Selecting a gate reveals its **queue of items awaiting sign-off**.
+- **Traceability spine (S4):** for a selected work-item, a horizontal **requirement → spec → code → test → deploy** chain of nodes; edges painted with the spectral gradient when the chain is intact, greyed/dashed where a link is stale or missing. Each node expands to its **evidence** (source excerpt, author agent/human, timestamp, content hash). This is the "prove it" view.
+- **Audit ledger (S5):** append-only, hash-chained rows — `timestamp · actor · action · object-id · hash (prev←)`. Filterable by gate, actor, object. Immutable by design (ISO-42001-aligned).
+- **Domain-expert sign-off (S6):** the differentiator vs. senior-eng-only review — an expert approves at the **spec / gate / artifact** level. Action panel: view the spec + its traceability, add expert notes, then **Sign off** (writes actor + hash + time to the ledger) or **Request changes**. Approvals are scoped: an expert can sign G-DESIGN or a spec's correctness without touching code review.
+- **Why it differentiates:** gates-as-objects + full requirement↔deploy traceability + an immutable audit ledger + non-engineer expert sign-off is the combination competitors don't have and regulation (EU AI Act Aug 2026, ISO 42001) is about to demand.
+
+### Surface C — Second-brain intake (S7, S8)
+
+**Goal:** turn expert conversations into cited, grounded, structured work — owning the *upstream* of the flywheel.
+
+- **Three panes:** (1) **conversation transcript** with speaker turns + timestamps and **highlighted spans** where intake extracted something; (2) **extracted items** — cards typed as Requirement / Work-item / Spec / Risk, each with a generated id (mono), a one-line statement, and a **confidence** meter; (3) **provenance** — clicking an item jumps the transcript to and highlights the exact span that produced it, showing speaker + timestamp + source.
+- **Grounding:** each item shows which **domain-knowledge nodes** it drew on / contributes to (chips linking to S8). Accept / edit / reject controls promote an extracted item into the tracker or the spec library — carrying its citation with it.
+- **Provenance trail:** the promoted work-item keeps a permanent **conversation → requirement** link, so the traceability spine (Surface B) can run all the way back to the sentence a domain expert actually said.
+- **Why it differentiates:** competitors start at "here's a ticket." Shade starts at "here's the conversation, and here's the cited line that justifies this requirement" — and that citation survives all the way to deploy.
+
+### Surface D — Backbone screens with Shade overlays (S13–S16) — **P2, do not redesign**
+
+**Goal:** make Huly's tracker / documents / controlled-docs / test-management read as one product with the console, with *minimum* net-new design.
+
+- **The overlay = tokens only:** apply the Shade top context bar, left rail, accent, status/gate chips, and the gate ribbon to Huly's existing screens. Rebrand (`<Org> Shade`), swap the palette to the Shade tokens, and wire the **controlled-documents lifecycle** (Draft → In review → **Effective**) to **G-LOCK** so a spec going Effective is a real gate event that lands in the audit ledger.
+- **Explicitly out of scope this pass:** re-laying-out tracker boards, doc editors, or test grids. Those are Huly's, and they are good enough; our fidelity budget is spent on Surfaces A–C.
+
+---
+
+## 4 · Primary user flows
+
+### Flow 1 — Steer a parallel agent fleet + review an artifact
+
+1. Operator opens **Fleet / Mission Control (S1)**; scans the summary strip — *2 threads awaiting review*.
+2. Filters/groups the board by **Awaiting review**; sees a Claude thread `TH-2043` on `REQ-014` with a `Diff +142/−31` and `Tests 18/18` chip.
+3. Clicks the card → **inspector drawer (S9)** opens on the **Diff** tab; flips to **Tests** (all green) and **Provenance** (chain intact back to `REQ-014`).
+4. Approves the plan / diff → action writes to the **audit ledger (S5)**; thread advances toward its next gate.
+5. A Gemini design thread is stuck in **Blocked** → operator **reassigns** part of the work to Prism to unblock, or opens the thread (S2) to add direction.
+
+```mermaid
+flowchart LR
+    A[Open Fleet S1] --> B{Anything awaiting review?}
+    B -- yes --> C[Group by Awaiting review]
+    C --> D[Select thread card TH-2043]
+    D --> E[Inspector: Plan / Diff / Tests / Provenance]
+    E --> F{Evidence sufficient?}
+    F -- approve --> G[Approve -> writes audit ledger]
+    F -- no --> H[Request changes -> back to agent]
+    B -- blocked exists --> I[Open blocked thread]
+    I --> J[Reassign Prism/Claude/Gemini or steer]
+    G --> K[Thread advances to next gate]
+```
+
+### Flow 2 — Gate approval (G-DESIGN) with the traceability view
+
+1. Operator opens **Gate Cockpit (S3)**; the gate ribbon shows **G-DESIGN** with `◐ Awaiting · 3 of 4 signed`.
+2. Selects **G-DESIGN** → queue of items awaiting design sign-off; picks work-item `WI-88 "Checkout redesign"`.
+3. Opens its **traceability spine (S4)**: `REQ-014 → SPEC-07 → (code pending) → (tests pending) → (deploy pending)`; the requirement→spec edge is intact (spectral), later edges are locked because the gate hasn't passed.
+4. Reviews the **spec artifact** + expands each node's evidence (who authored, when, hash).
+5. Confirms required approvers; the **domain-expert** slot is still open → routes to the expert (Flow 3) or, if the operator *is* the last approver, **signs off**.
+6. Sign-off writes actor + object + content-hash + timestamp to the **audit ledger (S5)**; G-DESIGN flips to `● Passed`; downstream gates (G-LOCK…) unlock; the spectral chain extends.
+
+```mermaid
+flowchart TD
+    A[Gate Cockpit S3] --> B[Select G-DESIGN]
+    B --> C[Queue of items awaiting sign-off]
+    C --> D[Pick WI-88]
+    D --> E[Traceability spine S4]
+    E --> F[Expand node evidence: author, time, hash]
+    F --> G{All required approvers signed?}
+    G -- expert slot open --> H[Route to domain expert - Flow 3]
+    G -- operator is last --> I[Sign off]
+    H --> I
+    I --> J[Append to audit ledger S5 with hash]
+    J --> K[G-DESIGN = Passed -> unlock G-LOCK]
+```
+
+### Flow 3 — Domain-expert sign-off at spec / gate level
+
+1. Domain expert (not an engineer) receives a review request; opens **Domain-expert sign-off (S6)** for `SPEC-07`.
+2. Sees the spec, its **traceability** to `REQ-014`, and the **cited conversation origin** (link into S7) — no code required to judge correctness.
+3. Reads the requirement's provenance; confirms the spec is domain-correct; adds expert notes.
+4. **Signs off** (scoped to spec correctness / G-DESIGN) → recorded in the **audit ledger (S5)** with the expert as actor. Or **Requests changes**, which returns the item to the responsible agent thread (S2) with the notes attached.
+5. The gate's approver roster updates; when the last required approver signs, the gate passes (rejoins Flow 2 step 6).
+
+```mermaid
+flowchart LR
+    A[Review request] --> B[Domain-expert sign-off S6]
+    B --> C[Spec + traceability + cited origin]
+    C --> D{Domain-correct?}
+    D -- yes --> E[Add notes + Sign off scoped]
+    D -- no --> F[Request changes -> agent thread S2]
+    E --> G[Audit ledger records expert + hash]
+    F --> H[Agent revises -> re-review]
+    G --> I[Approver roster updates -> gate may pass]
+```
+
+### Flow 4 — Second-brain intake: conversation → cited scope / work-items
+
+1. A client/prospect call transcript lands in **Second-Brain Intake (S7)** (via Google Drive/Workspace MCP or manual paste).
+2. Intake highlights spans and proposes **extracted items** (Requirement / Work-item / Spec / Risk), each with a confidence meter.
+3. Operator clicks an extracted `REQ-014` → transcript scrolls to and highlights the **exact span** the expert said; provenance shows speaker + timestamp + source.
+4. Operator **accepts / edits / rejects** each item; accepted items promote into the **tracker / spec library**, carrying the citation.
+5. The promoted item now has a permanent **conversation → requirement** link, so Surface B's traceability spine can run from the spoken sentence all the way to deploy.
+
+```mermaid
+flowchart TD
+    A[Transcript ingested - Drive MCP / paste] --> B[Intake extracts + highlights spans]
+    B --> C[Extracted item cards + confidence]
+    C --> D[Operator selects REQ-014]
+    D --> E[Transcript jumps to cited span + speaker/time]
+    E --> F{Accept / edit / reject}
+    F -- accept --> G[Promote to tracker / spec library WITH citation]
+    F -- edit --> G
+    F -- reject --> H[Discard - logged]
+    G --> I[Permanent conversation->requirement link]
+    I --> J[Feeds Surface B traceability to deploy]
+```
+
+### Flow 5 — Spec lifecycle → G-LOCK (backbone overlay in action)
+
+1. In **Controlled Docs (S15, Huly + overlay)** a spec sits in **In review**.
+2. Reviewers (incl. domain expert via S6) approve; the spec is set **Effective**.
+3. Going Effective **fires G-LOCK** — a real gate event written to the audit ledger; the spec version is frozen and its hash recorded.
+4. The traceability spine (S4) marks the `spec` node as locked/fresh; downstream code work may now start against a frozen spec.
+
+```mermaid
+flowchart LR
+    A[Spec In review - S15 overlay] --> B[Reviewers + expert approve]
+    B --> C[Set Effective]
+    C --> D[Fires G-LOCK gate event]
+    D --> E[Ledger records version + hash - immutable]
+    E --> F[Trace node 'spec' = locked/fresh]
+    F --> G[Code work unlocked against frozen spec]
+```
+
+---
+
+## 5 · Navigation model
+
+- **Left rail** — *Console* group (Fleet · Gates · Second Brain · Activity) over the hairline; *Backbone* group (Tracker · Documents · Specs/QMS · Tests) under it. Collapsible to icons.
+- **Top context bar** — `<Org> Shade` workspace switcher · breadcrumb · **gate ribbon** (5 dots, global gate state, always visible) · global search (`⌘K`, jump by object id) · actor/agent menu.
+- **Inspector drawer** — right, opens on any object selection; the single home of artifact-first review across screens.
+- **Cross-links are the point:** a thread card → its work-item → its traceability spine → each node's evidence → the gate it's blocked on → the ledger row that will record the approval → back to the conversation span that started it. Every arrow in the flywheel is a clickable link in the UI.
+
+---
+
+## 6 · What we deliberately did NOT design
+
+- Tracker boards, doc editor, test grids — **Huly's**, kept as-is under the overlay.
+- A bespoke terminal/browser-embedded console — **roadmap**, not v1 (interim cockpit is Claude CLI + MCP in Zed).
+- Prism's single-chat-over-fleet conversational surface — flagged **OQ-3** for G-DESIGN; board-first for v1.
+- Billing/invoice screens for G-MONEY beyond the gate object itself — deferred to the Xero/Mercury MCP integration pass.

--- a/docs/hh-shade/CONTEXT.md
+++ b/docs/hh-shade/CONTEXT.md
@@ -1,0 +1,37 @@
+# HH Shade — Instance Context
+
+Instance-specific memory for **HH Shade**, the **Hardscape House** deployment of **4C Shade**. For the product itself, see [`../4c-shade/`](../4c-shade/).
+
+---
+
+## What HH Shade is
+
+- **The alpha deployment of 4C Shade** — the flagship reference instance that proves the platform.
+- **Owner/operator:** the **Hardscape House** joint venture (FutureBuild + Dibbits). License path is an open item (via FutureBuild's perpetual license vs its own from 4C Digital — see `../4c-shade/LICENSING-AND-ENTITY.md`).
+- **Current repo state:** an upstream Huly platform fork (EPL-2.0), being repurposed into the Shade backbone. Fork-source archival to an `upstream-mirror` branch is planned but **not yet done**.
+
+## What it delivers
+
+HH Shade is the command center for building **HardscapeOS** — a greenfield ERP for hardscape/landscape supply, first client **Dibbits Landscape Supply** (Trenton + Kingston, Ontario).
+
+## Sibling repositories (the code being delivered)
+
+- **`dibbits`** — React partner portal + project manual + Phase-1 planning/spec library. Railway auto-deploys `master` → `dibbits.gablelbm.com`.
+- **`hardscapeos_dibbits`** — the greenfield HardscapeOS ERP (Go modular monolith backend + Lit frontend). CI + staging deploy to a DigitalOcean droplet (`dibbits-staging.gablelbm.com`).
+- *(historical)* **`dibbits_workspace`** — the git+Obsidian "ShadeOS" command-center being **harvested-then-archived**; its machinery (crew ops, gates, second-brain) productizes into 4C Shade.
+
+## Migration posture
+
+- **Interim:** work continues on the current setup (Obsidian + lean-terminal + self-hosted Plane at `pm.futurebuild.ai`) until HH Shade is ready.
+- **Cutover:** a single clean migration of the live Dibbits build onto HH Shade (no throwaway interim). Open item: define "ready" as **backbone-ready** (sooner) vs **full-console-ready** (later).
+- The existing Plane tracker (`DIB` project: 142 issues / 26 cycles / 12 modules) and the `dibbits_workspace` second-brain are the migration source material.
+
+## v1 scope for this instance
+
+Shade backbone (PM/KB + controlled-doc QMS specs + gates-as-objects, multi-workspace) + MCP integration + a lean Claude-CLI/Zed cockpit + the second-brain intake engine → then the Dibbits migration. **Prism** (the native OSS coordinator) starts light: scheduled routines + doc-upkeep. Custom console + local self-hosted inference are roadmap, not v1.
+
+## Key facts
+
+- **Currency/locale:** CAD, HST 13%, Ontario Construction Act / Bill 60 compliance.
+- **Design system (ERP):** "Hardscape Dark" (Stone Amber `#E8A74E`, Deep Earth `#0C0D12`).
+- **Money/quantity conventions:** integer cents in app code, `DECIMAL(19,4)` in DB; every quantity paired with a UOM.

--- a/prototypes/agent-fleet.html
+++ b/prototypes/agent-fleet.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Fleet · Mission Control — 4C Shade</title>
+<style>
+:root{
+  --bg:#0A0D13;--surface-1:#0F131B;--surface-2:#151A24;--surface-3:#1C2230;--surface-4:#232B3B;
+  --border:#242C3A;--border-2:#313B4D;--overlay:rgba(5,7,11,.62);
+  --ink-1:#EAEEF6;--ink-2:#AEB8CC;--ink-3:#727E93;--ink-4:#4B5567;
+  --accent:#37CFBD;--accent-hover:#4ADED0;--accent-press:#28B4A3;--accent-fg:#04120F;
+  --accent-weak:rgba(55,207,189,.14);--accent-line:rgba(55,207,189,.38);
+  --spectral:linear-gradient(90deg,#8B7CF0 0%,#4EC5E0 52%,#37CFBD 100%);
+  --prism:#8B7CF0;--prism-weak:rgba(139,124,240,.16);
+  --claude:#E0785B;--claude-weak:rgba(224,120,91,.16);
+  --gemini:#5B9DF9;--gemini-weak:rgba(91,157,249,.16);
+  --human:#AEB8CC;--human-weak:rgba(174,184,204,.12);
+  --ok:#46C98A;--ok-weak:rgba(70,201,138,.14);
+  --warn:#E7B54B;--warn-weak:rgba(231,181,75,.14);
+  --risk:#E8894A;--risk-weak:rgba(232,137,74,.14);
+  --crit:#E86A6A;--crit-weak:rgba(232,106,106,.14);
+  --info:#5B9DF9;--info-weak:rgba(91,157,249,.14);
+  --r-1:6px;--r-2:10px;--r-3:14px;--r-pill:999px;
+  --shadow-1:0 1px 2px rgba(0,0,0,.4);--shadow-2:0 8px 28px -10px rgba(0,0,0,.62);--shadow-pop:0 16px 48px -14px rgba(0,0,0,.72);
+  --font-sans:ui-sans-serif,system-ui,-apple-system,"Segoe UI Variable Display","Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+  --font-mono:ui-monospace,"SF Mono","JetBrains Mono","Cascadia Code","Roboto Mono",Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;height:100%}
+body{background:var(--bg);color:var(--ink-1);font-family:var(--font-sans);font-size:13.5px;line-height:20px;-webkit-font-smoothing:antialiased}
+.mono{font-family:var(--font-mono);font-variant-numeric:tabular-nums}
+.label{font-size:11px;font-weight:600;letter-spacing:.07em;text-transform:uppercase;color:var(--ink-3)}
+button{font-family:inherit;cursor:pointer}
+:focus-visible{outline:none;box-shadow:0 0 0 2px var(--bg),0 0 0 4px var(--accent);border-radius:var(--r-1)}
+::-webkit-scrollbar{width:10px;height:10px}::-webkit-scrollbar-thumb{background:var(--surface-4);border-radius:99px;border:2px solid transparent;background-clip:padding-box}
+
+/* shell */
+.app{height:100vh;display:flex;flex-direction:column;overflow:hidden}
+.topbar{height:48px;flex:0 0 auto;display:flex;align-items:center;gap:14px;padding:0 14px;background:var(--surface-1);border-bottom:1px solid var(--border)}
+.brand{display:flex;align-items:center;gap:9px;font-weight:600}
+.brand .mark{width:20px;height:20px;border-radius:5px;background:var(--spectral);box-shadow:0 0 0 1px rgba(255,255,255,.08) inset}
+.ws{display:flex;align-items:center;gap:7px;padding:5px 9px;background:var(--surface-3);border:1px solid var(--border);border-radius:var(--r-1);font-size:12.5px;color:var(--ink-2)}
+.ws b{color:var(--ink-1);font-weight:600}
+.crumb{color:var(--ink-3);font-size:12.5px}.crumb b{color:var(--ink-2);font-weight:500}
+.spacer{flex:1}
+.ribbon{display:flex;align-items:center;gap:5px}
+.gdot{display:flex;align-items:center;gap:5px;padding:3px 8px;border-radius:var(--r-pill);font-size:10.5px;font-weight:600;letter-spacing:.04em;font-family:var(--font-mono);border:1px solid var(--border)}
+.gdot i{width:7px;height:7px;border-radius:50%;display:inline-block}
+.search{display:flex;align-items:center;gap:7px;padding:5px 10px;background:var(--surface-3);border:1px solid var(--border);border-radius:var(--r-1);color:var(--ink-3);font-size:12.5px;width:200px}
+.search kbd{margin-left:auto;font-family:var(--font-mono);font-size:10px;background:var(--surface-1);border:1px solid var(--border);border-radius:4px;padding:1px 5px;color:var(--ink-3)}
+.avatar{width:26px;height:26px;border-radius:50%;display:grid;place-items:center;font-size:11px;font-weight:700;border:1px solid var(--border-2)}
+
+.body{flex:1;display:flex;min-height:0}
+.rail{width:216px;flex:0 0 auto;background:var(--surface-1);border-right:1px solid var(--border);padding:12px 10px;overflow:auto;display:flex;flex-direction:column;gap:3px}
+.rail .grp{margin:10px 8px 4px}
+.nav{display:flex;align-items:center;gap:10px;padding:7px 10px;border-radius:var(--r-1);color:var(--ink-2);font-size:13px;font-weight:500;text-decoration:none;cursor:pointer}
+.nav:hover{background:var(--surface-3);color:var(--ink-1)}
+.nav.on{background:var(--accent-weak);color:var(--ink-1);box-shadow:inset 0 0 0 1px var(--accent-line)}
+.nav .ic{width:16px;text-align:center;color:var(--ink-3)}
+.nav.on .ic{color:var(--accent)}
+.nav .ct{margin-left:auto;font-size:11px;color:var(--ink-3);font-family:var(--font-mono)}
+.rail hr{border:none;border-top:1px solid var(--border);margin:10px 4px}
+
+.main{flex:1;min-width:0;overflow:auto;display:flex;flex-direction:column}
+.inspector{width:396px;flex:0 0 auto;background:var(--surface-1);border-left:1px solid var(--border);overflow:auto;display:none}
+.inspector.open{display:block}
+
+/* summary strip */
+.strip{display:flex;gap:12px;padding:16px 18px 4px;flex-wrap:wrap}
+.tile{background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-2);padding:12px 14px;min-width:150px;flex:1}
+.tile .k{font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-3)}
+.tile .v{font-size:26px;font-weight:600;font-family:var(--font-mono);font-variant-numeric:tabular-nums;margin-top:4px;letter-spacing:-.01em}
+.tile .sub{font-size:11.5px;color:var(--ink-3);margin-top:2px}
+.tile.spark{min-width:210px;display:flex;flex-direction:column}
+.tile.attn{box-shadow:inset 0 0 0 1px var(--warn-weak)}
+.tile.attn .v{color:var(--warn)}
+
+/* toolbar */
+.toolbar{display:flex;align-items:center;gap:10px;padding:12px 18px;flex-wrap:wrap}
+.seg{display:inline-flex;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-1);padding:2px}
+.seg button{border:none;background:transparent;color:var(--ink-3);font-size:12px;font-weight:600;padding:5px 11px;border-radius:5px}
+.seg button.on{background:var(--surface-4);color:var(--ink-1)}
+.chipf{display:inline-flex;align-items:center;gap:6px;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-pill);padding:5px 11px;font-size:12px;color:var(--ink-2)}
+.chipf .x{color:var(--ink-4)}
+
+/* board */
+.board{display:flex;gap:14px;padding:6px 18px 20px;align-items:flex-start;overflow-x:auto;flex:1}
+.col{flex:0 0 288px;display:flex;flex-direction:column;gap:10px}
+.colhead{display:flex;align-items:center;gap:8px;padding:6px 4px}
+.colhead .ct{font-family:var(--font-mono);font-size:11px;color:var(--ink-3);background:var(--surface-3);border-radius:var(--r-pill);padding:1px 8px}
+.colhead.queue{border-left:2px solid var(--warn);padding-left:8px;border-radius:2px}
+
+.card{background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-2);padding:12px 13px 11px 15px;position:relative;cursor:pointer;transition:transform .06s ease,background .1s ease,box-shadow .1s ease}
+.card::before{content:"";position:absolute;left:0;top:10px;bottom:10px;width:2px;border-radius:2px;background:var(--stripe,var(--ink-3))}
+.card:hover{background:var(--surface-3);box-shadow:var(--shadow-1);transform:translateY(-1px)}
+.card.sel{box-shadow:0 0 0 1px var(--accent-line),var(--shadow-1);background:var(--surface-3)}
+.card .top{display:flex;align-items:center;gap:8px;margin-bottom:7px}
+.mono-av{width:22px;height:22px;border-radius:6px;display:grid;place-items:center;font-size:10px;font-weight:700;font-family:var(--font-mono)}
+.card .who{font-size:12.5px;font-weight:600}
+.card .tid{margin-left:auto;font-family:var(--font-mono);font-size:11px;color:var(--ink-3)}
+.card .title{font-size:13px;font-weight:600;line-height:18px;margin:0 0 3px}
+.card .req{font-family:var(--font-mono);font-size:11px;color:var(--ink-3)}
+.card .doing{font-size:12px;color:var(--ink-2);margin-top:6px;display:flex;gap:6px;align-items:baseline}
+.card .arts{display:flex;gap:6px;flex-wrap:wrap;margin-top:9px}
+.card .foot{display:flex;align-items:center;gap:8px;margin-top:9px;font-size:11px;color:var(--ink-3)}
+
+.chip{display:inline-flex;align-items:center;gap:5px;border-radius:var(--r-pill);padding:2px 8px;font-size:11px;font-weight:600;line-height:16px;white-space:nowrap}
+.chip .g{width:6px;height:6px;border-radius:50%}
+.art{display:inline-flex;align-items:center;gap:5px;border-radius:var(--r-1);padding:2px 7px;font-size:11px;font-weight:600;background:var(--surface-3);border:1px solid var(--border);color:var(--ink-2);font-family:var(--font-mono)}
+.art:hover{border-color:var(--border-2);color:var(--ink-1)}
+.st-ok{background:var(--ok-weak);color:var(--ok)}.st-warn{background:var(--warn-weak);color:var(--warn)}
+.st-crit{background:var(--crit-weak);color:var(--crit)}.st-info{background:var(--info-weak);color:var(--info)}
+.st-run{background:var(--accent-weak);color:var(--accent)}.st-risk{background:var(--risk-weak);color:var(--risk)}
+.tag{font-size:10.5px;color:var(--ink-3);font-family:var(--font-mono);border:1px solid var(--border);border-radius:4px;padding:0 5px}
+
+/* inspector */
+.insp-head{padding:14px 16px;border-bottom:1px solid var(--border)}
+.insp-head .row1{display:flex;align-items:center;gap:9px}
+.insp-head .close{margin-left:auto;background:var(--surface-3);border:1px solid var(--border);color:var(--ink-2);border-radius:var(--r-1);width:26px;height:26px;font-size:15px;line-height:1}
+.insp-title{font-size:15px;font-weight:600;margin:11px 0 3px;line-height:20px}
+.insp-sub{font-size:12px;color:var(--ink-3)}
+.tabs{display:flex;gap:2px;padding:0 12px;border-bottom:1px solid var(--border);background:var(--surface-1);position:sticky;top:0}
+.tabs button{border:none;background:transparent;color:var(--ink-3);font-size:12.5px;font-weight:600;padding:11px 12px;border-bottom:2px solid transparent}
+.tabs button.on{color:var(--ink-1);border-bottom-color:var(--accent)}
+.panel{padding:16px;display:none}.panel.on{display:block}
+.md h4{margin:0 0 8px;font-size:13px}.md p{margin:0 0 10px;color:var(--ink-2)}
+.md ol,.md ul{margin:0 0 10px;padding-left:18px;color:var(--ink-2)}.md li{margin:3px 0}
+.md code{font-family:var(--font-mono);font-size:12px;background:var(--surface-3);padding:1px 5px;border-radius:4px;color:var(--ink-1)}
+.diff{font-family:var(--font-mono);font-size:12px;line-height:18px;border:1px solid var(--border);border-radius:var(--r-1);overflow:hidden}
+.diff .fn{background:var(--surface-3);padding:6px 10px;color:var(--ink-2);border-bottom:1px solid var(--border);font-size:11.5px}
+.diff .ln{display:flex;gap:10px;padding:0 10px;white-space:pre}
+.diff .ln .g{width:26px;color:var(--ink-4);text-align:right;user-select:none}
+.diff .add{background:rgba(70,201,138,.10)}.diff .add .t{color:#bfe9d0}
+.diff .del{background:rgba(232,106,106,.10)}.diff .del .t{color:#f0c0c0}
+.testrow{display:flex;align-items:center;gap:10px;padding:8px 10px;border:1px solid var(--border);border-radius:var(--r-1);margin-bottom:7px;font-size:12.5px}
+.testrow .nm{color:var(--ink-2)}.testrow .ms{margin-left:auto;font-family:var(--font-mono);font-size:11px;color:var(--ink-3)}
+.bar{height:6px;border-radius:99px;background:var(--surface-3);overflow:hidden;margin:6px 0 14px}
+.bar i{display:block;height:100%;background:var(--ok)}
+.trace{display:flex;align-items:center;gap:0;overflow-x:auto;padding:6px 0 12px}
+.tnode{flex:0 0 auto;display:flex;flex-direction:column;gap:3px;align-items:flex-start;border:1px solid var(--accent-line);background:var(--surface-2);border-radius:var(--r-1);padding:7px 10px;min-width:96px}
+.tnode.pending{border-style:dashed;border-color:var(--border-2);opacity:.7}
+.tnode .s{font-size:9.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-3);font-weight:700}
+.tnode .id{font-family:var(--font-mono);font-size:11.5px;color:var(--ink-1)}
+.tedge{flex:0 0 22px;height:2px;background:var(--spectral)}
+.tedge.off{background:var(--border-2)}
+.actionbar{display:flex;gap:8px;padding:14px 16px;border-top:1px solid var(--border);position:sticky;bottom:0;background:var(--surface-1)}
+.btn{border:1px solid var(--border-2);background:var(--surface-3);color:var(--ink-1);font-size:12.5px;font-weight:600;padding:8px 14px;border-radius:var(--r-1)}
+.btn.primary{background:var(--accent);color:var(--accent-fg);border-color:transparent}
+.btn.primary:hover{background:var(--accent-hover)}
+.btn.danger{color:var(--crit);border-color:var(--border)}
+.ledger-mini{border:1px solid var(--border);border-radius:var(--r-1);overflow:hidden;margin-top:4px}
+.ledger-mini .lr{display:flex;gap:9px;padding:7px 10px;font-family:var(--font-mono);font-size:11px;color:var(--ink-3);border-bottom:1px solid var(--border)}
+.ledger-mini .lr:last-child{border-bottom:none}
+.ledger-mini .lr b{color:var(--ink-1);font-weight:600}
+.hint{color:var(--ink-4);font-size:11px;padding:6px 4px;text-align:center}
+</style>
+</head>
+<body>
+<div class="app">
+  <!-- top context bar -->
+  <div class="topbar">
+    <div class="brand"><span class="mark"></span> Shade</div>
+    <div class="ws"><b>Acme</b> Shade ▾</div>
+    <div class="crumb"><b>Console</b> / Fleet · Mission Control</div>
+    <div class="spacer"></div>
+    <div class="ribbon" title="Global gate state">
+      <span class="gdot" style="border-color:var(--accent-line)"><i style="background:var(--accent)"></i>G-DESIGN</span>
+      <span class="gdot"><i style="background:var(--warn)"></i>G-LOCK</span>
+      <span class="gdot"><i style="background:var(--ink-4)"></i>G-PUSH</span>
+      <span class="gdot"><i style="background:var(--ink-4)"></i>G-CLIENT</span>
+      <span class="gdot"><i style="background:var(--ink-4)"></i>G-MONEY</span>
+    </div>
+    <div class="search">⌕ Search objects… <kbd>⌘K</kbd></div>
+    <div class="avatar" style="background:var(--human-weak);color:var(--ink-1)">CT</div>
+  </div>
+
+  <div class="body">
+    <!-- left rail -->
+    <nav class="rail">
+      <div class="grp label">Console</div>
+      <a class="nav on"><span class="ic">◈</span> Fleet <span class="ct">14</span></a>
+      <a class="nav" href="gate-traceability.html"><span class="ic">⛨</span> Gates <span class="ct">3</span></a>
+      <a class="nav" href="second-brain.html"><span class="ic">◍</span> Second Brain</a>
+      <a class="nav"><span class="ic">≋</span> Activity</a>
+      <hr/>
+      <div class="grp label">Backbone <span style="color:var(--ink-4);font-weight:500;text-transform:none;letter-spacing:0">· Huly + overlay</span></div>
+      <a class="nav"><span class="ic">◧</span> Tracker</a>
+      <a class="nav"><span class="ic">▤</span> Documents</a>
+      <a class="nav"><span class="ic">▦</span> Specs · QMS</a>
+      <a class="nav"><span class="ic">◫</span> Test Mgmt</a>
+      <div style="flex:1"></div>
+      <div class="hint">Prism coordinator · online</div>
+    </nav>
+
+    <!-- main -->
+    <main class="main">
+      <div class="strip">
+        <div class="tile"><div class="k">Active threads</div><div class="v">14</div><div class="sub">3 Prism · 8 Claude · 3 Gemini</div></div>
+        <div class="tile attn"><div class="k">Awaiting your review</div><div class="v">2</div><div class="sub">gate sign-off queue</div></div>
+        <div class="tile"><div class="k">Blocked</div><div class="v" style="color:var(--crit)">1</div><div class="sub">CI failure · TH-2051</div></div>
+        <div class="tile"><div class="k">Merged today</div><div class="v" style="color:var(--ok)">9</div><div class="sub">+3 vs. yesterday</div></div>
+        <div class="tile spark">
+          <div class="k">Throughput · 12h</div>
+          <svg width="100%" height="46" viewBox="0 0 200 46" preserveAspectRatio="none" style="margin-top:6px">
+            <defs><linearGradient id="sg" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="rgba(55,207,189,.28)"/><stop offset="1" stop-color="rgba(55,207,189,0)"/></linearGradient></defs>
+            <path d="M0,38 L18,34 L36,36 L54,28 L72,30 L90,22 L108,24 L126,16 L144,18 L162,12 L180,14 L200,8 L200,46 L0,46 Z" fill="url(#sg)"/>
+            <path d="M0,38 L18,34 L36,36 L54,28 L72,30 L90,22 L108,24 L126,16 L144,18 L162,12 L180,14 L200,8" fill="none" stroke="var(--accent)" stroke-width="1.6"/>
+            <circle cx="200" cy="8" r="2.8" fill="var(--accent)"/>
+          </svg>
+          <div class="sub">threads reaching Done / hour</div>
+        </div>
+      </div>
+
+      <div class="toolbar">
+        <span class="label" style="margin-right:2px">Group by</span>
+        <div class="seg">
+          <button class="on">State</button><button>Agent</button><button>Work-item</button><button>Gate</button>
+        </div>
+        <span class="chipf">All agents <span class="x">▾</span></span>
+        <span class="chipf">Workspace: Acme <span class="x">▾</span></span>
+        <div style="flex:1"></div>
+        <span class="chipf" style="color:var(--ink-3)">Live · updated 4s ago</span>
+      </div>
+
+      <div class="board" id="board">
+        <!-- columns populated by JS -->
+      </div>
+    </main>
+
+    <!-- inspector drawer -->
+    <aside class="inspector" id="insp">
+      <div class="insp-head">
+        <div class="row1">
+          <span class="mono-av" id="iav">CL</span>
+          <span class="who" id="iwho">Claude</span>
+          <span class="chip" id="istate">◆ Awaiting review</span>
+          <button class="close" onclick="closeInsp()">✕</button>
+        </div>
+        <div class="insp-title" id="ititle">—</div>
+        <div class="insp-sub"><span class="mono" id="itid">TH-0000</span> · <span class="mono" id="ireq">REQ-000</span> · <span id="imodel">—</span></div>
+      </div>
+      <div class="tabs">
+        <button class="on" data-t="plan" onclick="tab(this)">Plan</button>
+        <button data-t="diff" onclick="tab(this)">Diff</button>
+        <button data-t="tests" onclick="tab(this)">Tests</button>
+        <button data-t="prov" onclick="tab(this)">Provenance</button>
+      </div>
+      <div class="panel on" id="p-plan"></div>
+      <div class="panel" id="p-diff"></div>
+      <div class="panel" id="p-tests"></div>
+      <div class="panel" id="p-prov"></div>
+      <div class="actionbar">
+        <button class="btn primary">Approve</button>
+        <button class="btn danger">Request changes</button>
+        <button class="btn">Reassign ▾</button>
+      </div>
+    </aside>
+  </div>
+</div>
+
+<script>
+const AG = {
+  prism:{av:'PR',name:'Prism',cls:'--prism',bg:'var(--prism-weak)',fg:'var(--prism)'},
+  claude:{av:'CL',name:'Claude',cls:'--claude',bg:'var(--claude-weak)',fg:'var(--claude)'},
+  gemini:{av:'GM',name:'Gemini',cls:'--gemini',bg:'var(--gemini-weak)',fg:'var(--gemini)'}
+};
+// generic software-delivery placeholder data (no client specifics)
+const THREADS = [
+  {id:'TH-2043',ag:'claude',col:'review',title:'Rework checkout total to integer cents',req:'REQ-014',doing:'Diff ready · awaiting G-DESIGN sign-off',state:['◆ Awaiting review','st-warn'],model:'claude · sonnet · subs',
+    arts:[['⌥ Diff +142/−31','diff'],['✓ Tests 18/18','tests'],['◫ Plan','plan']],
+    plan:`<div class="md"><h4>Plan · REQ-014 checkout totals</h4><p>Move all money math to integer cents; render with a single <code>formatMoney()</code>. Remove float accumulation in <code>CartTotals</code>.</p><ol><li>Introduce <code>Money</code> value type (cents + currency).</li><li>Refactor <code>CartTotals.subtotal/tax/total</code>.</li><li>Add property tests for rounding.</li><li>Backfill snapshot fixtures.</li></ol><p>Touches 6 files · est. low risk · no schema change.</p></div>`,
+    diff:`<div class="diff"><div class="fn">src/cart/CartTotals.ts</div>
+<div class="ln del"><span class="g">142</span><span class="t">-  const total = subtotal + subtotal * 0.13</span></div>
+<div class="ln add"><span class="g">142</span><span class="t">+  const total = addCents(subtotal, taxCents(subtotal))</span></div>
+<div class="ln"><span class="g">143</span><span class="t">   return total</span></div>
+<div class="fn" style="margin-top:8px">src/money/Money.ts (new)</div>
+<div class="ln add"><span class="g">1</span><span class="t">+export const addCents = (a:number,b:number)=> a + b</span></div>
+<div class="ln add"><span class="g">2</span><span class="t">+export const taxCents = (c:number)=> Math.round(c * 0.13)</span></div></div>`,
+    tests:`<div style="font-size:12.5px;color:var(--ink-2);margin-bottom:8px">18 passed · 0 failed · 1.9s</div><div class="bar"><i style="width:100%"></i></div>
+<div class="testrow"><span class="chip st-ok"><span class="g" style="background:var(--ok)"></span>pass</span><span class="nm">rounds tax half-up at boundary</span><span class="ms">4ms</span></div>
+<div class="testrow"><span class="chip st-ok"><span class="g" style="background:var(--ok)"></span>pass</span><span class="nm">no float drift over 10k line items</span><span class="ms">61ms</span></div>
+<div class="testrow"><span class="chip st-ok"><span class="g" style="background:var(--ok)"></span>pass</span><span class="nm">total = subtotal + tax (property)</span><span class="ms">120ms</span></div>`,
+    prov:`<div class="label" style="margin-bottom:8px">Traceability</div><div class="trace">
+<div class="tnode"><span class="s">Requirement</span><span class="id">REQ-014</span></div><span class="tedge"></span>
+<div class="tnode"><span class="s">Spec</span><span class="id">SPEC-07</span></div><span class="tedge"></span>
+<div class="tnode"><span class="s">Code</span><span class="id">TH-2043</span></div><span class="tedge off"></span>
+<div class="tnode pending"><span class="s">Test</span><span class="id">pending</span></div><span class="tedge off"></span>
+<div class="tnode pending"><span class="s">Deploy</span><span class="id">—</span></div></div>
+<div class="label" style="margin:12px 0 6px">Audit trail</div><div class="ledger-mini">
+<div class="lr">14:02:11 · <b>Claude</b> · opened thread · <b>TH-2043</b> · a1b9f3c</div>
+<div class="lr">14:19:40 · <b>Claude</b> · plan submitted · <b>REQ-014</b> · 7c2e0b1</div>
+<div class="lr">14:41:02 · <b>you</b> · reviewing… · <b>TH-2043</b> · —</div></div>` },
+  {id:'TH-2048',ag:'gemini',col:'review',title:'Checkout redesign — high-fidelity spec',req:'REQ-014',doing:'Design spec ready for G-DESIGN',state:['◆ Awaiting review','st-warn'],model:'gemini · 2.x · MCP',
+    arts:[['◫ Spec','plan'],['⬒ 6 screens','plan']],
+    plan:`<div class="md"><h4>Design spec · Checkout redesign</h4><p>3-step checkout collapsed to a single reviewable page; totals block pinned. 6 screens delivered as Stitch export + tokens.</p><ul><li>Single-page layout · sticky order summary</li><li>Inline validation on address fields</li><li>Total block wired to <code>REQ-014</code> cents math</li></ul><p>Ready for domain-expert + design sign-off (G-DESIGN).</p></div>`,
+    diff:`<div class="hint">No code diff — design artifact. See Plan tab.</div>`,
+    tests:`<div class="hint">No automated tests on a design spec — reviewed at G-DESIGN.</div>`,
+    prov:`<div class="label" style="margin-bottom:8px">Traceability</div><div class="trace">
+<div class="tnode"><span class="s">Requirement</span><span class="id">REQ-014</span></div><span class="tedge"></span>
+<div class="tnode"><span class="s">Spec</span><span class="id">SPEC-07</span></div><span class="tedge off"></span>
+<div class="tnode pending"><span class="s">Code</span><span class="id">pending</span></div></div>
+<div class="label" style="margin:12px 0 6px">Audit trail</div><div class="ledger-mini">
+<div class="lr">13:20:00 · <b>Gemini</b> · spec drafted · <b>SPEC-07</b> · 55aa10f</div>
+<div class="lr">13:58:22 · <b>Gemini</b> · submitted to G-DESIGN · <b>SPEC-07</b> · 9f0c4d2</div></div>` },
+  {id:'TH-2051',ag:'claude',col:'blocked',title:'Migrate orders table to DECIMAL(19,4)',req:'REQ-021',doing:'CI failed — migration lock timeout',state:['✕ Blocked','st-crit'],model:'claude · sonnet · subs',
+    arts:[['⌥ Diff +88/−12','diff'],['✕ Tests 14/16','tests']],
+    plan:`<div class="md"><h4>Plan · REQ-021 money column precision</h4><p>Alter <code>orders.total</code> to <code>DECIMAL(19,4)</code> with a backfill migration.</p><ol><li>Add column, backfill from cents.</li><li>Dual-write window.</li><li>Cut over reads, drop old.</li></ol></div>`,
+    diff:`<div class="diff"><div class="fn">migrations/0042_orders_decimal.sql</div>
+<div class="ln add"><span class="g">1</span><span class="t">+ALTER TABLE orders ADD COLUMN total_d DECIMAL(19,4);</span></div>
+<div class="ln add"><span class="g">2</span><span class="t">+UPDATE orders SET total_d = total_cents / 100.0;</span></div></div>`,
+    tests:`<div style="font-size:12.5px;color:var(--crit);margin-bottom:8px">14 passed · 2 failed · lock timeout</div><div class="bar"><i style="width:87%;background:var(--crit)"></i></div>
+<div class="testrow"><span class="chip st-crit"><span class="g" style="background:var(--crit)"></span>fail</span><span class="nm">migration acquires lock &lt; 5s</span><span class="ms">5001ms</span></div>
+<div class="testrow"><span class="chip st-crit"><span class="g" style="background:var(--crit)"></span>fail</span><span class="nm">dual-write keeps parity</span><span class="ms">—</span></div>
+<div class="testrow"><span class="chip st-ok"><span class="g" style="background:var(--ok)"></span>pass</span><span class="nm">backfill math exact</span><span class="ms">33ms</span></div>`,
+    prov:`<div class="hint">Blocked — resolve CI before traceability advances.</div>` },
+  {id:'TH-2039',ag:'prism',col:'working',title:'Schedule weekly QMS doc-upkeep sweep',req:'REQ-009',doing:'Reconciling stale spec links (3 of 11)',state:['● Running','st-run'],model:'prism · local OSS',
+    arts:[['◫ Plan','plan'],['≋ Log','plan']],
+    plan:`<div class="md"><h4>Routine · doc-upkeep</h4><p>Weekly sweep: find controlled docs whose linked requirements changed since last Effective; flag for re-review.</p><ul><li>11 specs scanned · 3 drifted</li><li>Opens tracker issues, tags owners</li></ul></div>`,
+    diff:`<div class="hint">Coordinator routine — no code diff.</div>`,
+    tests:`<div class="hint">N/A — housekeeping routine.</div>`,
+    prov:`<div class="hint">Feeds G-LOCK freshness checks.</div>` },
+  {id:'TH-2055',ag:'claude',col:'working',title:'Add idempotency keys to payments API',req:'REQ-030',doing:'Writing handler + retry tests',state:['● Running','st-run'],model:'claude · sonnet · subs',
+    arts:[['⌥ Diff +64/−4','diff'],['◫ Plan','plan']],
+    plan:`<div class="md"><h4>Plan · REQ-030 idempotency</h4><p>Add <code>Idempotency-Key</code> support to POST /payments; store key→result for 24h.</p></div>`,
+    diff:`<div class="diff"><div class="fn">src/api/payments.ts</div>
+<div class="ln add"><span class="g">51</span><span class="t">+  const key = req.header('Idempotency-Key')</span></div>
+<div class="ln add"><span class="g">52</span><span class="t">+  const prior = await idem.get(key); if (prior) return prior</span></div></div>`,
+    tests:`<div class="hint">In progress — tests being written.</div>`,
+    prov:`<div class="hint">Chain forms once tests land.</div>` },
+  {id:'TH-2058',ag:'gemini',col:'working',title:'Empty-state illustrations for tracker',req:'REQ-033',doing:'Generating 4 variants',state:['● Running','st-run'],model:'gemini · 2.x · MCP',
+    arts:[['⬒ 4 variants','plan']],
+    plan:`<div class="md"><h4>Design · empty states</h4><p>4 on-brand empty-state illustrations using Shade tokens for the tracker overlay.</p></div>`,
+    diff:`<div class="hint">Design artifact.</div>`,tests:`<div class="hint">N/A.</div>`,prov:`<div class="hint">—</div>` },
+  {id:'TH-2061',ag:'prism',col:'planning',title:'Break down "invoicing" epic into work-items',req:'REQ-041',doing:'Drafting 8 candidate work-items from spec',state:['◐ Planning','st-info'],model:'prism · local OSS',
+    arts:[['◫ Draft plan','plan']],
+    plan:`<div class="md"><h4>Decomposition · invoicing epic</h4><p>Proposes 8 work-items with acceptance criteria, each cited back to SPEC-12. Awaiting operator confirm before dispatch to Claude/Gemini.</p></div>`,
+    diff:`<div class="hint">—</div>`,tests:`<div class="hint">—</div>`,
+    prov:`<div class="label" style="margin-bottom:8px">Traceability</div><div class="trace"><div class="tnode"><span class="s">Requirement</span><span class="id">REQ-041</span></div><span class="tedge"></span><div class="tnode"><span class="s">Spec</span><span class="id">SPEC-12</span></div></div>` },
+  {id:'TH-2062',ag:'claude',col:'planning',title:'Rate-limit the public search endpoint',req:'REQ-044',doing:'Reading codebase · drafting approach',state:['◐ Planning','st-info'],model:'claude · sonnet · subs',
+    arts:[['◫ Draft plan','plan']],
+    plan:`<div class="md"><h4>Approach · search rate-limit</h4><p>Token-bucket per API key; 429 with Retry-After. Draft plan for review.</p></div>`,
+    diff:`<div class="hint">—</div>`,tests:`<div class="hint">—</div>`,prov:`<div class="hint">—</div>` },
+  {id:'TH-2030',ag:'claude',col:'done',title:'Fix off-by-one in cycle burndown',req:'REQ-002',doing:'Merged · deployed to staging',state:['● Passed','st-ok'],model:'claude · sonnet · subs',
+    arts:[['⌥ Diff +12/−9','diff'],['✓ Tests 22/22','tests'],['⇧ Deploy','prov']],
+    plan:`<div class="md"><h4>Fix · burndown off-by-one</h4><p>Inclusive end-of-day boundary corrected.</p></div>`,
+    diff:`<div class="diff"><div class="fn">src/charts/burndown.ts</div><div class="ln del"><span class="g">30</span><span class="t">-  for (let d=0; d&lt;days; d++)</span></div><div class="ln add"><span class="g">30</span><span class="t">+  for (let d=0; d&lt;=days; d++)</span></div></div>`,
+    tests:`<div style="font-size:12.5px;color:var(--ok);margin-bottom:8px">22 passed · 0 failed</div><div class="bar"><i style="width:100%"></i></div><div class="testrow"><span class="chip st-ok"><span class="g" style="background:var(--ok)"></span>pass</span><span class="nm">last day included in burndown</span><span class="ms">7ms</span></div>`,
+    prov:`<div class="label" style="margin-bottom:8px">Traceability · complete</div><div class="trace">
+<div class="tnode"><span class="s">Requirement</span><span class="id">REQ-002</span></div><span class="tedge"></span>
+<div class="tnode"><span class="s">Spec</span><span class="id">SPEC-01</span></div><span class="tedge"></span>
+<div class="tnode"><span class="s">Code</span><span class="id">a1b9f3c</span></div><span class="tedge"></span>
+<div class="tnode"><span class="s">Test</span><span class="id">run#812</span></div><span class="tedge"></span>
+<div class="tnode"><span class="s">Deploy</span><span class="id">stg-4471</span></div></div>
+<div class="label" style="margin:12px 0 6px">Audit trail</div><div class="ledger-mini">
+<div class="lr">11:02 · <b>Claude</b> · merged · <b>a1b9f3c</b> · 3d1f9aa</div>
+<div class="lr">11:05 · <b>you</b> · G-PUSH signed · <b>REQ-002</b> · e77b210</div>
+<div class="lr">11:07 · <b>Prism</b> · deployed staging · <b>stg-4471</b> · c0aa993</div></div>` }
+];
+const COLS=[
+  {k:'planning',t:'Planning'},{k:'working',t:'Working'},{k:'review',t:'Awaiting review',queue:true},{k:'blocked',t:'Blocked'},{k:'done',t:'Done'}
+];
+const board=document.getElementById('board');
+COLS.forEach(c=>{
+  const items=THREADS.filter(t=>t.col===c.k);
+  const col=document.createElement('div');col.className='col';
+  col.innerHTML=`<div class="colhead ${c.queue?'queue':''}"><span class="label" style="color:var(--ink-2)">${c.t}</span><span class="ct">${items.length}</span></div>`;
+  items.forEach(t=>{
+    const a=AG[t.ag];
+    const card=document.createElement('div');card.className='card';card.style.setProperty('--stripe',`var(${a.cls})`);
+    card.innerHTML=`
+      <div class="top">
+        <span class="mono-av" style="background:${a.bg};color:${a.fg}">${a.av}</span>
+        <span class="who">${a.name}</span>
+        <span class="tid">${t.id}</span>
+      </div>
+      <div class="title">${t.title}</div>
+      <div class="req">${t.req}</div>
+      <div class="doing">${t.doing}</div>
+      <div class="arts">${t.arts.map(x=>`<span class="art" data-tab="${x[1]}">${x[0]}</span>`).join('')}</div>
+      <div class="foot"><span class="chip ${t.state[1]}">${t.state[0]}</span><span class="tag">${t.model}</span></div>`;
+    card.addEventListener('click',(e)=>{const wantTab=e.target.closest('.art')?.dataset.tab; openInsp(t.id,wantTab);});
+    col.appendChild(card);
+  });
+  board.appendChild(col);
+});
+
+let selCard=null;
+function openInsp(id,wantTab){
+  const t=THREADS.find(x=>x.id===id);const a=AG[t.ag];
+  document.querySelectorAll('.card').forEach(c=>c.classList.remove('sel'));
+  // mark selected
+  [...document.querySelectorAll('.card')].forEach(c=>{ if(c.querySelector('.tid')?.textContent===id) c.classList.add('sel'); });
+  document.getElementById('iav').textContent=a.av;
+  document.getElementById('iav').style.background=a.bg;document.getElementById('iav').style.color=a.fg;
+  document.getElementById('iwho').textContent=a.name;
+  const st=document.getElementById('istate');st.textContent=t.state[0];st.className='chip '+t.state[1];
+  document.getElementById('ititle').textContent=t.title;
+  document.getElementById('itid').textContent=t.id;
+  document.getElementById('ireq').textContent=t.req;
+  document.getElementById('imodel').textContent=t.model;
+  document.getElementById('p-plan').innerHTML=t.plan;
+  document.getElementById('p-diff').innerHTML=t.diff;
+  document.getElementById('p-tests').innerHTML=t.tests;
+  document.getElementById('p-prov').innerHTML=t.prov;
+  document.getElementById('insp').classList.add('open');
+  const tt=wantTab&&['plan','diff','tests','prov'].includes(wantTab)?wantTab:'plan';
+  showTab(tt);
+}
+function closeInsp(){document.getElementById('insp').classList.remove('open');document.querySelectorAll('.card').forEach(c=>c.classList.remove('sel'));}
+function tab(btn){showTab(btn.dataset.t);}
+function showTab(t){
+  document.querySelectorAll('.tabs button').forEach(b=>b.classList.toggle('on',b.dataset.t===t));
+  ['plan','diff','tests','prov'].forEach(x=>document.getElementById('p-'+x).classList.toggle('on',x===t));
+}
+// open the first review item by default so the drawer isn't empty
+openInsp('TH-2043','diff');
+</script>
+</body>
+</html>

--- a/prototypes/gate-traceability.html
+++ b/prototypes/gate-traceability.html
@@ -1,0 +1,445 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Gates · Traceability Cockpit — 4C Shade</title>
+<style>
+:root{
+  --bg:#0A0D13;--surface-1:#0F131B;--surface-2:#151A24;--surface-3:#1C2230;--surface-4:#232B3B;
+  --border:#242C3A;--border-2:#313B4D;--overlay:rgba(5,7,11,.62);
+  --ink-1:#EAEEF6;--ink-2:#AEB8CC;--ink-3:#727E93;--ink-4:#4B5567;
+  --accent:#37CFBD;--accent-hover:#4ADED0;--accent-press:#28B4A3;--accent-fg:#04120F;
+  --accent-weak:rgba(55,207,189,.14);--accent-line:rgba(55,207,189,.38);
+  --spectral:linear-gradient(90deg,#8B7CF0 0%,#4EC5E0 52%,#37CFBD 100%);
+  --prism:#8B7CF0;--prism-weak:rgba(139,124,240,.16);
+  --claude:#E0785B;--claude-weak:rgba(224,120,91,.16);
+  --gemini:#5B9DF9;--gemini-weak:rgba(91,157,249,.16);
+  --human:#AEB8CC;--human-weak:rgba(174,184,204,.12);
+  --ok:#46C98A;--ok-weak:rgba(70,201,138,.14);
+  --warn:#E7B54B;--warn-weak:rgba(231,181,75,.14);
+  --risk:#E8894A;--risk-weak:rgba(232,137,74,.14);
+  --crit:#E86A6A;--crit-weak:rgba(232,106,106,.14);
+  --info:#5B9DF9;--info-weak:rgba(91,157,249,.14);
+  --r-1:6px;--r-2:10px;--r-3:14px;--r-pill:999px;
+  --shadow-1:0 1px 2px rgba(0,0,0,.4);--shadow-2:0 8px 28px -10px rgba(0,0,0,.62);
+  --font-sans:ui-sans-serif,system-ui,-apple-system,"Segoe UI Variable Display","Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+  --font-mono:ui-monospace,"SF Mono","JetBrains Mono","Cascadia Code","Roboto Mono",Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;height:100%}
+body{background:var(--bg);color:var(--ink-1);font-family:var(--font-sans);font-size:13.5px;line-height:20px;-webkit-font-smoothing:antialiased}
+.mono{font-family:var(--font-mono);font-variant-numeric:tabular-nums}
+.label{font-size:11px;font-weight:600;letter-spacing:.07em;text-transform:uppercase;color:var(--ink-3)}
+button{font-family:inherit;cursor:pointer}
+:focus-visible{outline:none;box-shadow:0 0 0 2px var(--bg),0 0 0 4px var(--accent);border-radius:var(--r-1)}
+::-webkit-scrollbar{width:10px;height:10px}::-webkit-scrollbar-thumb{background:var(--surface-4);border-radius:99px;border:2px solid transparent;background-clip:padding-box}
+
+.app{height:100vh;display:flex;flex-direction:column;overflow:hidden}
+.topbar{height:48px;flex:0 0 auto;display:flex;align-items:center;gap:14px;padding:0 14px;background:var(--surface-1);border-bottom:1px solid var(--border)}
+.brand{display:flex;align-items:center;gap:9px;font-weight:600}
+.brand .mark{width:20px;height:20px;border-radius:5px;background:var(--spectral);box-shadow:0 0 0 1px rgba(255,255,255,.08) inset}
+.ws{display:flex;align-items:center;gap:7px;padding:5px 9px;background:var(--surface-3);border:1px solid var(--border);border-radius:var(--r-1);font-size:12.5px;color:var(--ink-2)}
+.ws b{color:var(--ink-1);font-weight:600}
+.crumb{color:var(--ink-3);font-size:12.5px}.crumb b{color:var(--ink-2);font-weight:500}
+.spacer{flex:1}
+.search{display:flex;align-items:center;gap:7px;padding:5px 10px;background:var(--surface-3);border:1px solid var(--border);border-radius:var(--r-1);color:var(--ink-3);font-size:12.5px;width:200px}
+.search kbd{margin-left:auto;font-family:var(--font-mono);font-size:10px;background:var(--surface-1);border:1px solid var(--border);border-radius:4px;padding:1px 5px}
+.avatar{width:26px;height:26px;border-radius:50%;display:grid;place-items:center;font-size:11px;font-weight:700;border:1px solid var(--border-2)}
+
+.body{flex:1;display:flex;min-height:0}
+.rail{width:216px;flex:0 0 auto;background:var(--surface-1);border-right:1px solid var(--border);padding:12px 10px;overflow:auto;display:flex;flex-direction:column;gap:3px}
+.rail .grp{margin:10px 8px 4px}
+.nav{display:flex;align-items:center;gap:10px;padding:7px 10px;border-radius:var(--r-1);color:var(--ink-2);font-size:13px;font-weight:500;text-decoration:none;cursor:pointer}
+.nav:hover{background:var(--surface-3);color:var(--ink-1)}
+.nav.on{background:var(--accent-weak);color:var(--ink-1);box-shadow:inset 0 0 0 1px var(--accent-line)}
+.nav .ic{width:16px;text-align:center;color:var(--ink-3)}.nav.on .ic{color:var(--accent)}
+.nav .ct{margin-left:auto;font-size:11px;color:var(--ink-3);font-family:var(--font-mono)}
+.rail hr{border:none;border-top:1px solid var(--border);margin:10px 4px}
+.hint{color:var(--ink-4);font-size:11px;padding:6px 4px;text-align:center}
+
+.main{flex:1;min-width:0;overflow:auto;display:flex;flex-direction:column;padding:16px 18px}
+.h1{font-size:20px;font-weight:600;letter-spacing:-.005em;margin:0 0 2px}
+.sub{color:var(--ink-3);font-size:12.5px;margin-bottom:14px}
+
+/* gate board */
+.gateboard{display:flex;gap:12px;overflow-x:auto;padding-bottom:6px}
+.gate{flex:0 0 208px;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-2);padding:13px;cursor:pointer;position:relative;transition:background .1s,box-shadow .1s}
+.gate:hover{background:var(--surface-3)}
+.gate.sel{box-shadow:0 0 0 1px var(--accent-line);background:var(--surface-3)}
+.gate .gid{font-family:var(--font-mono);font-size:12px;color:var(--ink-1);font-weight:600}
+.gate .gname{font-size:11.5px;color:var(--ink-3);margin:3px 0 10px;min-height:30px}
+.gate .meter{height:5px;border-radius:99px;background:var(--surface-4);overflow:hidden;margin-bottom:8px}
+.gate .meter i{display:block;height:100%}
+.gate .grow{display:flex;align-items:center;gap:7px}
+.gate .avs{display:flex;margin-left:auto}
+.gate .avs span{width:19px;height:19px;border-radius:50%;display:grid;place-items:center;font-size:9px;font-weight:700;border:1.5px solid var(--surface-2);margin-left:-5px;font-family:var(--font-mono)}
+.chip{display:inline-flex;align-items:center;gap:5px;border-radius:var(--r-pill);padding:2px 9px;font-size:11px;font-weight:600;line-height:16px;white-space:nowrap}
+.st-ok{background:var(--ok-weak);color:var(--ok)}.st-warn{background:var(--warn-weak);color:var(--warn)}
+.st-crit{background:var(--crit-weak);color:var(--crit)}.st-run{background:var(--accent-weak);color:var(--accent)}
+.st-lock{background:var(--surface-4);color:var(--ink-3)}
+
+/* work area split */
+.split{display:grid;grid-template-columns:270px 1fr 320px;gap:14px;margin-top:16px;flex:1;min-height:0}
+.pane{background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-2);overflow:auto}
+.pane .ph{padding:11px 13px;border-bottom:1px solid var(--border);position:sticky;top:0;background:var(--surface-2);display:flex;align-items:center;gap:8px}
+.pane .pb{padding:12px 13px}
+
+/* queue */
+.qitem{border:1px solid var(--border);border-radius:var(--r-1);padding:10px 11px;margin-bottom:9px;cursor:pointer}
+.qitem:hover{background:var(--surface-3)}
+.qitem.sel{box-shadow:inset 0 0 0 1px var(--accent-line);background:var(--surface-3)}
+.qitem .wid{font-family:var(--font-mono);font-size:11px;color:var(--ink-3)}
+.qitem .wt{font-size:13px;font-weight:600;margin:2px 0 6px;line-height:18px}
+.qitem .qm{display:flex;gap:6px;flex-wrap:wrap}
+
+/* traceability spine */
+.spinehead{display:flex;align-items:center;gap:10px;margin-bottom:4px}
+.trace{display:flex;align-items:stretch;overflow-x:auto;padding:14px 2px 8px}
+.tnode{flex:0 0 auto;display:flex;flex-direction:column;gap:4px;align-items:flex-start;border:1px solid var(--accent-line);background:var(--surface-1);border-radius:var(--r-1);padding:9px 12px;min-width:118px;cursor:pointer;transition:box-shadow .1s}
+.tnode:hover{box-shadow:0 0 0 1px var(--accent-line)}
+.tnode.pending{border-style:dashed;border-color:var(--border-2);opacity:.72;cursor:default}
+.tnode.stale{border-style:dashed;border-color:var(--risk)}
+.tnode.sel{box-shadow:0 0 0 1px var(--accent)}
+.tnode .s{font-size:9.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-3);font-weight:700;display:flex;gap:5px;align-items:center}
+.tnode .id{font-family:var(--font-mono);font-size:12px;color:var(--ink-1)}
+.tnode .meta{font-size:10px;color:var(--ink-4)}
+.tedge{flex:0 0 26px;align-self:center;height:2px;background:var(--spectral)}
+.tedge.off{background:var(--border-2)}
+.tedge.stale{background:repeating-linear-gradient(90deg,var(--risk) 0 5px,transparent 5px 9px)}
+
+.evidence{border:1px solid var(--border);border-radius:var(--r-1);padding:12px 13px;margin-top:6px;background:var(--surface-1)}
+.evidence .et{font-size:12.5px;font-weight:600;margin-bottom:6px;display:flex;gap:8px;align-items:center}
+.evidence .ex{font-size:12.5px;color:var(--ink-2);border-left:2px solid var(--accent-line);padding:4px 0 4px 10px;margin:8px 0}
+.kv{display:grid;grid-template-columns:96px 1fr;gap:4px 10px;font-size:12px}
+.kv dt{color:var(--ink-3)}.kv dd{margin:0;color:var(--ink-1);font-family:var(--font-mono);font-size:11.5px}
+.mono-av{width:20px;height:20px;border-radius:5px;display:grid;place-items:center;font-size:9px;font-weight:700;font-family:var(--font-mono)}
+
+/* ledger */
+.ledger{border:1px solid var(--border);border-radius:var(--r-1);overflow:hidden;margin-top:14px}
+.ledger .lh{display:grid;grid-template-columns:120px 90px 1fr 96px;gap:10px;padding:8px 12px;background:var(--surface-3);border-bottom:1px solid var(--border);font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-3);font-weight:700}
+.lr{display:grid;grid-template-columns:120px 90px 1fr 96px;gap:10px;padding:9px 12px;border-bottom:1px solid var(--border);font-family:var(--font-mono);font-size:11px;align-items:center}
+.lr:last-child{border-bottom:none}
+.lr .ts{color:var(--ink-3)}
+.lr .who{color:var(--ink-1);font-weight:600;display:flex;align-items:center;gap:6px}
+.lr .act{color:var(--ink-2)}
+.lr .act .v-ok{color:var(--ok)}.lr .act .v-warn{color:var(--warn)}.lr .act .v-crit{color:var(--crit)}
+.lr .hash{color:var(--ink-4)}
+.lr.new{animation:flash 1.4s ease}
+@keyframes flash{0%{background:var(--accent-weak)}100%{background:transparent}}
+
+/* sign-off inspector */
+.approver{display:flex;align-items:center;gap:9px;padding:9px 0;border-bottom:1px solid var(--border)}
+.approver:last-of-type{border-bottom:none}
+.approver .nm{font-size:12.5px}.approver .rl{font-size:11px;color:var(--ink-3)}
+.approver .st{margin-left:auto;font-size:11px;font-weight:600}
+textarea{width:100%;background:var(--surface-1);border:1px solid var(--border);border-radius:var(--r-1);color:var(--ink-1);font-family:inherit;font-size:12.5px;padding:9px;resize:vertical;min-height:64px;margin:8px 0 12px}
+textarea:focus{outline:none;border-color:var(--accent-line)}
+.btn{border:1px solid var(--border-2);background:var(--surface-3);color:var(--ink-1);font-size:12.5px;font-weight:600;padding:9px 14px;border-radius:var(--r-1);width:100%}
+.btn.primary{background:var(--accent);color:var(--accent-fg);border-color:transparent}
+.btn.primary:hover{background:var(--accent-hover)}
+.btn.primary:disabled{background:var(--surface-4);color:var(--ink-4);cursor:not-allowed}
+.btn.danger{color:var(--crit);border-color:var(--border);margin-top:8px}
+.note{font-size:11px;color:var(--ink-4);margin-top:10px;line-height:16px}
+.callout{display:flex;gap:9px;background:var(--warn-weak);border:1px solid rgba(231,181,75,.28);border-radius:var(--r-1);padding:10px 11px;font-size:12px;color:var(--ink-2);margin-bottom:12px}
+</style>
+</head>
+<body>
+<div class="app">
+  <div class="topbar">
+    <div class="brand"><span class="mark"></span> Shade</div>
+    <div class="ws"><b>Acme</b> Shade ▾</div>
+    <div class="crumb"><b>Console</b> / Gates · Traceability Cockpit</div>
+    <div class="spacer"></div>
+    <div class="search">⌕ Search objects… <kbd>⌘K</kbd></div>
+    <div class="avatar" style="background:var(--human-weak);color:var(--ink-1)">CT</div>
+  </div>
+
+  <div class="body">
+    <nav class="rail">
+      <div class="grp label">Console</div>
+      <a class="nav" href="agent-fleet.html"><span class="ic">◈</span> Fleet <span class="ct">14</span></a>
+      <a class="nav on"><span class="ic">⛨</span> Gates <span class="ct">3</span></a>
+      <a class="nav" href="second-brain.html"><span class="ic">◍</span> Second Brain</a>
+      <a class="nav"><span class="ic">≋</span> Activity</a>
+      <hr/>
+      <div class="grp label">Backbone <span style="color:var(--ink-4);font-weight:500;text-transform:none;letter-spacing:0">· Huly + overlay</span></div>
+      <a class="nav"><span class="ic">◧</span> Tracker</a>
+      <a class="nav"><span class="ic">▤</span> Documents</a>
+      <a class="nav"><span class="ic">▦</span> Specs · QMS</a>
+      <a class="nav"><span class="ic">◫</span> Test Mgmt</a>
+      <div style="flex:1"></div>
+      <div class="hint">Prism coordinator · online</div>
+    </nav>
+
+    <main class="main">
+      <h1 class="h1">Gates &amp; Traceability</h1>
+      <div class="sub">The 5 delivery gates as first-class objects · requirement → spec → code → test → deploy · immutable audit ledger.</div>
+
+      <div class="gateboard" id="gateboard"></div>
+
+      <div class="split">
+        <!-- queue -->
+        <section class="pane">
+          <div class="ph"><span class="label" id="qh">Awaiting G-DESIGN</span><span class="chip st-warn" id="qc" style="margin-left:auto">3 items</span></div>
+          <div class="pb" id="queue"></div>
+        </section>
+
+        <!-- item detail: spine + evidence + ledger -->
+        <section class="pane">
+          <div class="ph">
+            <span class="mono" id="dwid" style="color:var(--ink-3);font-size:11px">WI-88</span>
+            <span id="dwt" style="font-weight:600;font-size:13.5px">—</span>
+            <span class="chip st-run" style="margin-left:auto">◆ In G-DESIGN</span>
+          </div>
+          <div class="pb">
+            <div class="spinehead"><span class="label">Traceability spine</span><span style="font-size:11px;color:var(--ink-3)" id="coverage">coverage 2 / 5</span></div>
+            <div class="trace" id="trace"></div>
+            <div id="evidence"></div>
+
+            <div class="label" style="margin:18px 0 2px">Audit ledger <span style="color:var(--ink-4);font-weight:500;text-transform:none;letter-spacing:0">· append-only, hash-chained</span></div>
+            <div class="ledger">
+              <div class="lh"><div>timestamp</div><div>actor</div><div>action · object</div><div>hash</div></div>
+              <div id="ledger"></div>
+            </div>
+          </div>
+        </section>
+
+        <!-- domain-expert sign-off -->
+        <aside class="pane">
+          <div class="ph"><span class="label">Domain-expert sign-off</span></div>
+          <div class="pb">
+            <div class="callout">⚑ Gates never auto-pass. Sign-off records <b>who · what-hash · when</b> to the ledger and is scoped to your role.</div>
+            <div class="label" style="margin-bottom:2px">Required approvers</div>
+            <div id="approvers"></div>
+
+            <div class="label" style="margin:16px 0 0">Your role</div>
+            <div style="font-size:12.5px;color:var(--ink-2);margin:4px 0 2px">Domain expert — hardscape supply ops</div>
+            <textarea id="notes" placeholder="Optional: note what you verified (spec is domain-correct, UOM handling, tax rule…)"></textarea>
+            <button class="btn primary" id="signbtn" onclick="signOff()">Sign off G-DESIGN · WI-88</button>
+            <button class="btn danger" onclick="reqChanges()">Request changes</button>
+            <div class="note">Signing verifies the spec is <b>domain-correct</b> — not the code. Engineering review is a separate approver slot.</div>
+          </div>
+        </aside>
+      </div>
+    </main>
+  </div>
+</div>
+
+<script>
+const AG={
+  prism:{av:'PR',bg:'var(--prism-weak)',fg:'var(--prism)'},
+  claude:{av:'CL',bg:'var(--claude-weak)',fg:'var(--claude)'},
+  gemini:{av:'GM',bg:'var(--gemini-weak)',fg:'var(--gemini)'},
+  human:{av:'HU',bg:'var(--human-weak)',fg:'var(--ink-1)'}
+};
+const GATES=[
+  {id:'G-DESIGN',name:'UI/UX approved before build',state:['◆ In review','st-run'],pct:75,fill:'var(--accent)',avs:[['GM','gemini'],['HU','human'],['CT','human']],sel:true},
+  {id:'G-LOCK',name:'Spec set Effective (frozen)',state:['◐ Awaiting','st-warn'],pct:40,fill:'var(--warn)',avs:[['HU','human'],['CT','human']]},
+  {id:'G-PUSH',name:'Push / deploy approved',state:['○ Locked','st-lock'],pct:0,fill:'var(--ink-4)',avs:[['CT','human']]},
+  {id:'G-CLIENT',name:'Client-visible release',state:['○ Locked','st-lock'],pct:0,fill:'var(--ink-4)',avs:[['CT','human']]},
+  {id:'G-MONEY',name:'Hours · invoice · payment',state:['○ Locked','st-lock'],pct:0,fill:'var(--ink-4)',avs:[['CT','human']]}
+];
+const ITEMS=[
+  {wid:'WI-88',wt:'Checkout redesign',gate:'G-DESIGN',coverage:'2 / 5',
+   chain:[
+     {s:'Requirement',id:'REQ-014',cls:'',by:'human',ev:{title:'From client call · 12 Jun',quote:'"The total has to be exact to the cent — no rounding surprises at the till."',dt:'author Dibbits ops lead · via Second Brain',ts:'2026-06-12T14:22:03Z',hash:'req-2af19c'}},
+     {s:'Spec',id:'SPEC-07',cls:'',by:'gemini',ev:{title:'Design spec · Checkout redesign',quote:'Single-page checkout; order-summary block bound to integer-cents money type; inline validation.',dt:'author Gemini (MCP) · reviewed by design lead',ts:'2026-07-14T13:20:00Z',hash:'spec-9f0c4d'}},
+     {s:'Code',id:'pending',cls:'pending',by:null,ev:null},
+     {s:'Test',id:'pending',cls:'pending',by:null,ev:null},
+     {s:'Deploy',id:'—',cls:'pending',by:null,ev:null}
+   ],
+   ledger:[
+     ['2026-06-12 14:22','human','captured requirement','v-ok','REQ-014','req-2af19c'],
+     ['2026-07-14 13:20','gemini','drafted spec','','SPEC-07','spec-9f0c4d'],
+     ['2026-07-15 09:41','human','design lead approved','v-ok','SPEC-07','7c2e0b1'],
+     ['2026-07-15 10:03','human','eng review approved','v-ok','SPEC-07','3d1f9aa']
+   ],
+   approvers:[
+     {nm:'A. Rivera',rl:'Design lead',by:'gemini',st:['✓ Signed','var(--ok)']},
+     {nm:'M. Osei',rl:'Senior engineer',by:'human',st:['✓ Signed','var(--ok)']},
+     {nm:'You',rl:'Domain expert',by:'human',st:['◐ Open','var(--warn)']}
+   ]},
+  {wid:'WI-91',wt:'Invoicing epic — decomposition',gate:'G-DESIGN',coverage:'2 / 5',
+   chain:[
+     {s:'Requirement',id:'REQ-041',cls:'',by:'human',ev:{title:'From onboarding workshop',quote:'"Invoices must show HST split and reference the PO."',dt:'author finance lead · via Second Brain',ts:'2026-07-02T10:10:00Z',hash:'req-51ab77'}},
+     {s:'Spec',id:'SPEC-12',cls:'',by:'prism',ev:{title:'Decomposition spec',quote:'8 work-items with acceptance criteria, each cited to REQ-041.',dt:'author Prism (coordinator)',ts:'2026-07-15T16:40:00Z',hash:'spec-c12aa0'}},
+     {s:'Code',id:'pending',cls:'pending',by:null,ev:null},
+     {s:'Test',id:'pending',cls:'pending',by:null,ev:null},
+     {s:'Deploy',id:'—',cls:'pending',by:null,ev:null}
+   ],
+   ledger:[
+     ['2026-07-02 10:10','human','captured requirement','v-ok','REQ-041','req-51ab77'],
+     ['2026-07-15 16:40','prism','decomposed epic','','SPEC-12','spec-c12aa0']
+   ],
+   approvers:[
+     {nm:'A. Rivera',rl:'Design lead',by:'gemini',st:['◐ Open','var(--warn)']},
+     {nm:'M. Osei',rl:'Senior engineer',by:'human',st:['✓ Signed','var(--ok)']},
+     {nm:'You',rl:'Domain expert',by:'human',st:['◐ Open','var(--warn)']}
+   ]},
+  {wid:'WI-73',wt:'Public search rate-limit',gate:'G-DESIGN',coverage:'1 / 5',
+   chain:[
+     {s:'Requirement',id:'REQ-044',cls:'',by:'human',ev:{title:'From incident review',quote:'"Search got hammered and took down the portal — needs a limiter."',dt:'author platform owner · via Second Brain',ts:'2026-07-10T08:55:00Z',hash:'req-77c0e1'}},
+     {s:'Spec',id:'missing',cls:'stale',by:null,ev:{title:'Spec not yet linked',quote:'No controlled spec drafted — requirement has no design artifact. G-DESIGN cannot pass.',dt:'—',ts:'—',hash:'—'}},
+     {s:'Code',id:'pending',cls:'pending',by:null,ev:null},
+     {s:'Test',id:'pending',cls:'pending',by:null,ev:null},
+     {s:'Deploy',id:'—',cls:'pending',by:null,ev:null}
+   ],
+   ledger:[
+     ['2026-07-10 08:55','human','captured requirement','v-ok','REQ-044','req-77c0e1']
+   ],
+   approvers:[
+     {nm:'A. Rivera',rl:'Design lead',by:'gemini',st:['⊘ Blocked','var(--crit)']},
+     {nm:'M. Osei',rl:'Senior engineer',by:'human',st:['◐ Open','var(--warn)']},
+     {nm:'You',rl:'Domain expert',by:'human',st:['◐ Open','var(--warn)']}
+   ]}
+];
+
+// render gate board
+const gb=document.getElementById('gateboard');
+GATES.forEach(g=>{
+  const el=document.createElement('div');el.className='gate'+(g.sel?' sel':'');
+  el.innerHTML=`<div class="gid">${g.id}</div><div class="gname">${g.name}</div>
+    <div class="meter"><i style="width:${g.pct}%;background:${g.fill}"></i></div>
+    <div class="grow"><span class="chip ${g.state[1]}">${g.state[0]}</span>
+    <span class="avs">${g.avs.map(a=>`<span style="background:${AG[a[1]].bg};color:${AG[a[1]].fg}">${a[0]}</span>`).join('')}</span></div>`;
+  el.addEventListener('click',()=>{
+    document.querySelectorAll('.gate').forEach(x=>x.classList.remove('sel'));el.classList.add('sel');
+    const items=ITEMS.filter(i=>i.gate===g.id);
+    document.getElementById('qh').textContent='Awaiting '+g.id;
+    document.getElementById('qc').textContent=items.length+' items';
+    renderQueue(g.id);
+    if(items.length) selectItem(items[0].wid); else clearDetail(g.id);
+  });
+  gb.appendChild(el);
+});
+
+function renderQueue(gate){
+  const q=document.getElementById('queue');q.innerHTML='';
+  const items=ITEMS.filter(i=>i.gate===gate);
+  if(!items.length){q.innerHTML='<div class="hint">No items awaiting this gate.</div>';return;}
+  items.forEach(it=>{
+    const el=document.createElement('div');el.className='qitem'+(it.wid===cur?' sel':'');
+    el.innerHTML=`<div class="wid">${it.wid} · ${it.chain[0].id}</div><div class="wt">${it.wt}</div>
+      <div class="qm"><span class="chip st-run">◆ ${gate}</span><span class="chip st-lock">cov ${it.coverage}</span></div>`;
+    el.addEventListener('click',()=>selectItem(it.wid));
+    q.appendChild(el);
+  });
+}
+function clearDetail(gate){
+  document.getElementById('dwid').textContent='';
+  document.getElementById('dwt').textContent=gate+' — no items awaiting';
+  document.getElementById('trace').innerHTML='<div class="hint" style="padding:20px">Nothing queued for this gate right now.</div>';
+  document.getElementById('evidence').innerHTML='';document.getElementById('ledger').innerHTML='';
+  document.getElementById('approvers').innerHTML='<div class="hint">—</div>';
+}
+
+let cur='WI-88';
+function selectItem(wid){
+  cur=wid;const it=ITEMS.find(i=>i.wid===wid);
+  document.querySelectorAll('.qitem').forEach(q=>q.classList.toggle('sel',q.querySelector('.wid').textContent.startsWith(wid)));
+  document.getElementById('dwid').textContent=it.wid;
+  document.getElementById('dwt').textContent=it.wt;
+  document.getElementById('coverage').textContent='coverage '+it.coverage;
+  // spine
+  const t=document.getElementById('trace');t.innerHTML='';
+  it.chain.forEach((n,i)=>{
+    const node=document.createElement('div');node.className='tnode '+n.cls;
+    const glyph=n.cls==='pending'?'○':(n.cls==='stale'?'▲':'●');
+    node.innerHTML=`<div class="s">${glyph} ${n.s}</div><div class="id">${n.id}</div>${n.by?`<div class="meta">by ${n.by}</div>`:''}`;
+    if(n.ev){node.addEventListener('click',()=>showEvidence(wid,i,node));}
+    t.appendChild(node);
+    if(i<it.chain.length-1){
+      const e=document.createElement('div');
+      const nextPending=it.chain[i+1].cls==='pending';const thisStale=it.chain[i+1].cls==='stale'||n.cls==='stale';
+      e.className='tedge'+(thisStale?' stale':(nextPending?' off':''));
+      t.appendChild(e);
+    }
+  });
+  document.getElementById('evidence').innerHTML='';
+  renderLedger(it.ledger);
+  renderApprovers(it);
+  updateSignBtn(it);
+}
+function showEvidence(wid,idx,node){
+  document.querySelectorAll('.tnode').forEach(n=>n.classList.remove('sel'));node.classList.add('sel');
+  const it=ITEMS.find(i=>i.wid===wid);const n=it.chain[idx];const ev=n.ev;
+  const box=document.getElementById('evidence');
+  const byAv=n.by?`<span class="mono-av" style="background:${AG[n.by].bg};color:${AG[n.by].fg}">${AG[n.by].av}</span>`:'';
+  box.innerHTML=`<div class="evidence">
+    <div class="et">${byAv} ${n.s} · <span class="mono" style="color:var(--ink-2)">${n.id}</span></div>
+    <div style="font-size:12px;color:var(--ink-3)">${ev.title}</div>
+    <div class="ex">${ev.quote}</div>
+    <dl class="kv"><dt>author</dt><dd>${ev.dt}</dd><dt>timestamp</dt><dd>${ev.ts}</dd><dt>content hash</dt><dd>${ev.hash}</dd></dl>
+  </div>`;
+}
+function renderLedger(rows){
+  const l=document.getElementById('ledger');l.innerHTML='';
+  rows.forEach((r,i)=>{
+    const av=AG[r[1]]||AG.human;
+    const el=document.createElement('div');el.className='lr';
+    el.innerHTML=`<div class="ts">${r[0]}</div>
+      <div class="who"><span class="mono-av" style="background:${av.bg};color:${av.fg}">${av.av}</span>${r[1]}</div>
+      <div class="act"><span class="${r[3]}">${r[2]}</span> · ${r[4]}</div>
+      <div class="hash">${i>0?'←':''}${r[5]}</div>`;
+    l.appendChild(el);
+  });
+}
+function renderApprovers(it){
+  const a=document.getElementById('approvers');a.innerHTML='';
+  it.approvers.forEach(p=>{
+    const av=AG[p.by]||AG.human;
+    const el=document.createElement('div');el.className='approver';
+    el.innerHTML=`<span class="mono-av" style="width:24px;height:24px;background:${av.bg};color:${av.fg}">${av.av}</span>
+      <div><div class="nm">${p.nm}</div><div class="rl">${p.rl}</div></div>
+      <div class="st" style="color:${p.st[1]}">${p.st[0]}</div>`;
+    a.appendChild(el);
+  });
+}
+function updateSignBtn(it){
+  const btn=document.getElementById('signbtn');
+  const you=it.approvers.find(p=>p.nm==='You');
+  const blocked=it.chain.some(c=>c.cls==='stale');
+  if(blocked){btn.disabled=true;btn.textContent='Blocked — link a spec first';}
+  else if(you && you.st[0].startsWith('✓')){btn.disabled=true;btn.textContent='You have signed ✓';}
+  else{btn.disabled=false;btn.textContent='Sign off '+it.gate+' · '+it.wid;}
+}
+function signOff(){
+  const it=ITEMS.find(i=>i.wid===cur);
+  const you=it.approvers.find(p=>p.nm==='You');if(!you)return;
+  you.st=['✓ Signed','var(--ok)'];you.by='human';
+  const note=document.getElementById('notes').value.trim();
+  const now=new Date();const ts=now.toISOString().slice(0,16).replace('T',' ');
+  const hash='sig-'+Math.random().toString(16).slice(2,8);
+  it.ledger.push([ts,'human','domain-expert signed'+(note?' ("'+note.slice(0,28)+(note.length>28?'…':'')+'")':''),'v-ok',it.gate+'·'+it.wid,hash]);
+  // if all signed, pass the gate
+  const allSigned=it.approvers.every(p=>p.st[0].startsWith('✓'));
+  renderApprovers(it);renderLedger(it.ledger);updateSignBtn(it);
+  document.getElementById('notes').value='';
+  // flash newest ledger row
+  const rows=document.querySelectorAll('#ledger .lr');if(rows.length)rows[rows.length-1].classList.add('new');
+  if(allSigned){
+    const g=GATES.find(x=>x.id===it.gate);
+    document.querySelectorAll('.gate').forEach(el=>{
+      if(el.querySelector('.gid').textContent===it.gate){
+        el.querySelector('.chip').outerHTML='<span class="chip st-ok">● Passed</span>';
+        el.querySelector('.meter i').style.width='100%';el.querySelector('.meter i').style.background='var(--ok)';
+      }
+    });
+  }
+}
+function reqChanges(){
+  const it=ITEMS.find(i=>i.wid===cur);
+  const now=new Date();const ts=now.toISOString().slice(0,16).replace('T',' ');
+  it.ledger.push([ts,'human','changes requested','v-crit',it.gate+'·'+it.wid,'chg-'+Math.random().toString(16).slice(2,8)]);
+  renderLedger(it.ledger);
+  const rows=document.querySelectorAll('#ledger .lr');if(rows.length)rows[rows.length-1].classList.add('new');
+}
+
+// init
+renderQueue('G-DESIGN');
+selectItem('WI-88');
+showEvidence('WI-88',0,document.querySelectorAll('#trace .tnode')[0]);
+</script>
+</body>
+</html>

--- a/prototypes/index.html
+++ b/prototypes/index.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>4C Shade Console — G-DESIGN Prototypes</title>
+<style>
+:root{
+  --bg:#0A0D13;--surface-1:#0F131B;--surface-2:#151A24;--surface-3:#1C2230;--surface-4:#232B3B;
+  --border:#242C3A;--border-2:#313B4D;
+  --ink-1:#EAEEF6;--ink-2:#AEB8CC;--ink-3:#727E93;--ink-4:#4B5567;
+  --accent:#37CFBD;--accent-hover:#4ADED0;--accent-fg:#04120F;--accent-weak:rgba(55,207,189,.14);--accent-line:rgba(55,207,189,.38);
+  --spectral:linear-gradient(90deg,#8B7CF0 0%,#4EC5E0 52%,#37CFBD 100%);
+  --prism:#8B7CF0;--prism-weak:rgba(139,124,240,.16);
+  --claude:#E0785B;--claude-weak:rgba(224,120,91,.16);
+  --gemini:#5B9DF9;--gemini-weak:rgba(91,157,249,.16);
+  --human:#AEB8CC;--human-weak:rgba(174,184,204,.12);
+  --ok:#46C98A;--warn:#E7B54B;--risk:#E8894A;--crit:#E86A6A;--info:#5B9DF9;
+  --r-1:6px;--r-2:10px;--r-3:14px;--r-pill:999px;
+  --shadow-2:0 12px 40px -14px rgba(0,0,0,.7);
+  --font-sans:ui-sans-serif,system-ui,-apple-system,"Segoe UI Variable Display","Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+  --font-mono:ui-monospace,"SF Mono","JetBrains Mono","Cascadia Code","Roboto Mono",Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0}
+body{background:
+    radial-gradient(1100px 500px at 78% -8%,rgba(139,124,240,.10),transparent 60%),
+    radial-gradient(900px 480px at 10% 0%,rgba(55,207,189,.07),transparent 55%),
+    var(--bg);
+  color:var(--ink-1);font-family:var(--font-sans);font-size:14px;line-height:22px;-webkit-font-smoothing:antialiased;min-height:100vh}
+.mono{font-family:var(--font-mono)}
+a{color:inherit;text-decoration:none}
+.wrap{max-width:1060px;margin:0 auto;padding:56px 28px 72px}
+
+/* header */
+.head{display:flex;align-items:center;gap:13px;margin-bottom:6px}
+.mark{width:34px;height:34px;border-radius:9px;background:var(--spectral);box-shadow:0 0 0 1px rgba(255,255,255,.10) inset,var(--shadow-2)}
+.head h1{font-size:15px;font-weight:600;margin:0;letter-spacing:.02em}
+.head .pill{margin-left:auto;font-family:var(--font-mono);font-size:11px;color:var(--accent);background:var(--accent-weak);border:1px solid var(--accent-line);border-radius:var(--r-pill);padding:4px 12px}
+.hero{margin:26px 0 10px}
+.hero h2{font-size:38px;line-height:1.08;font-weight:600;letter-spacing:-.02em;margin:0 0 14px;max-width:19ch;text-wrap:balance}
+.hero h2 .g{background:var(--spectral);-webkit-background-clip:text;background-clip:text;color:transparent}
+.hero p{font-size:15.5px;color:var(--ink-2);max-width:64ch;margin:0}
+.hero p b{color:var(--ink-1);font-weight:600}
+.metastrip{display:flex;gap:10px;flex-wrap:wrap;margin:22px 0 4px}
+.ms{font-size:11.5px;color:var(--ink-2);background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-pill);padding:5px 12px}
+.ms i{font-style:normal;color:var(--ink-4)}
+
+.sechead{display:flex;align-items:center;gap:10px;margin:44px 0 16px}
+.sechead .lb{font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--ink-3)}
+.sechead .rule{flex:1;height:1px;background:var(--border)}
+
+/* prototype cards */
+.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
+@media(max-width:860px){.grid{grid-template-columns:1fr}}
+.card{background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-3);overflow:hidden;display:flex;flex-direction:column;transition:transform .1s ease,box-shadow .12s ease,border-color .12s}
+.card:hover{transform:translateY(-3px);box-shadow:var(--shadow-2);border-color:var(--border-2)}
+.thumb{height:104px;position:relative;border-bottom:1px solid var(--border);overflow:hidden;background:var(--surface-1)}
+.thumb .num{position:absolute;top:10px;left:12px;font-family:var(--font-mono);font-size:11px;color:var(--ink-3)}
+.cbody{padding:15px 16px 17px;display:flex;flex-direction:column;flex:1}
+.cbody h3{margin:0 0 5px;font-size:15.5px;font-weight:600}
+.cbody p{margin:0 0 14px;font-size:12.8px;color:var(--ink-3);line-height:19px;flex:1}
+.cbody .go{align-self:flex-start;font-size:12.5px;font-weight:600;color:var(--accent-fg);background:var(--accent);border-radius:var(--r-1);padding:7px 14px}
+.tags{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:12px}
+.tag{font-size:10.5px;font-weight:600;color:var(--ink-2);background:var(--surface-3);border:1px solid var(--border);border-radius:var(--r-pill);padding:2px 8px}
+
+/* mini thumbnail motifs (pure CSS, no assets) */
+.tb-fleet{display:flex;gap:6px;padding:14px 12px 0}
+.tb-fleet .c{flex:1;background:var(--surface-2);border:1px solid var(--border);border-radius:5px;height:74px;padding:6px}
+.tb-fleet .c .bar{height:4px;border-radius:2px;margin-bottom:4px}
+.tb-fleet .c.p .bar{background:var(--prism)}.tb-fleet .c.cl .bar{background:var(--claude)}.tb-fleet .c.g .bar{background:var(--gemini)}
+.tb-fleet .c .ln{height:5px;border-radius:2px;background:var(--surface-4);margin-bottom:4px}
+.tb-fleet .c .ln.s{width:60%}
+
+.tb-gate{display:flex;align-items:center;gap:0;padding:34px 14px 0;overflow:hidden}
+.tb-gate .n{flex:0 0 auto;border:1px solid var(--accent-line);border-radius:4px;padding:5px 8px;font-family:var(--font-mono);font-size:9px;color:var(--ink-1);background:var(--surface-2)}
+.tb-gate .n.pend{border-style:dashed;border-color:var(--border-2);color:var(--ink-4)}
+.tb-gate .e{flex:0 0 16px;height:2px;background:var(--spectral)}
+.tb-gate .e.off{background:var(--border-2)}
+
+.tb-brain{padding:14px 12px 0;display:flex;gap:8px}
+.tb-brain .col1{flex:1.3;display:flex;flex-direction:column;gap:5px}
+.tb-brain .col1 .ln{height:5px;border-radius:2px;background:var(--surface-4)}
+.tb-brain .col1 .ln.hl{background:var(--accent-weak);box-shadow:inset 0 0 0 1px var(--accent-line)}
+.tb-brain .col2{flex:1;display:flex;flex-direction:column;gap:5px}
+.tb-brain .col2 .chipm{height:16px;border-radius:4px;background:var(--surface-2);border:1px solid var(--border)}
+.tb-brain .col2 .chipm.a{border-color:var(--accent-line)}
+
+/* backbone + docs */
+.two{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+@media(max-width:760px){.two{grid-template-columns:1fr}}
+.panel{background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-2);padding:18px 18px}
+.panel h4{margin:0 0 8px;font-size:13.5px}
+.panel p{margin:0 0 10px;font-size:12.8px;color:var(--ink-3);line-height:19px}
+.doclink{display:flex;align-items:center;gap:9px;padding:9px 11px;border:1px solid var(--border);border-radius:var(--r-1);margin-top:8px;font-size:12.5px;color:var(--ink-2)}
+.doclink .mono{color:var(--ink-1)}
+.doclink .arw{margin-left:auto;color:var(--ink-4)}
+.legend{display:flex;gap:14px;flex-wrap:wrap;margin-top:2px}
+.legend span{display:inline-flex;align-items:center;gap:6px;font-size:12px;color:var(--ink-2)}
+.legend i{width:9px;height:9px;border-radius:50%}
+.oq{margin:10px 0 0;padding-left:18px;color:var(--ink-3);font-size:12.8px}
+.oq li{margin:5px 0}.oq li b{color:var(--ink-2);font-family:var(--font-mono);font-size:11.5px}
+.foot{margin-top:44px;padding-top:18px;border-top:1px solid var(--border);color:var(--ink-4);font-size:11.5px;display:flex;gap:14px;flex-wrap:wrap;align-items:center}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="head">
+    <span class="mark"></span>
+    <h1>4C SHADE · Console</h1>
+    <span class="pill">G-DESIGN · design pass · Track A</span>
+  </div>
+
+  <div class="hero">
+    <h2>Autonomous delivery you can <span class="g">prove</span> and stand behind.</h2>
+    <p>The console is an <b>instrument, not a hype surface</b>: agent-native, artifact-first, with gates and full requirement→deploy traceability as first-class objects. These three clickable mockups prototype the <b>differentiating surfaces</b> — the ones no generic agent-manager (Cursor / GitHub / Antigravity) has. Backbone screens (tracker / docs / QMS) stay Huly's UI under a Shade overlay and are deliberately not redesigned.</p>
+    <div class="metastrip">
+      <span class="ms"><i>agents ·</i> Prism <b style="color:var(--prism)">●</b> · Claude <b style="color:var(--claude)">●</b> · Gemini <b style="color:var(--gemini)">●</b></span>
+      <span class="ms"><i>gates ·</i> G-DESIGN · G-LOCK · G-PUSH · G-CLIENT · G-MONEY</span>
+      <span class="ms"><i>offline ·</i> opens via file:// · no network</span>
+    </div>
+  </div>
+
+  <div class="sechead"><span class="lb">Prototyped surfaces · click to open</span><span class="rule"></span></div>
+  <div class="grid">
+
+    <a class="card" href="agent-fleet.html">
+      <div class="thumb"><span class="num">01</span>
+        <div class="tb-fleet">
+          <div class="c cl"><div class="bar"></div><div class="ln"></div><div class="ln s"></div></div>
+          <div class="c g"><div class="bar"></div><div class="ln"></div><div class="ln s"></div></div>
+          <div class="c p"><div class="bar"></div><div class="ln"></div><div class="ln s"></div></div>
+        </div>
+      </div>
+      <div class="cbody">
+        <div class="tags"><span class="tag">mission-control</span><span class="tag">artifact-first</span></div>
+        <h3>Agent Fleet</h3>
+        <p>See and steer every parallel agent thread grouped by state; review the plan, diff and test evidence right on the card.</p>
+        <span class="go">Open prototype →</span>
+      </div>
+    </a>
+
+    <a class="card" href="gate-traceability.html">
+      <div class="thumb"><span class="num">02</span>
+        <div class="tb-gate">
+          <div class="n">REQ</div><div class="e"></div>
+          <div class="n">SPEC</div><div class="e off"></div>
+          <div class="n pend">CODE</div><div class="e off"></div>
+          <div class="n pend">TEST</div>
+        </div>
+      </div>
+      <div class="cbody">
+        <div class="tags"><span class="tag">gates-as-objects</span><span class="tag">audit ledger</span></div>
+        <h3>Gate &amp; Traceability Cockpit</h3>
+        <p>The 5 gates as objects, the requirement↔spec↔code↔test↔deploy spine, an immutable who-approved-what ledger, and a live domain-expert sign-off.</p>
+        <span class="go">Open prototype →</span>
+      </div>
+    </a>
+
+    <a class="card" href="second-brain.html">
+      <div class="thumb"><span class="num">03</span>
+        <div class="tb-brain">
+          <div class="col1"><div class="ln"></div><div class="ln hl"></div><div class="ln"></div><div class="ln hl"></div><div class="ln"></div></div>
+          <div class="col2"><div class="chipm a"></div><div class="chipm"></div><div class="chipm a"></div><div class="chipm"></div></div>
+        </div>
+      </div>
+      <div class="cbody">
+        <div class="tags"><span class="tag">conversation→spec</span><span class="tag">provenance</span></div>
+        <h3>Second-Brain Intake</h3>
+        <p>Expert conversation → cited requirements, work-items and specs, each traceable back to the exact spoken span that created it.</p>
+        <span class="go">Open prototype →</span>
+      </div>
+    </a>
+  </div>
+
+  <div class="sechead"><span class="lb">Design system &amp; scope</span><span class="rule"></span></div>
+  <div class="two">
+    <div class="panel">
+      <h4>One system · dark-committed "Shade"</h4>
+      <p>All three prototypes are driven by the same token set — cool blue-slate ground, one luminous cyan-teal accent, and a single spectral motif (violet→cyan→teal) reserved for the Prism coordinator and the traceability spine. Monospace carries every traceable ID (chain-of-custody as typography).</p>
+      <div class="legend">
+        <span><i style="background:var(--accent)"></i>accent</span>
+        <span><i style="background:var(--prism)"></i>Prism</span>
+        <span><i style="background:var(--claude)"></i>Claude</span>
+        <span><i style="background:var(--gemini)"></i>Gemini</span>
+        <span><i style="background:var(--ok)"></i>pass</span>
+        <span><i style="background:var(--warn)"></i>awaiting</span>
+        <span><i style="background:var(--crit)"></i>blocked</span>
+      </div>
+      <div class="doclink">◫ tokens &amp; component specs · <span class="mono">docs/4c-shade/design/DESIGN.md</span><span class="arw">↗</span></div>
+      <div class="doclink">◫ screen inventory &amp; flows · <span class="mono">docs/4c-shade/design/UI-UX-MAP.md</span><span class="arw">↗</span></div>
+    </div>
+    <div class="panel">
+      <h4>Backbone = Huly UI + Shade overlay <span style="color:var(--ink-4);font-weight:400">(not redesigned)</span></h4>
+      <p>Tracker, Documents, Controlled-doc QMS specs and Test Management keep Huly's existing screens. The Shade "overlay" is tokens only — top bar, rail, accent, status/gate chips — plus wiring the spec lifecycle (Draft→Effective) to <span class="mono" style="color:var(--ink-2)">G-LOCK</span>.</p>
+      <h4 style="margin-top:14px">Open questions for the gate</h4>
+      <ul class="oq">
+        <li><b>OQ-1</b> Ship a light mode in v1, or commit fully to dark?</li>
+        <li><b>OQ-3</b> Design Prism's single-chat-over-fleet now, or keep board-first for v1?</li>
+        <li><b>OQ-4</b> Are all 5 gates mandatory per item, or configurable per workspace?</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="foot">
+    <span>4C Shade · product console · design-first / G-DESIGN</span>
+    <span style="margin-left:auto" class="mono">placeholder data — generic software-delivery, no client specifics</span>
+  </div>
+</div>
+</body>
+</html>

--- a/prototypes/second-brain.html
+++ b/prototypes/second-brain.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Second Brain · Intake — 4C Shade</title>
+<style>
+:root{
+  --bg:#0A0D13;--surface-1:#0F131B;--surface-2:#151A24;--surface-3:#1C2230;--surface-4:#232B3B;
+  --border:#242C3A;--border-2:#313B4D;--overlay:rgba(5,7,11,.62);
+  --ink-1:#EAEEF6;--ink-2:#AEB8CC;--ink-3:#727E93;--ink-4:#4B5567;
+  --accent:#37CFBD;--accent-hover:#4ADED0;--accent-press:#28B4A3;--accent-fg:#04120F;
+  --accent-weak:rgba(55,207,189,.14);--accent-line:rgba(55,207,189,.38);
+  --spectral:linear-gradient(90deg,#8B7CF0 0%,#4EC5E0 52%,#37CFBD 100%);
+  --prism:#8B7CF0;--prism-weak:rgba(139,124,240,.16);
+  --claude:#E0785B;--claude-weak:rgba(224,120,91,.16);
+  --gemini:#5B9DF9;--gemini-weak:rgba(91,157,249,.16);
+  --human:#AEB8CC;--human-weak:rgba(174,184,204,.12);
+  --ok:#46C98A;--ok-weak:rgba(70,201,138,.14);
+  --warn:#E7B54B;--warn-weak:rgba(231,181,75,.14);
+  --risk:#E8894A;--risk-weak:rgba(232,137,74,.14);
+  --crit:#E86A6A;--crit-weak:rgba(232,106,106,.14);
+  --info:#5B9DF9;--info-weak:rgba(91,157,249,.14);
+  --r-1:6px;--r-2:10px;--r-3:14px;--r-pill:999px;
+  --shadow-1:0 1px 2px rgba(0,0,0,.4);
+  --font-sans:ui-sans-serif,system-ui,-apple-system,"Segoe UI Variable Display","Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+  --font-mono:ui-monospace,"SF Mono","JetBrains Mono","Cascadia Code","Roboto Mono",Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;height:100%}
+body{background:var(--bg);color:var(--ink-1);font-family:var(--font-sans);font-size:13.5px;line-height:20px;-webkit-font-smoothing:antialiased}
+.mono{font-family:var(--font-mono);font-variant-numeric:tabular-nums}
+.label{font-size:11px;font-weight:600;letter-spacing:.07em;text-transform:uppercase;color:var(--ink-3)}
+button{font-family:inherit;cursor:pointer}
+:focus-visible{outline:none;box-shadow:0 0 0 2px var(--bg),0 0 0 4px var(--accent);border-radius:var(--r-1)}
+::-webkit-scrollbar{width:10px;height:10px}::-webkit-scrollbar-thumb{background:var(--surface-4);border-radius:99px;border:2px solid transparent;background-clip:padding-box}
+
+.app{height:100vh;display:flex;flex-direction:column;overflow:hidden}
+.topbar{height:48px;flex:0 0 auto;display:flex;align-items:center;gap:14px;padding:0 14px;background:var(--surface-1);border-bottom:1px solid var(--border)}
+.brand{display:flex;align-items:center;gap:9px;font-weight:600}
+.brand .mark{width:20px;height:20px;border-radius:5px;background:var(--spectral);box-shadow:0 0 0 1px rgba(255,255,255,.08) inset}
+.ws{display:flex;align-items:center;gap:7px;padding:5px 9px;background:var(--surface-3);border:1px solid var(--border);border-radius:var(--r-1);font-size:12.5px;color:var(--ink-2)}
+.ws b{color:var(--ink-1);font-weight:600}
+.crumb{color:var(--ink-3);font-size:12.5px}.crumb b{color:var(--ink-2);font-weight:500}
+.spacer{flex:1}
+.search{display:flex;align-items:center;gap:7px;padding:5px 10px;background:var(--surface-3);border:1px solid var(--border);border-radius:var(--r-1);color:var(--ink-3);font-size:12.5px;width:200px}
+.search kbd{margin-left:auto;font-family:var(--font-mono);font-size:10px;background:var(--surface-1);border:1px solid var(--border);border-radius:4px;padding:1px 5px}
+.avatar{width:26px;height:26px;border-radius:50%;display:grid;place-items:center;font-size:11px;font-weight:700;border:1px solid var(--border-2)}
+
+.body{flex:1;display:flex;min-height:0}
+.rail{width:216px;flex:0 0 auto;background:var(--surface-1);border-right:1px solid var(--border);padding:12px 10px;overflow:auto;display:flex;flex-direction:column;gap:3px}
+.rail .grp{margin:10px 8px 4px}
+.nav{display:flex;align-items:center;gap:10px;padding:7px 10px;border-radius:var(--r-1);color:var(--ink-2);font-size:13px;font-weight:500;text-decoration:none;cursor:pointer}
+.nav:hover{background:var(--surface-3);color:var(--ink-1)}
+.nav.on{background:var(--accent-weak);color:var(--ink-1);box-shadow:inset 0 0 0 1px var(--accent-line)}
+.nav .ic{width:16px;text-align:center;color:var(--ink-3)}.nav.on .ic{color:var(--accent)}
+.nav .ct{margin-left:auto;font-size:11px;color:var(--ink-3);font-family:var(--font-mono)}
+.rail hr{border:none;border-top:1px solid var(--border);margin:10px 4px}
+.hint{color:var(--ink-4);font-size:11px;padding:6px 4px;text-align:center}
+
+.main{flex:1;min-width:0;display:grid;grid-template-columns:1fr 392px;min-height:0}
+
+/* conversation pane */
+.convo{overflow:auto;border-right:1px solid var(--border);padding:0}
+.cvh{padding:16px 22px 12px;border-bottom:1px solid var(--border);position:sticky;top:0;background:var(--bg);z-index:2}
+.cvh h1{font-size:18px;font-weight:600;margin:0 0 3px}
+.cvh .meta{font-size:12px;color:var(--ink-3);display:flex;gap:12px;flex-wrap:wrap;align-items:center}
+.cvh .src{display:inline-flex;align-items:center;gap:6px;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-pill);padding:3px 9px;font-size:11px;color:var(--ink-2)}
+.transcript{padding:8px 22px 40px;max-width:720px}
+.turn{display:flex;gap:11px;padding:11px 0}
+.turn .sav{width:28px;height:28px;flex:0 0 auto;border-radius:50%;display:grid;place-items:center;font-size:10px;font-weight:700;font-family:var(--font-mono);margin-top:1px}
+.turn .body .who{font-size:12px;font-weight:600;color:var(--ink-1)}
+.turn .body .who .t{color:var(--ink-4);font-weight:500;font-family:var(--font-mono);margin-left:7px;font-size:11px}
+.turn .body p{margin:3px 0 0;color:var(--ink-2);line-height:22px;font-size:13.5px}
+mark.cited{background:var(--accent-weak);color:var(--ink-1);border-bottom:1.5px solid var(--accent-line);border-radius:3px;padding:1px 2px;cursor:pointer;transition:background .1s}
+mark.cited:hover{background:rgba(55,207,189,.22)}
+mark.cited.active{background:rgba(55,207,189,.30);box-shadow:0 0 0 1px var(--accent-line)}
+mark.cited.risk{background:var(--risk-weak);border-bottom-color:rgba(232,137,74,.4)}
+mark.cited.risk.active{background:rgba(232,137,74,.28)}
+mark.cited.low{background:var(--warn-weak);border-bottom-color:rgba(231,181,75,.4)}
+mark.cited.low.active{background:rgba(231,181,75,.26)}
+
+/* extracted pane */
+.xpane{overflow:auto;background:var(--surface-1);display:flex;flex-direction:column}
+.xph{padding:14px 16px 10px;border-bottom:1px solid var(--border);position:sticky;top:0;background:var(--surface-1);z-index:2}
+.xph .t{display:flex;align-items:center;gap:8px}
+.xph h2{font-size:14px;font-weight:600;margin:0}
+.filters{display:flex;gap:6px;margin-top:10px;flex-wrap:wrap}
+.filters button{border:1px solid var(--border);background:var(--surface-2);color:var(--ink-2);font-size:11.5px;font-weight:600;padding:4px 10px;border-radius:var(--r-pill)}
+.filters button.on{background:var(--accent-weak);color:var(--ink-1);border-color:var(--accent-line)}
+.xlist{padding:12px 14px;display:flex;flex-direction:column;gap:10px}
+
+.xitem{background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-2);padding:12px 13px;cursor:pointer;transition:box-shadow .1s,background .1s}
+.xitem:hover{background:var(--surface-3)}
+.xitem.sel{box-shadow:0 0 0 1px var(--accent-line);background:var(--surface-3)}
+.xitem .xh{display:flex;align-items:center;gap:8px;margin-bottom:6px}
+.tbadge{font-size:10px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;padding:2px 7px;border-radius:var(--r-1)}
+.tb-req{background:var(--accent-weak);color:var(--accent)}
+.tb-wi{background:var(--info-weak);color:var(--info)}
+.tb-spec{background:var(--prism-weak);color:var(--prism)}
+.tb-risk{background:var(--risk-weak);color:var(--risk)}
+.xitem .xid{font-family:var(--font-mono);font-size:11px;color:var(--ink-3);margin-left:auto}
+.xitem .xstmt{font-size:13px;color:var(--ink-1);line-height:19px}
+.conf{display:flex;align-items:center;gap:8px;margin-top:9px}
+.conf .bar{flex:1;height:5px;border-radius:99px;background:var(--surface-4);overflow:hidden}
+.conf .bar i{display:block;height:100%;background:var(--accent)}
+.conf .pc{font-family:var(--font-mono);font-size:10.5px;color:var(--ink-3)}
+.grounding{display:flex;gap:5px;flex-wrap:wrap;margin-top:9px}
+.gchip{font-size:10.5px;color:var(--ink-2);background:var(--surface-1);border:1px solid var(--border);border-radius:var(--r-pill);padding:2px 8px}
+.gchip::before{content:"◍ ";color:var(--prism)}
+
+.prov{margin-top:10px;padding-top:10px;border-top:1px dashed var(--border);display:none}
+.xitem.sel .prov{display:block}
+.prov .pt{font-size:11px;color:var(--ink-3);display:flex;align-items:center;gap:6px;margin-bottom:8px}
+.trail{display:flex;align-items:center;gap:6px;flex-wrap:wrap;font-size:10.5px}
+.trail .tstep{background:var(--surface-1);border:1px solid var(--border);border-radius:var(--r-1);padding:3px 8px;font-family:var(--font-mono);color:var(--ink-2)}
+.trail .tstep.origin{border-color:var(--accent-line);color:var(--ink-1)}
+.trail .arr{color:var(--ink-4)}
+.acts{display:flex;gap:7px;margin-top:11px}
+.acts button{flex:1;border:1px solid var(--border-2);background:var(--surface-1);color:var(--ink-1);font-size:12px;font-weight:600;padding:7px;border-radius:var(--r-1)}
+.acts .accept{background:var(--accent);color:var(--accent-fg);border-color:transparent}
+.acts .accept:hover{background:var(--accent-hover)}
+.acts .reject{color:var(--ink-3)}
+.promoted{display:flex;align-items:center;gap:7px;margin-top:11px;font-size:11.5px;color:var(--ok);background:var(--ok-weak);border-radius:var(--r-1);padding:7px 9px}
+.needclar{display:inline-flex;align-items:center;gap:5px;font-size:10.5px;color:var(--warn);background:var(--warn-weak);border-radius:var(--r-pill);padding:2px 8px;margin-top:8px}
+</style>
+</head>
+<body>
+<div class="app">
+  <div class="topbar">
+    <div class="brand"><span class="mark"></span> Shade</div>
+    <div class="ws"><b>Acme</b> Shade ▾</div>
+    <div class="crumb"><b>Console</b> / Second Brain · Intake</div>
+    <div class="spacer"></div>
+    <div class="search">⌕ Search objects… <kbd>⌘K</kbd></div>
+    <div class="avatar" style="background:var(--human-weak);color:var(--ink-1)">CT</div>
+  </div>
+
+  <div class="body">
+    <nav class="rail">
+      <div class="grp label">Console</div>
+      <a class="nav" href="agent-fleet.html"><span class="ic">◈</span> Fleet <span class="ct">14</span></a>
+      <a class="nav" href="gate-traceability.html"><span class="ic">⛨</span> Gates <span class="ct">3</span></a>
+      <a class="nav on"><span class="ic">◍</span> Second Brain</a>
+      <a class="nav"><span class="ic">≋</span> Activity</a>
+      <hr/>
+      <div class="grp label">Backbone <span style="color:var(--ink-4);font-weight:500;text-transform:none;letter-spacing:0">· Huly + overlay</span></div>
+      <a class="nav"><span class="ic">◧</span> Tracker</a>
+      <a class="nav"><span class="ic">▤</span> Documents</a>
+      <a class="nav"><span class="ic">▦</span> Specs · QMS</a>
+      <a class="nav"><span class="ic">◫</span> Test Mgmt</a>
+      <div style="flex:1"></div>
+      <div class="hint">Prism · intake engine idle</div>
+    </nav>
+
+    <main class="main">
+      <!-- conversation transcript -->
+      <section class="convo">
+        <div class="cvh">
+          <h1>Discovery call — Checkout &amp; billing scope</h1>
+          <div class="meta">
+            <span class="src">▶ Call transcript</span>
+            <span class="src">◫ ingested via Google Drive MCP</span>
+            <span>2026-06-12 · 41 min · 2 participants</span>
+            <span style="margin-left:auto"><span class="mono" style="color:var(--accent)">6</span> items extracted by Prism</span>
+          </div>
+        </div>
+        <div class="transcript" id="transcript">
+          <div class="turn">
+            <span class="sav" style="background:var(--accent-weak);color:var(--accent)">DO</span>
+            <div class="body"><div class="who">Dana · ops lead (client) <span class="t">14:21:40</span></div>
+            <p>So the biggest thing for us on checkout — <mark class="cited" data-item="REQ-014">the order total has to be exact to the cent. No rounding surprises when the customer gets to the till.</mark> We've been burned by that before with floating-point math.</p></div>
+          </div>
+          <div class="turn">
+            <span class="sav" style="background:var(--human-weak);color:var(--ink-1)">SA</span>
+            <div class="body"><div class="who">Sam · delivery analyst <span class="t">14:22:10</span></div>
+            <p>Understood — we'll model money as integer cents end-to-end. What about payment retries?</p></div>
+          </div>
+          <div class="turn">
+            <span class="sav" style="background:var(--accent-weak);color:var(--accent)">DO</span>
+            <div class="body"><div class="who">Dana · ops lead (client) <span class="t">14:23:02</span></div>
+            <p>Right — <mark class="cited" data-item="REQ-030">a payment must be safe to retry. If the network hiccups and the request goes twice, the customer must never be double-charged.</mark> That's non-negotiable.</p></div>
+          </div>
+          <div class="turn">
+            <span class="sav" style="background:var(--accent-weak);color:var(--accent)">DO</span>
+            <div class="body"><div class="who">Dana · ops lead (client) <span class="t">14:25:30</span></div>
+            <p>Also the current flow is three separate pages and people drop off. <mark class="cited" data-item="WI-88">Ideally checkout collapses into one page you can review before paying.</mark></p></div>
+          </div>
+          <div class="turn">
+            <span class="sav" style="background:var(--human-weak);color:var(--ink-1)">SA</span>
+            <div class="body"><div class="who">Sam · delivery analyst <span class="t">14:27:05</span></div>
+            <p>Good. On the finance side — anything the invoice must show?</p></div>
+          </div>
+          <div class="turn">
+            <span class="sav" style="background:var(--accent-weak);color:var(--accent)">DO</span>
+            <div class="body"><div class="who">Dana · ops lead (client) <span class="t">14:27:48</span></div>
+            <p>Yes — <mark class="cited" data-item="SPEC-12">every invoice needs the tax broken out as its own line and it has to reference the purchase-order number.</mark> Finance reconciles against the PO.</p></div>
+          </div>
+          <div class="turn">
+            <span class="sav" style="background:var(--accent-weak);color:var(--accent)">DO</span>
+            <div class="body"><div class="who">Dana · ops lead (client) <span class="t">14:33:12</span></div>
+            <p>Oh — and one warning. <mark class="cited risk" data-item="RISK-05">Last quarter our public search endpoint got hammered by a bot and it took the whole portal down. There's no rate limit on it today.</mark> Whatever you build, don't repeat that.</p></div>
+          </div>
+          <div class="turn">
+            <span class="sav" style="background:var(--accent-weak);color:var(--accent)">DO</span>
+            <div class="body"><div class="who">Dana · ops lead (client) <span class="t">14:38:55</span></div>
+            <p>Down the road <mark class="cited low" data-item="REQ-047">we might want to export everything to our accounting system</mark>, but honestly that's a maybe — don't hold up phase one for it.</p></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- extracted items -->
+      <section class="xpane">
+        <div class="xph">
+          <div class="t"><h2>Extracted items</h2><span class="mono" style="margin-left:auto;color:var(--ink-3);font-size:11px">6 cited</span></div>
+          <div class="filters">
+            <button class="on" data-f="all">All</button>
+            <button data-f="req">Requirements</button>
+            <button data-f="wi">Work-items</button>
+            <button data-f="spec">Specs</button>
+            <button data-f="risk">Risks</button>
+          </div>
+        </div>
+        <div class="xlist" id="xlist"></div>
+      </section>
+    </main>
+  </div>
+</div>
+
+<script>
+const ITEMS=[
+  {id:'REQ-014',type:'req',tb:'Requirement',stmt:'Order totals must be exact to the cent — no rounding error at any step.',conf:96,who:'Dana · ops lead',ts:'14:21:40',ground:['money → integer cents','rounding policy'],dest:'Tracker · REQ-014'},
+  {id:'REQ-030',type:'req',tb:'Requirement',stmt:'Payments must be idempotent — a retried request never double-charges.',conf:94,who:'Dana · ops lead',ts:'14:23:02',ground:['payments API','idempotency keys'],dest:'Tracker · REQ-030'},
+  {id:'WI-88',type:'wi',tb:'Work-item',stmt:'Collapse the 3-step checkout into a single reviewable page.',conf:78,who:'Dana · ops lead',ts:'14:25:30',ground:['checkout flow','conversion'],dest:'Tracker · WI-88'},
+  {id:'SPEC-12',type:'spec',tb:'Spec',stmt:'Invoices must itemise tax on its own line and reference the PO number.',conf:88,who:'Dana · ops lead',ts:'14:27:48',ground:['invoice template','tax rules','PO matching'],dest:'Specs · SPEC-12 (draft)'},
+  {id:'RISK-05',type:'risk',tb:'Risk',stmt:'Public search endpoint has no rate limit — prior outage under bot load.',conf:91,who:'Dana · ops lead',ts:'14:33:12',ground:['search endpoint','rate limiting','incident'],dest:'Tracker · RISK-05'},
+  {id:'REQ-047',type:'req',tb:'Requirement',stmt:'Possible future: export data to the accounting system (out of phase 1).',conf:44,who:'Dana · ops lead',ts:'14:38:55',ground:['accounting export'],dest:null,clar:true}
+];
+const list=document.getElementById('xlist');
+let sel=null;
+
+function confColor(c){return c>=80?'var(--accent)':(c>=60?'var(--warn)':'var(--risk)');}
+
+function render(filter='all'){
+  list.innerHTML='';
+  ITEMS.filter(it=>filter==='all'||it.type===filter).forEach(it=>{
+    const el=document.createElement('div');el.className='xitem'+(sel===it.id?' sel':'');el.dataset.id=it.id;
+    el.innerHTML=`
+      <div class="xh"><span class="tbadge tb-${it.type}">${it.tb}</span><span class="xid">${it.id}</span></div>
+      <div class="xstmt">${it.stmt}</div>
+      ${it.clar?'<span class="needclar">⚑ needs clarification · low confidence</span>':''}
+      <div class="conf"><span class="bar"><i style="width:${it.conf}%;background:${confColor(it.conf)}"></i></span><span class="pc">${it.conf}% confidence</span></div>
+      <div class="grounding">${it.ground.map(g=>`<span class="gchip">${g}</span>`).join('')}</div>
+      <div class="prov">
+        <div class="pt">◍ Provenance — cited from <b style="color:var(--ink-2)">${it.who}</b> · <span class="mono">${it.ts}</span> · Discovery call</div>
+        <div class="trail">
+          <span class="tstep origin">call span</span><span class="arr">→</span>
+          <span class="tstep">${it.id}</span><span class="arr">→</span>
+          <span class="tstep" id="dest-${it.id}">${it.dest?it.dest:'(not promoted)'}</span>
+        </div>
+        <div class="acts" id="acts-${it.id}">
+          <button class="accept" onclick="promote(event,'${it.id}')">Accept &amp; promote</button>
+          <button onclick="event.stopPropagation()">Edit</button>
+          <button class="reject" onclick="reject(event,'${it.id}')">Reject</button>
+        </div>
+      </div>`;
+    el.addEventListener('click',()=>select(it.id));
+    list.appendChild(el);
+  });
+  // restore promoted visual state
+  ITEMS.forEach(it=>{ if(it._done) markPromoted(it.id,it._done); });
+}
+function select(id){
+  sel=id;render(curFilter);
+  document.querySelectorAll('mark.cited').forEach(m=>m.classList.remove('active'));
+  const m=document.querySelector(`mark.cited[data-item="${id}"]`);
+  if(m){m.classList.add('active');m.scrollIntoView({behavior:'smooth',block:'center'});}
+  // scroll the selected card into view within its pane
+  const card=document.querySelector(`.xitem[data-id="${id}"]`);
+  if(card)card.scrollIntoView({behavior:'smooth',block:'nearest'});
+}
+function promote(e,id){
+  e.stopPropagation();const it=ITEMS.find(x=>x.id===id);
+  it._done='accept';markPromoted(id,'accept');
+}
+function reject(e,id){
+  e.stopPropagation();const it=ITEMS.find(x=>x.id===id);
+  it._done='reject';markPromoted(id,'reject');
+}
+function markPromoted(id,kind){
+  const acts=document.getElementById('acts-'+id);const dest=document.getElementById('dest-'+id);
+  const it=ITEMS.find(x=>x.id===id);
+  if(!acts)return;
+  if(kind==='accept'){
+    acts.outerHTML=`<div class="promoted">✓ Promoted to <b style="color:var(--ink-1);margin-left:3px">${it.dest||'Tracker'}</b> · conversation→requirement link created</div>`;
+    if(dest)dest.style.color='var(--ok)';
+  }else{
+    acts.outerHTML=`<div class="promoted" style="color:var(--ink-3);background:var(--surface-4)">✕ Rejected · logged with reason to audit trail</div>`;
+  }
+}
+// clicking a highlighted span selects its card
+document.querySelectorAll('mark.cited').forEach(m=>{
+  m.addEventListener('click',()=>select(m.dataset.item));
+});
+// filters
+let curFilter='all';
+document.querySelectorAll('.filters button').forEach(b=>{
+  b.addEventListener('click',()=>{
+    document.querySelectorAll('.filters button').forEach(x=>x.classList.remove('on'));b.classList.add('on');
+    curFilter=b.dataset.f;render(curFilter);
+  });
+});
+render();
+select('REQ-014');
+</script>
+</body>
+</html>


### PR DESCRIPTION
- docs/4c-shade/: vision brief, decision log, licensing & entity structure, index
- CLAUDE.md: HH Shade project memory (force-tracked; upstream gitignored it)
- docs/hh-shade/CONTEXT.md: instance context (Dibbits build, sibling repos, alpha status)

Establishes this repo's identity as HH Shade, the Hardscape House deployment of 4C Shade (by 4C Digital). No platform/source changes.

Claude-Session: https://claude.ai/code/session_01Wi5ywDCQ3PytwHmBXdNmhp