### PR TITLE
fix(github): recover write access when user OAuth token expires

### DIFF
--- a/services/github/pod-github/src/platform.ts
+++ b/services/github/pod-github/src/platform.ts
@@ -738,7 +738,7 @@ export class PlatformWorker {
   }
 
   async checkRefreshToken (ctx: MeasureContext, auth: GithubUserRecord, force: boolean = false): Promise<boolean> {
-    if (auth.refreshToken != null && auth.expiresIn != null && auth.expiresIn < Date.now() / 1000) {
+    if (auth.refreshToken != null && (force || (auth.expiresIn != null && auth.expiresIn < Date.now() / 1000))) {
       const uri =
         'https://github.com/login/oauth/access_token?' +
         makeQuery({

--- a/services/github/pod-github/src/users.ts
+++ b/services/github/pod-github/src/users.ts
@@ -36,11 +36,12 @@ export class UserManager {
   }
 
   private secretToUserRecord (secret: IntegrationSecret, login: string): GithubUserRecord | undefined {
+    const parsed = JSON.parse(secret.secret) ?? {}
     return {
-      ...(JSON.parse(secret.secret) ?? {}), // TODO: Add security
+      ...parsed, // TODO: Add security
       account: secret.socialId,
       _id: login,
-      accounts: {}
+      accounts: parsed.accounts ?? {}
     }
   }
 

--- a/services/github/pod-github/src/worker.ts
+++ b/services/github/pod-github/src/worker.ts
@@ -642,7 +642,11 @@ export class GithubWorker implements IntegrationManager {
     if (record !== undefined) {
       ctx.info('get octokit', { account, recordId: record._id, workspace: this.workspace.uuid })
       if (!(await this.platform.checkRefreshToken(ctx, record))) {
+        // Token is invalid and could not be refreshed: report no octokit so
+        // callers fall back to the installation token instead of using a
+        // client with dead credentials.
         record.octokit = undefined
+        return undefined
       }
       if (record.octokit !== undefined) {
         return record.octokit


### PR DESCRIPTION
Fixes #10994

## What changed

When a user's GitHub OAuth token became invalid, the integration entered a permanent write-failure state (`401 Bad credentials` on every Huly → GitHub write). Three small defects in `services/github/pod-github` each disabled a recovery mechanism the code already has:

1. **`worker.ts` — `getOctokit` returned a dead-token Octokit.** After `checkRefreshToken` returned `false`, the code cleared the cached instance but then rebuilt a new `Octokit` from the same invalid `record.token`. It now returns `undefined` in that case, so the existing `?? container.container.octokit` installation-token fallback at every call site becomes reachable and writes succeed.

2. **`users.ts` — `secretToUserRecord` clobbered the persisted `accounts` map with `{}`** (the spread came first). That made `revokeUserAuth` iterate an empty object — a structural no-op — so cleanup never ran and the `AuthenticatedWithGithubRequired` re-auth notification never reached the user. The parsed value is now preserved (`parsed.accounts ?? {}`), matching what the OAuth callback persists.

3. **`platform.ts` — `checkRefreshToken` never read its `force` parameter**, so the deliberate forced refresh in `syncUsers` (`worker.ts`) did nothing. `force === true` now triggers a refresh regardless of expiry when a refresh token is present.

## Verification

- `rush validate --to pod-github` — clean
- `rush format --to pod-github` — no changes
- `rushx test` in pod-github — 4 suites, 77 tests passed

https://claude.ai/code/session_01ANdoXbdn5k2hZy734EwKe7