### PR TITLE
account: include pending-deletion workspaces in getPendingWorkspace 'all' operation

### DIFF
--- a/server/account/src/__tests__/mongo.test.ts
+++ b/server/account/src/__tests__/mongo.test.ts
@@ -1011,6 +1011,22 @@ describe('MongoAccountDB', () => {
         )
       })
 
+      it('should get workspace for all operations including pending-deletion', async () => {
+        await accountDb.getPendingWorkspace('', version, 'all', processingTimeoutMs)
+
+        // The query should match pending-deletion / deleting workspaces too
+        const callArgs = (accountDb.workspace.collection.findOneAndUpdate as jest.Mock).mock.calls[0][0]
+        const orClauses = callArgs.$and[1].$or
+        const flatOrs = orClauses.flatMap((c: any) => (c.$or ? c.$or : [c]))
+        const deletingClause = flatOrs.find(
+          (c: any) => c['status.mode']?.$in?.includes('pending-deletion')
+        )
+        expect(deletingClause).toBeDefined()
+        expect(deletingClause['status.mode'].$in).toEqual(
+          expect.arrayContaining(['pending-deletion', 'deleting'])
+        )
+      })
+
       it('should get workspace for all+backup operations', async () => {
         await accountDb.getPendingWorkspace('', version, 'all+backup', processingTimeoutMs)
 

--- a/server/account/src/__tests__/postgres.test.ts
+++ b/server/account/src/__tests__/postgres.test.ts
@@ -795,10 +795,11 @@ describe('PostgresAccountDB', () => {
                     OR
                     (
                       (s.is_disabled = FALSE OR s.is_disabled IS NULL)
-                      AND s.mode = 'upgrading'
+AND s.mode = 'upgrading'
                     )
                   )
-               )
+                  OR s.mode IN ('pending-deletion', 'deleting')
+                )
                AND s.mode <> 'manual-creation'
                AND (s.processing_attempts IS NULL OR s.processing_attempts <= 3)
                AND (s.last_processing_time IS NULL OR s.last_processing_time < $5)

--- a/server/account/src/collections/mongo.ts
+++ b/server/account/src/collections/mongo.ts
@@ -740,7 +740,7 @@ export class MongoAccountDB implements AccountDB {
         operationQuery = { $or: pendingUpgradeQuery }
         break
       case 'all':
-        operationQuery = { $or: [...pendingCreationQuery, ...pendingUpgradeQuery] }
+        operationQuery = { $or: [...pendingCreationQuery, ...pendingUpgradeQuery, ...deletingQuery] }
         break
       case 'all+backup':
         operationQuery = {

--- a/server/account/src/collections/postgres/postgres.ts
+++ b/server/account/src/collections/postgres/postgres.ts
@@ -999,7 +999,7 @@ export class PostgresAccountDB implements AccountDB {
         operationSql = pendingUpgradeSql
         break
       case 'all':
-        operationSql = `(${pendingCreationSql} OR ${pendingUpgradeSql})`
+        operationSql = `(${pendingCreationSql} OR ${pendingUpgradeSql} OR ${deletingSql})`
         break
       case 'all+backup':
         operationSql = `(${pendingCreationSql} OR ${pendingUpgradeSql} OR ${migrationSql} OR ${archivingSql} OR ${restoringSql} OR ${deletingSql})`
@@ -1015,8 +1015,6 @@ export class PostgresAccountDB implements AccountDB {
     }
     whereChunks.push(operationSql)
 
-    // TODO: support returning pending deletion workspaces when we will actually want
-    // to clear them with the worker.
     whereChunks.push("s.mode <> 'manual-creation'")
     whereChunks.push('(s.processing_attempts IS NULL OR s.processing_attempts <= 3)')
     whereChunks.push(`(s.last_processing_time IS NULL OR s.last_processing_time < $${values.length + 1})`)


### PR DESCRIPTION
## Context

The `getPendingWorkspace` query supports an `'all'` operation that selects workspaces pending any worker action. It only matched workspaces pending creation or upgrade, so workspaces waiting on deletion were never picked up by the worker and just sat there. The `'all+backup'` branch already includes the deletion clause, so this is a missing entry rather than a new behavior.

## Implementation

In `server/account/src/collections/mongo.ts`, the `'all'` case now spreads `deletingQuery` into the existing or-clauses. In `server/account/src/collections/postgres/postgres.ts`, the `'all'` SQL now ORs in the existing `deletingSql`, matching the pattern used for pending creation and upgrade. The stale TODO comment about returning pending deletion workspaces was removed.

## Tests

Updated the `'all'` SQL snapshot in `postgres.test.ts` to include the new clause and added a focused test in `mongo.test.ts` that asserts the `'all'` operation's or-array contains a `status.mode $in ['pending-deletion', 'deleting']` clause.