### PR TITLE
feat(drive): download folder as archive

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -20361,6 +20361,9 @@ importers:
       fast-equals:
         specifier: ^5.2.2
         version: 5.3.2
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
       svelte:
         specifier: ^4.2.20
         version: 4.2.20
@@ -47614,6 +47617,9 @@ packages:
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   file-api@0.10.4:
     resolution: {integrity: sha512-RVBXJGmsnQxokdpy264pmsdBjbUuxE6QT2xxhOrO2pzwTetbTNoWVFgkONFWmopm5mellsXrQIQhMY9fjufi9g==}
 
@@ -59263,6 +59269,8 @@ snapshots:
       pend: 1.2.0
 
   fecha@4.2.3: {}
+
+  fflate@0.8.3: {}
 
   file-api@0.10.4:
     dependencies:

--- a/models/drive/src/index.ts
+++ b/models/drive/src/index.ts
@@ -511,6 +511,24 @@ function defineFolder (builder: Builder): void {
   createAction(
     builder,
     {
+      action: drive.actionImpl.DownloadFolder,
+      label: drive.string.DownloadAsArchive,
+      icon: drive.icon.Download,
+      category: drive.category.Drive,
+      input: 'none',
+      target: drive.class.Folder,
+      context: {
+        mode: ['context', 'browser'],
+        application: drive.app.Drive,
+        group: 'tools'
+      }
+    },
+    drive.action.DownloadFolder
+  )
+
+  createAction(
+    builder,
+    {
       action: drive.actionImpl.RenameFolder,
       label: drive.string.Rename,
       icon: view.icon.Edit,

--- a/models/drive/src/plugin.ts
+++ b/models/drive/src/plugin.ts
@@ -85,6 +85,7 @@ export default mergeIds(driveId, drive, {
     CreateRootFolder: '' as Ref<Action>,
     EditDrive: '' as Ref<Action>,
     DownloadFile: '' as Ref<Action>,
+    DownloadFolder: '' as Ref<Action>,
     DeleteFile: '' as Ref<Action>,
     DeleteFolder: '' as Ref<Action>,
     RenameFile: '' as Ref<Action>,
@@ -97,6 +98,7 @@ export default mergeIds(driveId, drive, {
     CreateRootFolder: '' as ViewAction,
     EditDrive: '' as ViewAction,
     DownloadFile: '' as ViewAction,
+    DownloadFolder: '' as ViewAction,
     RenameFile: '' as ViewAction,
     RenameFolder: '' as ViewAction,
     RestoreFileVersion: '' as ViewAction

--- a/plugins/drive-assets/lang/en.json
+++ b/plugins/drive-assets/lang/en.json
@@ -19,6 +19,7 @@
     "ContentType": "Content type",
     "LastModified": "Last Modified",
     "Download": "Download",
+    "DownloadAsArchive": "Download as archive",
     "Upload": "Upload",
     "CreateDrive": "Create Drive",
     "CreateFolder": "Create Folder",

--- a/plugins/drive-assets/lang/ru.json
+++ b/plugins/drive-assets/lang/ru.json
@@ -19,6 +19,7 @@
     "ContentType": "Тип содержимого",
     "LastModified": "Последнее изменение",
     "Download": "Скачать",
+    "DownloadAsArchive": "Скачать архивом",
     "Upload": "Загрузить",
     "CreateDrive": "Создать диск",
     "CreateFolder": "Создать папку",

--- a/plugins/drive-resources/package.json
+++ b/plugins/drive-resources/package.json
@@ -50,6 +50,7 @@
     "@hcengineering/view": "workspace:^0.7.0",
     "@hcengineering/view-resources": "workspace:^0.7.0",
     "svelte": "^4.2.20",
-    "fast-equals": "^5.2.2"
+    "fast-equals": "^5.2.2",
+    "fflate": "^0.8.2"
   }
 }

--- a/plugins/drive-resources/src/archive.ts
+++ b/plugins/drive-resources/src/archive.ts
@@ -1,0 +1,164 @@
+//
+// Copyright © 2025 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { SortingOrder, type Ref, type Timestamp } from '@hcengineering/core'
+import drive, { type FileVersion, type Folder } from '@hcengineering/drive'
+import { setPlatformStatus, unknownError } from '@hcengineering/platform'
+import { getClient, getFileUrl } from '@hcengineering/presentation'
+import { Zip, ZipPassThrough } from 'fflate'
+
+interface ArchiveEntry {
+  path: string
+  version: FileVersion
+  mtime: Timestamp
+}
+
+/** Replace path separators so a file title cannot escape its folder inside the archive. */
+function sanitizeName (title: string): string {
+  return title.replace(/[\\/]/g, '_')
+}
+
+/** Resolve duplicate titles within the same folder by appending a numeric suffix. */
+function uniquePath (path: string, used: Set<string>): string {
+  if (!used.has(path)) {
+    used.add(path)
+    return path
+  }
+  const slash = path.lastIndexOf('/')
+  const dot = path.lastIndexOf('.')
+  const base = dot > slash ? path.slice(0, dot) : path
+  const ext = dot > slash ? path.slice(dot) : ''
+  for (let index = 1; ; index++) {
+    const candidate = `${base} (${index})${ext}`
+    if (!used.has(candidate)) {
+      used.add(candidate)
+      return candidate
+    }
+  }
+}
+
+async function collectFiles (
+  folder: Folder,
+  prefix: string,
+  entries: ArchiveEntry[],
+  used: Set<string>,
+  visited: Set<Ref<Folder>>
+): Promise<void> {
+  if (visited.has(folder._id)) {
+    return
+  }
+  visited.add(folder._id)
+
+  const client = getClient()
+
+  const files = await client.findAll(
+    drive.class.File,
+    { space: folder.space, parent: folder._id },
+    { lookup: { file: drive.class.FileVersion }, sort: { title: SortingOrder.Ascending } }
+  )
+  for (const file of files) {
+    const version = file.$lookup?.file
+    if (version != null) {
+      entries.push({
+        path: uniquePath(prefix + sanitizeName(file.title), used),
+        version,
+        mtime: file.modifiedOn
+      })
+    }
+  }
+
+  const folders = await client.findAll(
+    drive.class.Folder,
+    { space: folder.space, parent: folder._id },
+    { sort: { title: SortingOrder.Ascending } }
+  )
+  for (const sub of folders) {
+    await collectFiles(sub, prefix + sanitizeName(sub.title) + '/', entries, used, visited)
+  }
+}
+
+async function createArchive (entries: ArchiveEntry[]): Promise<Blob> {
+  const chunks: Uint8Array[] = []
+
+  let resolveDone: () => void
+  let rejectDone: (err: Error) => void
+  const done = new Promise<void>((resolve, reject) => {
+    resolveDone = resolve
+    rejectDone = reject
+  })
+
+  const zip = new Zip((err, chunk, final) => {
+    if (err != null) {
+      rejectDone(err)
+      return
+    }
+    chunks.push(chunk)
+    if (final) {
+      resolveDone()
+    }
+  })
+
+  try {
+    for (const entry of entries) {
+      // Blobs in Drive are stored already compressed or incompressible more often
+      // than not (archives, media, build artifacts), so store them as-is instead
+      // of spending CPU on deflate.
+      const item = new ZipPassThrough(entry.path)
+      item.mtime = entry.mtime
+      zip.add(item)
+
+      const response = await fetch(getFileUrl(entry.version.file, entry.version.title))
+      if (!response.ok) {
+        throw new Error(`Failed to download ${entry.path}: HTTP ${response.status}`)
+      }
+      item.push(new Uint8Array(await response.arrayBuffer()), true)
+    }
+    zip.end()
+  } catch (err: any) {
+    done.catch(() => {})
+    zip.terminate()
+    throw err
+  }
+
+  await done
+  return new Blob(chunks, { type: 'application/zip' })
+}
+
+/** Download a folder from Drive as a single zip archive preserving the folder structure. */
+export async function downloadFolderArchive (doc: Folder | Folder[]): Promise<void> {
+  const folders = Array.isArray(doc) ? doc : [doc]
+  for (const folder of folders) {
+    try {
+      const entries: ArchiveEntry[] = []
+      await collectFiles(folder, '', entries, new Set(), new Set())
+      if (entries.length === 0) {
+        continue
+      }
+
+      const blob = await createArchive(entries)
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.style.display = 'none'
+      link.href = url
+      link.download = sanitizeName(folder.title) + '.zip'
+      link.click()
+      setTimeout(() => {
+        URL.revokeObjectURL(url)
+      }, 60 * 1000)
+    } catch (err: any) {
+      await setPlatformStatus(unknownError(err))
+    }
+  }
+}

--- a/plugins/drive-resources/src/index.ts
+++ b/plugins/drive-resources/src/index.ts
@@ -42,6 +42,7 @@ import GridView from './components/GridView.svelte'
 import MoveResource from './components/MoveResource.svelte'
 import ResourcePresenter from './components/ResourcePresenter.svelte'
 
+import { downloadFolderArchive } from './archive'
 import { getDriveLink, getFileLink, getFolderLink, resolveLocation } from './navigation'
 import { restoreFileVersion, showCreateFolderPopup, showRenameResourcePopup } from './utils'
 
@@ -123,6 +124,10 @@ async function DownloadFile (doc: WithLookup<File> | Array<WithLookup<File>>): P
       link.click()
     }
   }
+}
+
+async function DownloadFolder (doc: Folder | Folder[]): Promise<void> {
+  await downloadFolderArchive(doc)
 }
 
 async function DriveLinkProvider (doc: Doc): Promise<Location> {
@@ -285,6 +290,7 @@ export default async (): Promise<Resources> => ({
     CreateRootFolder,
     EditDrive,
     DownloadFile,
+    DownloadFolder,
     RenameFile,
     RenameFolder,
     RestoreFileVersion

--- a/plugins/drive-resources/src/plugin.ts
+++ b/plugins/drive-resources/src/plugin.ts
@@ -22,6 +22,7 @@ export default mergeIds(driveId, drive, {
     CreateFolder: '' as IntlString,
     UploadFile: '' as IntlString,
     Download: '' as IntlString,
+    DownloadAsArchive: '' as IntlString,
     Upload: '' as IntlString,
     EditDrive: '' as IntlString,
     Rename: '' as IntlString,


### PR DESCRIPTION
## Description

Adds a **Download as archive** action for folders in the Drive module. Previously only
individual files could be downloaded; folders with many files (e.g. build artifacts)
had to be fetched one file at a time.

The action walks the folder tree through the platform client, fetches every file blob
and packs everything into a single `<folder name>.zip` on the client, preserving the
relative folder structure inside the archive.

### Implementation notes

- **New action** `drive.action.DownloadFolder` / `drive.actionImpl.DownloadFolder`,
  registered for `drive.class.Folder` next to the existing file `Download` action
  (same category, `tools` group, context + browser modes).
- **Traversal** (`plugins/drive-resources/src/archive.ts`): recursive
  `client.findAll` over `drive.class.File` (with `$lookup` of the current
  `FileVersion`) and `drive.class.Folder`, sorted by title for deterministic
  archives. A visited-set guards against cycles, and duplicate titles within one
  folder get a numeric suffix.
- **Blob access** reuses `getFileUrl` from `@hcengineering/presentation` (the same
  URL the file `Download` action uses) and plain `fetch`, matching how
  `getJsonOrEmpty` fetches blobs elsewhere in the platform.
- **Zip library**: [`fflate`](https://www.npmjs.com/package/fflate) (`^0.8.2`), added
  to `@hcengineering/drive-resources`. No workspace package currently depends on a
  zip library directly (`jszip` appears in the lockfile only as a transitive
  dependency of docx tooling), so the smallest streaming option was chosen.
  Entries are added via `ZipPassThrough` (store, no re-compression): Drive blobs are
  typically already compressed or incompressible (archives, media, build artifacts),
  so this keeps CPU usage minimal while still producing a standard zip.
- Files are fetched sequentially; the archive is assembled in memory and saved via a
  temporary object URL. Empty folders produce no download. Errors are reported through
  `setPlatformStatus(unknownError(...))`, consistent with other drive-resources utils.
- **Localization**: new `DownloadAsArchive` string (en: "Download as archive",
  ru: "Скачать архивом"). Other locales fall back to English, matching existing
  partially-translated keys in `drive-assets`.

### Changed files

- `models/drive/src/index.ts` — register the folder action
- `models/drive/src/plugin.ts` — `action.DownloadFolder`, `actionImpl.DownloadFolder` ids
- `plugins/drive-resources/src/archive.ts` — new: traversal + zip + save
- `plugins/drive-resources/src/index.ts` — `DownloadFolder` action implementation
- `plugins/drive-resources/src/plugin.ts` — `DownloadAsArchive` string id
- `plugins/drive-resources/package.json` — add `fflate`
- `plugins/drive-assets/lang/en.json`, `plugins/drive-assets/lang/ru.json` — new string
- `common/config/rush/pnpm-lock.yaml` — lockfile update for `fflate`

## How to test

1. Open a workspace with the Drive application enabled.
2. Create a drive, add a folder with a few files and at least one nested subfolder
   with files (mixed types; ideally also two files with the same name in one folder).
3. Right-click the folder (or use the `...` menu) → **Download as archive**.
4. A `<folder name>.zip` download should start; after extraction the content must
   mirror the Drive folder structure, including nested subfolders.
5. Verify an empty folder triggers no download, and a folder whose name contains
   `/` or `\` still produces a valid archive name.
6. Regression: file **Download**, folder **Rename**/**Delete**/**Move** actions
   still work.

## Checklist

- [x] Affected packages compile (`rush build --to @hcengineering/model-drive --to @hcengineering/drive-resources`)
- [x] Localized strings added (en, ru)
- [ ] Screenshots / screencast (to attach when opening the PR)
