### PR TITLE
fix(notification): stamp matched types and provider cache in getCommonNotificationTxes

### DIFF
--- a/server-plugins/notification-resources/src/__tests__/commonNotificationTypes.test.ts
+++ b/server-plugins/notification-resources/src/__tests__/commonNotificationTypes.test.ts
@@ -1,0 +1,348 @@
+//
+// Copyright © 2026 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { type Employee, type PersonSpace } from '@hcengineering/contact'
+import core, {
+  TxFactory,
+  type AccountUuid,
+  type Class,
+  type Doc,
+  type PersonId,
+  type Ref,
+  type Space,
+  type Tx,
+  type TxCreateDoc,
+  type TxCUD
+} from '@hcengineering/core'
+import notification, {
+  type CommonInboxNotification,
+  type DocNotifyContext,
+  type InboxNotification,
+  type NotificationProvider,
+  type NotificationType
+} from '@hcengineering/notification'
+import { type TriggerControl } from '@hcengineering/server-core'
+import { type ReceiverInfo, type SenderInfo } from '@hcengineering/server-notification'
+
+import { getCommonNotificationTxes, pushInboxNotifications } from '../index'
+import { AvailableProvidersCacheKey, type AvailableProvidersCache, type NotifyResult } from '../types'
+import { NotificationProviderControl, isShouldNotifyTx } from '../utils'
+
+// Wire ids, not imported symbols: this package depends on neither
+// @hcengineering/time nor the fork's model-matrix, and adding a package
+// dependency to a test is a worse trade than a literal. Same convention the
+// fork's `_huly/models/matrix/src/notificationTypes.ts` documents.
+const TODO_CREATED = 'time:ids:ToDoCreated' as Ref<NotificationType>
+const PROJECT_TODO = 'time:class:ProjectToDo' as Ref<Class<Doc>>
+const DM_NOTIFICATION = 'chunter:ids:DMNotification' as Ref<NotificationType>
+const MATRIX_PROVIDER = 'matrix:providers:MatrixNotificationProvider' as Ref<NotificationProvider>
+const MATRIX_NEW_MESSAGE = 'matrix:ids:NewMessageNotification' as Ref<NotificationType>
+
+const RECEIVER: ReceiverInfo = {
+  account: 'account-clay' as AccountUuid,
+  employee: 'employee-clay' as Ref<Employee>,
+  role: 'USER',
+  socialIds: ['social-clay' as PersonId],
+  space: 'personspace-clay' as Ref<PersonSpace>
+}
+
+const SENDER: SenderInfo = { socialId: 'social-bot' as PersonId }
+
+const OBJECT_ID = 'todo-parent-issue' as Ref<Doc>
+const OBJECT_CLASS = 'tracker:class:Issue' as Ref<Class<Doc>>
+const OBJECT_SPACE = 'space-project' as Ref<Space>
+
+/** A pre-existing context, so the writer never takes the create-context branch. */
+const CONTEXT: DocNotifyContext = {
+  _id: 'ctx-1' as Ref<DocNotifyContext>,
+  _class: notification.class.DocNotifyContext,
+  space: RECEIVER.space,
+  objectId: OBJECT_ID,
+  objectClass: OBJECT_CLASS,
+  objectSpace: OBJECT_SPACE,
+  user: RECEIVER.account,
+  isPinned: false,
+  hidden: false,
+  modifiedOn: 1,
+  modifiedBy: SENDER.socialId
+} as unknown as DocNotifyContext
+
+interface Harness {
+  control: TriggerControl
+  contextCache: Map<string, any>
+}
+
+function harness (): Harness {
+  const contextCache = new Map<string, any>()
+  const control = {
+    ctx: { contextData: { broadcast: { txes: [] } } },
+    txes: [],
+    txFactory: new TxFactory(SENDER.socialId),
+    contextCache,
+    cache: new Map(),
+    removedMap: new Map(),
+    findAll: async () => [CONTEXT],
+    apply: async () => {}
+  } as unknown as TriggerControl
+
+  return { control, contextCache }
+}
+
+const measure = { contextData: { broadcast: { txes: [] } } } as any
+
+async function commonTxes (control: TriggerControl, notifyResult: NotifyResult): Promise<Tx[]> {
+  return await getCommonNotificationTxes(
+    measure,
+    control,
+    { _id: OBJECT_ID, _class: OBJECT_CLASS, space: OBJECT_SPACE } as unknown as Doc,
+    { header: 'time:string:ToDo' as any },
+    RECEIVER,
+    SENDER,
+    OBJECT_ID,
+    OBJECT_CLASS,
+    OBJECT_SPACE,
+    1,
+    notifyResult,
+    notification.class.CommonInboxNotification
+  )
+}
+
+function created (txes: Tx[]): TxCreateDoc<CommonInboxNotification> {
+  const tx = txes.find(
+    (it) =>
+      it._class === core.class.TxCreateDoc &&
+      (it as TxCreateDoc<Doc>).objectClass === notification.class.CommonInboxNotification
+  )
+  expect(tx).toBeDefined()
+  return tx as TxCreateDoc<CommonInboxNotification>
+}
+
+function cacheOf (h: Harness): AvailableProvidersCache {
+  return h.contextCache.get(AvailableProvidersCacheKey) ?? new Map()
+}
+
+describe('getCommonNotificationTxes carries the matched types', () => {
+  it('stamps the ToDo type onto the notification it creates', async () => {
+    const h = harness()
+    const notifyResult: NotifyResult = new Map([
+      [notification.providers.InboxNotificationProvider, [{ _id: TODO_CREATED } as NotificationType]],
+      [MATRIX_PROVIDER, [{ _id: TODO_CREATED } as NotificationType]]
+    ])
+
+    const txes = await commonTxes(h.control, notifyResult)
+
+    expect(created(txes).attributes.types).toEqual([TODO_CREATED])
+  })
+
+  it('publishes the allowed providers so the messenger triggers can see the notification', async () => {
+    const h = harness()
+    const notifyResult: NotifyResult = new Map([
+      [notification.providers.InboxNotificationProvider, [{ _id: TODO_CREATED } as NotificationType]],
+      [MATRIX_PROVIDER, [{ _id: TODO_CREATED } as NotificationType]]
+    ])
+
+    const txes = await commonTxes(h.control, notifyResult)
+    const notificationTx = created(txes)
+
+    // Consumers look the entry up by the notification's own _id, which is the
+    // create tx's objectId — the same key `getNotificationTxes` writes.
+    expect(cacheOf(h).get(notificationTx.objectId as Ref<InboxNotification>)).toEqual([
+      notification.providers.InboxNotificationProvider,
+      MATRIX_PROVIDER
+    ])
+  })
+
+  it('does not invent a type for a genuinely typeless notification', async () => {
+    const h = harness()
+    const notifyResult: NotifyResult = new Map([[notification.providers.InboxNotificationProvider, []]])
+
+    const txes = await commonTxes(h.control, notifyResult)
+
+    expect(created(txes).attributes.types).toEqual([])
+  })
+
+  it('leaves a type out of the cache for a provider that did not allow it', async () => {
+    // The §16.2.2 loop-breaker shape: matrix's own NewMessageNotification is in
+    // the matrix provider's ignoredTypes, so isAllowed drops the provider and
+    // it must not reappear in the cache.
+    const h = harness()
+    const notifyResult: NotifyResult = new Map([
+      [notification.providers.InboxNotificationProvider, [{ _id: MATRIX_NEW_MESSAGE } as NotificationType]]
+    ])
+
+    const txes = await commonTxes(h.control, notifyResult)
+    const providers = cacheOf(h).get(created(txes).objectId as Ref<InboxNotification>)
+
+    expect(providers).toEqual([notification.providers.InboxNotificationProvider])
+    expect(providers).not.toContain(MATRIX_PROVIDER)
+  })
+
+  it('still writes nothing at all when the inbox provider is absent', async () => {
+    const h = harness()
+    const notifyResult: NotifyResult = new Map([[MATRIX_PROVIDER, [{ _id: TODO_CREATED } as NotificationType]]])
+
+    const txes = await commonTxes(h.control, notifyResult)
+
+    expect(txes).toEqual([])
+    expect(h.contextCache.get(AvailableProvidersCacheKey)).toBeUndefined()
+  })
+})
+
+describe('the activity path is unchanged', () => {
+  it('keeps writing the types it is handed', async () => {
+    // The shape pushActivityInboxNotifications passes through for the
+    // issue-activity and DM/Thread paths that already worked.
+    const h = harness()
+    const res: Tx[] = []
+
+    await pushInboxNotifications(
+      measure,
+      h.control,
+      res,
+      RECEIVER,
+      SENDER,
+      OBJECT_ID,
+      OBJECT_CLASS,
+      OBJECT_SPACE,
+      [CONTEXT],
+      {},
+      notification.class.ActivityInboxNotification,
+      1,
+      [DM_NOTIFICATION],
+      true
+    )
+
+    expect((res[0] as TxCreateDoc<InboxNotification>).attributes.types).toEqual([DM_NOTIFICATION])
+  })
+})
+
+// ————— the hypothesis this fix had to disprove —————
+//
+// The 2026-08-13 report blamed `getMatchedTypes` for attributing no type to a
+// ToDo's bare TxCreateDoc. It does attribute one; the type was being dropped
+// afterwards. These cases pin the matcher so the wrong suspect stays ruled out.
+
+interface ModelStub {
+  types: NotificationType[]
+  providers: NotificationProvider[]
+  defaults: Array<{
+    provider: Ref<NotificationProvider>
+    ignoredTypes: Array<Ref<NotificationType>>
+    enabledTypes: Array<Ref<NotificationType>>
+  }>
+}
+
+function matcherControl (model: ModelStub): TriggerControl {
+  return {
+    modelDb: {
+      findAllSync: (_class: Ref<Class<Doc>>) => {
+        if (_class === notification.class.NotificationType) return model.types
+        if (_class === notification.class.NotificationProvider) return model.providers
+        if (_class === notification.class.NotificationProviderDefaults) return model.defaults
+        return []
+      }
+    },
+    hierarchy: {
+      getBaseClass: (c: Ref<Class<Doc>>) => c,
+      isDerived: (a: Ref<Class<Doc>>, b: Ref<Class<Doc>>) => a === b,
+      hasMixin: () => false
+    }
+  } as unknown as TriggerControl
+}
+
+const todoCreatedType = {
+  _id: TODO_CREATED,
+  _class: notification.class.NotificationType,
+  txClasses: [core.class.TxCreateDoc],
+  objectClass: PROJECT_TODO,
+  onlyOwn: true,
+  allowedForAuthor: true,
+  defaultEnabled: false
+} as unknown as NotificationType
+
+const matrixProvider = {
+  _id: MATRIX_PROVIDER,
+  _class: notification.class.NotificationProvider,
+  defaultEnabled: true
+} as unknown as NotificationProvider
+
+const todoCreateTx = {
+  _class: core.class.TxCreateDoc,
+  objectClass: PROJECT_TODO,
+  objectId: 'todo-1' as Ref<Doc>,
+  modifiedBy: SENDER.socialId
+} as unknown as TxCUD<Doc>
+
+describe('getMatchedTypes on a bare ToDo TxCreateDoc', () => {
+  it('matches the ToDo type when the matrix provider enables it', async () => {
+    const control = matcherControl({
+      types: [todoCreatedType],
+      providers: [matrixProvider],
+      defaults: [{ provider: MATRIX_PROVIDER, ignoredTypes: [], enabledTypes: [TODO_CREATED] }]
+    })
+
+    const result = await isShouldNotifyTx(
+      control,
+      todoCreateTx,
+      { _id: 'todo-1' } as unknown as Doc,
+      RECEIVER,
+      true,
+      false,
+      new NotificationProviderControl([], [])
+    )
+
+    expect(result.get(MATRIX_PROVIDER)?.map((it) => it._id)).toEqual([TODO_CREATED])
+  })
+
+  it('drops the type when the provider ignores it, so filtering still governs delivery', async () => {
+    const control = matcherControl({
+      types: [todoCreatedType],
+      providers: [matrixProvider],
+      defaults: [{ provider: MATRIX_PROVIDER, ignoredTypes: [TODO_CREATED], enabledTypes: [] }]
+    })
+
+    const result = await isShouldNotifyTx(
+      control,
+      todoCreateTx,
+      { _id: 'todo-1' } as unknown as Doc,
+      RECEIVER,
+      true,
+      false,
+      new NotificationProviderControl([], [])
+    )
+
+    expect(result.has(MATRIX_PROVIDER)).toBe(false)
+  })
+
+  it('drops the type when it is neither enabled nor defaultEnabled', async () => {
+    const control = matcherControl({
+      types: [todoCreatedType],
+      providers: [matrixProvider],
+      defaults: [{ provider: MATRIX_PROVIDER, ignoredTypes: [], enabledTypes: [] }]
+    })
+
+    const result = await isShouldNotifyTx(
+      control,
+      todoCreateTx,
+      { _id: 'todo-1' } as unknown as Doc,
+      RECEIVER,
+      true,
+      false,
+      new NotificationProviderControl([], [])
+    )
+
+    expect(result.has(MATRIX_PROVIDER)).toBe(false)
+  })
+})

--- a/server-plugins/notification-resources/src/index.ts
+++ b/server-plugins/notification-resources/src/index.ts
@@ -114,8 +114,9 @@ export async function getCommonNotificationTxes (
 
   const res: Tx[] = []
   const notifyContexts = await control.findAll(ctx, notification.class.DocNotifyContext, { objectId: attachedTo })
+  const types = (notifyResult.get(notification.providers.InboxNotificationProvider) ?? []).map((it) => it._id)
 
-  await pushInboxNotifications(
+  const notificationTx = await pushInboxNotifications(
     ctx,
     control,
     res,
@@ -128,10 +129,19 @@ export async function getCommonNotificationTxes (
     data,
     _class,
     modifiedOn,
-    [],
+    types,
     true,
     tx
   )
+
+  if (notificationTx !== undefined) {
+    const current: AvailableProvidersCache = control.contextCache.get(AvailableProvidersCacheKey) ?? new Map()
+    const providers = Array.from(notifyResult.keys())
+    if (providers.length > 0) {
+      current.set(notificationTx.objectId, providers)
+      control.contextCache.set(AvailableProvidersCacheKey, current)
+    }
+  }
 
   return res
 }


### PR DESCRIPTION
## Problem

`getCommonNotificationTxes` (`server-plugins/notification-resources/src/index.ts:96-137`) computes the matched notification types, then throws them away:

```ts
  await pushInboxNotifications(
    …
    modifiedOn,
    [],            // <- :131  the matched types, discarded
    true,
    tx
  )
```

`pushInboxNotifications` writes that argument straight onto the notification document (`:389-398`, `types` at `:396`), so **every** notification created through this function is born `types: []` — regardless of what actually matched.

**It also never populates `AvailableProvidersCache`.** `getNotificationTxes:638-645` publishes the allowed providers after creating its notification; `getCommonNotificationTxes` does not, and it is the only other place that creates one.

The sibling function does both correctly, four hundred lines away in the same file:

```ts
// getNotificationTxes:622-645
const ids = notifyResult.get(notification.providers.InboxNotificationProvider)?.map((it) => it._id)
…
if (notificationTx !== undefined) {
  const current: AvailableProvidersCache = control.contextCache.get(AvailableProvidersCacheKey) ?? new Map()
  const providers = Array.from(notifyResult.keys())
  if (providers.length > 0) {
    current.set(notificationTx.objectId, providers)
```

That asymmetry is the whole bug.

### Three callers are affected

| caller | notification class | what it hands in |
| --- | --- | --- |
| `server-plugins/time-resources/src/index.ts:303,314-328` | `CommonInboxNotification` | `isShouldNotifyTx(...)`'s full `notifyResult` |
| `server-plugins/activity-resources/src/index.ts:138-160` | `ReactionInboxNotification` | `new Map(allowedProviders.map((it) => [it, [type]]))` |
| `server-plugins/activity-resources/src/references.ts:136-172` | `MentionInboxNotification` | same shape, `MentionNotificationType` |

The reaction and mention callers are the tell: each resolves a `NotificationType` into a local variable, puts it in `notifyResult`, and the callee drops it on the floor.

### This defeats the tree's own fallbacks

`push.ts:248-260` carries a fallback whose comment describes exactly the situation it is then defeated by:

```ts
  // Fallback: if cache doesn't have the provider info (e.g. scheduled notifications created outside tx-trigger paths),
  // compute allowed providers from notification type + user settings.
      const type = (n.types ?? [])[0]
      if (type === undefined) continue
```

With `types: []`, `type` is `undefined` and the fallback gives up. `gmail-resources/src/index.ts:221,324` has the same fallback and **logs when it fires** — `NotificationsHandler: skipping notification without type`. Both halves have to be fixed: a consumer that gates on the cache never gets as far as reading `types`, and a consumer that falls back to `types` finds it empty.

## Fix

14 lines, both blocks lifted verbatim from `getNotificationTxes` so the two paths agree:

```diff
   const notifyContexts = await control.findAll(ctx, notification.class.DocNotifyContext, { objectId: attachedTo })
+  const types = (notifyResult.get(notification.providers.InboxNotificationProvider) ?? []).map((it) => it._id)
 
-  await pushInboxNotifications(
+  const notificationTx = await pushInboxNotifications(
     …
-    [],
+    types,
     true,
     tx
   )
+
+  if (notificationTx !== undefined) {
+    const current: AvailableProvidersCache = control.contextCache.get(AvailableProvidersCacheKey) ?? new Map()
+    const providers = Array.from(notifyResult.keys())
+    if (providers.length > 0) {
+      current.set(notificationTx.objectId, providers)
+      control.contextCache.set(AvailableProvidersCacheKey, current)
+    }
+  }
```

## Scope and residual risk

**Nothing is force-enabled.** `notifyResult` is computed by the callers from `isAllowed`, which already honours `ignoredTypes`, the per-user Settings → Notifications toggles, and each type's `defaultEnabled`. What changes is that the answer stops being discarded.

That does mean this unblocks delivery for **every** notification born through this function, for every provider `isAllowed` already approved — so it is worth being explicit about what starts flowing:

| family | today | after |
| --- | --- | --- |
| ToDo (`time:ids:ToDoCreated`) | allowed by settings, dropped for want of a type | delivered |
| reactions (`activity:ids:AddReactionNotification`) | allowed, dropped | delivered |
| mentions (`MentionInboxNotification`) → email | approved by `isAllowed`, then dropped | **email begins sending** |
| ToDo → email | `defaultEnabled: false`, no `enabledTypes` entry | unchanged, still no email |

⚠️ **The mention-email row is the one to look at before merging.** `notification:ids:MentionNotificationType` is `defaultEnabled: true` (`models/notification/src/index.ts:599-611`) and gmail's provider is `defaultEnabled: true` with an `ignoredTypes` that does not list it (`models/gmail/src/notification.ts:53-81`), so `isAllowed` approves email for mentions today and only the missing type suppresses the send. After this change a mention inside a followed conversation can produce **two** emails — one from the `ActivityInboxNotification` that already worked, and one from the `MentionInboxNotification`.

I have deliberately not changed that here. Suppressing it would mean adding `MentionNotificationType` to gmail's `ignoredTypes`, which is a product call rather than a bug fix, and I would rather surface the consequence than quietly bundle a behaviour decision into a correctness fix. Happy to add it in this PR if you'd prefer it landed together.

**Deliberately not touched:** `getNotificationTxes:653` sets the cache with the string literal `'AvailableNotificationProviders'` rather than the exported `AvailableProvidersCacheKey`. Equal today, a drift hazard tomorrow — but it is not this bug, and widening a fix to carry a nit is how patches stop applying cleanly. Flagging rather than fixing.

## Verification

`server-plugins/notification-resources` had `jest --passWithNoTests` and no suites; `commonNotificationTypes.test.ts` is the first one in it. jest, matching the package's own config.

| | before | after |
| --- | --- | --- |
| `server-plugins/notification-resources` | **3 failed / 6 passed** | **9 passed** |
| `server-plugins/activity-resources` (a caller) | 3 passed | 3 passed |
| `server-plugins/calendar-resources` | 7 passed | 7 passed |

The three reds were exactly the three new behaviours — the type on the document, the provider-cache entry, and the cache entry under the ignored-provider shape. The six that passed red are the control: three of them drive the real `isShouldNotifyTx` with the real `ToDoCreated` shape over a bare `TxCreateDoc` and assert that a type *is* matched, which pins that the matcher was never the problem and the loss happens after it.

Cases added:

- `stamps the ToDo type onto the notification it creates`
- `the activity path is unchanged › keeps writing the types it is handed`
- `does not invent a type for a genuinely typeless notification` — `types` stays `[]`, so gmail/push still skip it
- `still writes nothing at all when the inbox provider is absent`
- `drops the type when the provider ignores it`
- `drops the type when it is neither enabled nor defaultEnabled`
- `leaves a type out of the cache for a provider that did not allow it`

`tsc --noEmit`: the `src/index.ts` error set is byte-identical before and after once line numbers are normalised — the fix adds none.

No UI change, so there is nothing to screenshot.

## Provenance

Found while integrating a third-party notification consumer against a self-hosted deployment: ToDo notifications were created but never delivered, and the gmail handler's `skipping notification without type` line was the thread that led here. The mechanism above is read from the code and pinned by the tests; I have not measured the mention-email volume change on a live instance, which is why it is flagged as a question rather than asserted as safe.
