### PR TITLE
fix(account): honour the integrationServices list in findFullSocialIdBySocialKey

### DIFF
--- a/server/account/src/serviceOperations.ts
+++ b/server/account/src/serviceOperations.ts
@@ -932,7 +932,10 @@ export async function findFullSocialIdBySocialKey (
   params: { socialKey: string }
 ): Promise<SocialId | null> {
   const { extra } = decodeTokenVerbose(ctx, token)
-  verifyAllowedServices(['telegram-bot', 'gmail', 'tool', 'workspace', 'google-calendar'], extra)
+  verifyAllowedServices(
+    ['telegram-bot', 'gmail', 'tool', 'workspace', 'google-calendar', ...integrationServices],
+    extra
+  )
 
   const { socialKey } = params
 


### PR DESCRIPTION
## Problem

`findFullSocialIdBySocialKey` (`server/account/src/serviceOperations.ts:932-935`) gates its callers on a frozen literal instead of the shared `integrationServices` list:

```ts
const { extra } = decodeTokenVerbose(ctx, token)
verifyAllowedServices(['telegram-bot', 'gmail', 'tool', 'workspace', 'google-calendar'], extra)
```

`integrationServices` (`server/account/src/utils.ts:2024-2035`) is:

```ts
['github', 'telegram-bot', 'hulygram', 'mailbox', 'caldav', 'gmail', 'google-calendar', 'huly-mail', 'ai-assistant', 'tool']
```

So the literal omits **six names that are already trusted elsewhere in this very file**: `github`, `hulygram`, `mailbox`, `caldav`, `huly-mail`, `ai-assistant`.

Those six are trusted by every neighbouring endpoint — `getIntegrationSecret` (`:895`), `listIntegrationsSecrets` (`:921`), `listIntegrations` (`:726`), `findExistingIntegration` (`utils.ts:2049`) — all of which gate on `integrationServices` directly. A service that is allowed to **create and read its own integrations, including their secrets**, is refused when it tries to resolve a social key.

This needs no configuration to reproduce: it happens on a stock checkout with no environment variables set.

**Reproduction**

1. Mint a service token with `extra.service = 'github'`.
2. `createIntegration` — succeeds (gated on `integrationServices`, which contains `github`).
3. `findFullSocialIdBySocialKey` with the same token — `Forbidden`.

The practical consequence is that a deployment wanting any of those six services to resolve a social key has to run it under the `tool` service name instead, which is a far broader identity than the service needs — `tool` is the admin/migration name that `dev/tool` and the model migrations use.

## Fix

Union the endpoint's own names with `integrationServices`:

```diff
-  verifyAllowedServices(['telegram-bot', 'gmail', 'tool', 'workspace', 'google-calendar'], extra)
+  verifyAllowedServices(
+    ['telegram-bot', 'gmail', 'tool', 'workspace', 'google-calendar', ...integrationServices],
+    extra
+  )
```

This is the shape `findPersonBySocialKey` already uses seventy lines below, at `:1002`:

```ts
verifyAllowedServices(['tool', 'workspace', 'aibot', ...integrationServices], extra)
```

**Union rather than replace, deliberately.** `workspace` appears in this endpoint's literal but is *not* in `integrationServices`, so replacing the literal outright would revoke access that works today. Spreading keeps every existing caller working and only adds the six that the adjacent endpoints already trust.

## Scope and residual risk

- **Nothing is removed.** The five names in the literal keep working, `workspace` included.
- The six names added are exactly the six already permitted by the sibling calls in the same file, so this widens `findFullSocialIdBySocialKey` to the set the rest of the integration surface already uses — it does not invent a new trust boundary.
- No behaviour change for any caller that works today.

## Verification

Change is one call. `git apply` is clean against `develop` @ `1be6047c8`, and the reachability claim above was checked by reading `integrationServices` and each `verifyAllowedServices` call site in `serviceOperations.ts` on that commit.

No tests are added: `verifyAllowedServices` is a pure allow-list check and the change is to its argument, so a test would restate the list rather than pin behaviour. Happy to add one if you'd like the allow-list itself pinned.

## Related, not included

`integrationServices` is a hardcoded array with a maintainer comment asking `// Move to config?`. Making it extensible from the environment would let a deployment add its own integration service without patching, and would compose with this change — but that is a configuration-surface decision rather than a bug fix, so I have left it out of this PR. Happy to open it separately if it is wanted.

## Provenance

Found while running a first-party integration service against a self-hosted deployment under its own service name, which worked for every integration call and then failed on social-key resolution.
