### PR TITLE
fix(telegram-bot): point the postgres-real suite at the CockroachDB port CI uses

### DIFF
--- a/services/telegram-bot/pod-telegram-bot/src/__tests__/postgres-real.test.ts
+++ b/services/telegram-bot/pod-telegram-bot/src/__tests__/postgres-real.test.ts
@@ -46,7 +46,7 @@ jest.setTimeout(90000)
 
 describe('PostgresDB compatibility tests', () => {
   // Use environment variables or default to localhost databases
-  const cockroachDB: string = process.env.DB_URL ?? 'postgresql://root@localhost:26257/defaultdb?sslmode=disable'
+  const cockroachDB: string = process.env.DB_URL ?? 'postgresql://root@localhost:26258/defaultdb?sslmode=disable'
   const postgresDB: string = process.env.POSTGRES_URL ?? 'postgresql://postgres:postgres@localhost:5433/postgres'
 
   let crDbUri = cockroachDB


### PR DESCRIPTION
## Problem

`services/telegram-bot/pod-telegram-bot/src/__tests__/postgres-real.test.ts:49` defaults CockroachDB to host port **26257**:

```ts
const cockroachDB: string = process.env.DB_URL ?? 'postgresql://root@localhost:26257/defaultdb?sslmode=disable'
```

Everything else in the repository says **26258**. All four test compose files publish CockroachDB there:

```
tests/docker-compose.yaml:48                   - '26258:26257'
ws-tests/docker-compose.yaml:37                - '26258:26257'
qms-tests/docker-compose.yaml:8                - '26258:26257'
foundations/server/tests/docker-compose.yaml:21 - '26258:26257'
```

and the sibling `postgres-real` suite agrees:

```
server/account/src/__tests__/postgres-real.test.ts:17
  process.env.DB_URL ?? 'postgresql://root@localhost:26258/defaultdb?sslmode=disable'
```

as does CI:

```
.github/workflows/main.yml:230
  DB_URL: 'postgresql://root@localhost:26258/defaultdb?sslmode=disable'
```

`26257` is CockroachDB's *container* port; `26258` is the host port the compose files map it to. The telegram-bot suite is the lone reference to the container port from the host side.

**Consequence:** bring up the documented compose stack and run `rush test` locally, and the telegram-bot `postgres-real` suite fails in `beforeEach` with `ECONNREFUSED` while `server/account`'s identical suite passes. CI never sees it, because the workflow exports `DB_URL` and the default is not used.

## Fix

One character.

```diff
-  const cockroachDB: string = process.env.DB_URL ?? 'postgresql://root@localhost:26257/defaultdb?sslmode=disable'
+  const cockroachDB: string = process.env.DB_URL ?? 'postgresql://root@localhost:26258/defaultdb?sslmode=disable'
```

## Scope and residual risk

- `DB_URL` still wins where it is set, so CI behaviour is unchanged.
- The only behaviour that changes is the local default, which currently cannot connect to any stack this repository ships.
- `dev/docker-compose.yaml` does use `26257`, but that is the dev stack on a different CockroachDB image line, not a test stack, and no `postgres-real` suite points at it.

## Verification

Read out of `develop` @ `1be6047c8`: eight references to `26258` (four composes, two `postgres-real` defaults, the CI export, and `foundations`) against this one `26257`. `git apply` is clean.

I have not run the suite against a live CockroachDB — it needs the compose stack up, and the change is to a default string that is only reached when `DB_URL` is unset. The claim here is the consistency argument above rather than a measured pass.
