### PR TITLE
build: wire up the test and svelte-check phases that rush silently skips

### DIFF
--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -6,12 +6,14 @@
   "license": "EPL-2.0",
   "scripts": {
     "build": "compile ui",
+    "test": "jest --passWithNoTests --silent",
     "build:docs": "api-extractor run --local",
     "format": "format src",
     "svelte-check": "do-svelte-check",
     "_phase:svelte-check": "do-svelte-check",
     "build:watch": "compile ui",
     "_phase:build": "compile ui",
+    "_phase:test": "jest --passWithNoTests --silent",
     "_phase:format": "format src",
     "_phase:validate": "compile validate"
   },

--- a/plugins/login-resources/package.json
+++ b/plugins/login-resources/package.json
@@ -6,11 +6,13 @@
   "license": "EPL-2.0",
   "scripts": {
     "build": "compile ui",
+    "svelte-check": "do-svelte-check",
     "test": "jest --passWithNoTests --silent",
     "build:docs": "api-extractor run --local",
     "format": "format src",
     "build:watch": "compile ui",
     "_phase:build": "compile ui",
+    "_phase:svelte-check": "do-svelte-check",
     "_phase:test": "jest --passWithNoTests --silent",
     "_phase:format": "format src",
     "_phase:validate": "compile validate"

--- a/plugins/recorder-resources/package.json
+++ b/plugins/recorder-resources/package.json
@@ -6,12 +6,14 @@
   "license": "EPL-2.0",
   "scripts": {
     "build": "compile ui",
+    "test": "jest --passWithNoTests --silent",
     "build:docs": "api-extractor run --local",
     "format": "format src",
     "svelte-check": "do-svelte-check",
     "_phase:svelte-check": "do-svelte-check",
     "build:watch": "compile ui",
     "_phase:build": "compile ui",
+    "_phase:test": "jest --passWithNoTests --silent",
     "_phase:format": "format src",
     "_phase:validate": "compile validate"
   },


### PR DESCRIPTION
## Problem

`common/config/rush/command-line.json` declares the phased commands with `"ignoreMissingScript": true`. That is the right setting for a monorepo where most packages have no tests — but it means a package that **owns** tests and is missing the phase script is skipped by `rush test` without a word. There is no warning to notice.

Three packages are in that state on `develop`:

**`packages/presentation`** — has `jest.config.js`, has `jest` / `ts-jest` / `@types/jest` / `jest-environment-jsdom` / `@testing-library/jest-dom` in `devDependencies`, and has four suites:

```
packages/presentation/src/___tests___/drawing.test.ts
packages/presentation/src/___tests___/drawingUtils.test.ts
packages/presentation/src/___tests___/drawingCommandsProcessor.test.ts
packages/presentation/src/___tests___/link-preview.test.ts
```

Its `scripts` block has `_phase:svelte-check`, `_phase:build`, `_phase:format` and `_phase:validate` — and no `test` or `_phase:test`. The suites have never run in CI.

**`plugins/recorder-resources`** — same shape: `jest.config.js`, jest devDependencies, one suite (`src/__tests__/chunk-reader.test.ts`), no test script.

**`plugins/login-resources`** — the mirror image. It *has* `test` and `_phase:test`, but no `svelte-check` or `_phase:svelte-check`, so it is the one `compile ui` plugin whose Svelte components are not type-checked by the `svelte-check` phase anywhere.

## Fix

One or two lines per `package.json`, adding the phase script and the plain alias next to it, matching how neighbouring packages declare them:

- `packages/presentation` — `test` + `_phase:test`
- `plugins/recorder-resources` — `test` + `_phase:test`
- `plugins/login-resources` — `svelte-check` + `_phase:svelte-check`

No source changes, no config changes, no new dependencies — every package already has everything it needs to run these.

## Scope and residual risk

**This PR makes CI stricter, which is the point, and the risk worth stating plainly: if any of these suites is currently failing, this PR turns that into a red build.** On our checkout they pass, which is why this is offered as wiring rather than as a fix — but our checkout is not your CI, and if something goes red here that failure is itself the finding this PR exists to surface. I would rather that surface now than keep being invisible.

`svelte-check` on `login-resources` is the likeliest to have accumulated warnings, since nothing has ever checked it.

If you would rather land this incrementally, the three changes are independent and I am happy to split them into three PRs, or to drop the `login-resources` `svelte-check` line and keep just the two test phases.

## Verification

Read out of `develop` @ `1be6047c8`: the suite files, the `jest.config.js` files, the `devDependencies`, and the `scripts` blocks are all as described above, and `ignoreMissingScript: true` is set on the phases in `common/config/rush/command-line.json`.

The test counts behind "these pass" were measured on a `v0.7.432` checkout, not on this commit — the honest claim is that the suites exist, are runnable, and are currently skipped. Your CI running them is the real verification, and that is what this PR is asking for.
