### PR TITLE
fix(text-editor): re-run the mention search when fulltext indexing advances

### DIFF
--- a/plugins/text-editor-resources/src/components/MentionPopup.svelte
+++ b/plugins/text-editor-resources/src/components/MentionPopup.svelte
@@ -15,18 +15,30 @@
 -->
 <script lang="ts">
   import contact from '@hcengineering/contact'
-  import core, { Class, Doc, Ref, SearchResultDoc, SortingOrder, type VersionableDoc } from '@hcengineering/core'
+  import core, {
+    Class,
+    Doc,
+    Ref,
+    SearchResultDoc,
+    SortingOrder,
+    type Tx,
+    type TxWorkspaceEvent,
+    type VersionableDoc,
+    WorkspaceEvent
+  } from '@hcengineering/core'
   import { getResource, translate } from '@hcengineering/platform'
   import presentation, {
+    addTxListener,
     getClient,
     reduceCalls,
+    removeTxListener,
     searchFor,
     SearchResult,
     type SearchItem
   } from '@hcengineering/presentation'
   import { Label, ListView, resizeObserver, Submenu } from '@hcengineering/ui'
   import view, { type ReferenceVersion, type ReferenceVersionsProvider } from '@hcengineering/view'
-  import { createEventDispatcher } from 'svelte'
+  import { createEventDispatcher, onMount } from 'svelte'
   import { getReferenceLabel, getReferenceObject } from './extension/reference'
 
   import MentionVersionPopup from './MentionVersionPopup.svelte'
@@ -223,6 +235,27 @@
     }
   })
   $: void updateItems(query)
+
+  // The fulltext index is written asynchronously, so a document created moments ago
+  // is routinely missing from the first 'mention' search. Re-run the query when the
+  // server broadcasts that indexing advanced, the same way ActionsPopup does.
+  function txListener (txes: Tx[]): void {
+    if (
+      txes.some(
+        (it) =>
+          it._class === core.class.TxWorkspaceEvent && (it as TxWorkspaceEvent).event === WorkspaceEvent.IndexingUpdate
+      )
+    ) {
+      void updateItems(query)
+    }
+  }
+
+  onMount(() => {
+    addTxListener(txListener)
+    return () => {
+      removeTxListener(txListener)
+    }
+  })
 </script>
 
 {#if (items.length === 0 && query !== '') || items.length > 0}


### PR DESCRIPTION
## Problem

`MentionPopup.svelte` issues its fulltext query exactly once per query change and never retries:

```svelte
// plugins/text-editor-resources/src/components/MentionPopup.svelte:213,225
const updateItems = reduceCalls(async function (localQuery: string): Promise<void> {
  …
})
$: void updateItems(query)
```

Fulltext indexing is asynchronous. A document created seconds earlier is routinely absent from that one result, and when it is, the popup sits on **"No results"** until the user changes the query — deleting a character and retyping it is the usual workaround, if the user knows to try it.

So typing `@` and the name of a channel, issue or document you just created shows you nothing, and keeps showing you nothing, even after the index has caught up and the server has said so.

**The client is already told when the index advances.** The server broadcasts `TxWorkspaceEvent` with `WorkspaceEvent.IndexingUpdate`, and the client already delivers it to tx listeners. `ActionsPopup` subscribes to exactly this to refresh its own fulltext results (`plugins/view-resources/src/components/ActionsPopup.svelte:265-272`):

```ts
function txListener (txes: Tx[]): void {
  if (
    txes.some(
      (it) =>
        it._class === core.class.TxWorkspaceEvent && (it as TxWorkspaceEvent).event === WorkspaceEvent.IndexingUpdate
    )
  ) {
    void updateItems(search, filteredActions)
```

`MentionPopup` does not. That is the whole difference.

## Fix

Register the same listener for the lifetime of the popup, using the same `addTxListener` / `removeTxListener` pair from `@hcengineering/presentation` (`packages/presentation/src/utils.ts:85,96`) that `ActionsPopup` uses:

```svelte
  // The fulltext index is written asynchronously, so a document created moments ago
  // is routinely missing from the first 'mention' search. Re-run the query when the
  // server broadcasts that indexing advanced, the same way ActionsPopup does.
  function txListener (txes: Tx[]): void {
    if (
      txes.some(
        (it) =>
          it._class === core.class.TxWorkspaceEvent && (it as TxWorkspaceEvent).event === WorkspaceEvent.IndexingUpdate
      )
    ) {
      void updateItems(query)
    }
  }

  onMount(() => {
    addTxListener(txListener)
    return () => {
      removeTxListener(txListener)
    }
  })
```

The predicate is copied from `ActionsPopup` deliberately, so the two popups agree about what "indexing advanced" means and a future change to that event shape shows up in both places at once.

## Scope and residual risk

- The listener is registered on mount and removed on destroy, so it lives exactly as long as the popup.
- `updateItems` is already wrapped in `reduceCalls`, so a burst of indexing events collapses rather than issuing a query per event.
- Re-running the query is idempotent from the user's point of view: it replaces the result list, which is what a keystroke already does.
- No change to the query itself, to the result rendering, or to the empty state.

## Verification

Verified against `develop` @ `1be6047c8`: `MentionPopup.svelte:225` is still a bare `$: void updateItems(query)` with no tx listener, the `ActionsPopup` precedent is still at `:265-272`, and both `addTxListener` and `removeTxListener` are still exported from `@hcengineering/presentation`. `git apply` is clean.

**No automated test is offered.** `plugins/text-editor-resources` has no jest project, and the behaviour is a race between the fulltext pod and a Svelte component. Manual check: create a channel or document, immediately type `@` plus its name into a message box, and watch the popup populate when indexing catches up instead of staying on "No results".

## Related

The end-to-end symptom of this also shows up in the sanity suite. `tests/sanity`'s `sendMention` has a three-attempt retry that is currently unreachable for an unrelated reason, so this indexing delay turns into a hard failure there rather than a retried one. I have opened that separately as a test-only change; the two are independent and can land in either order.

## Provenance

Found while chasing an intermittent chat-backlinks failure on a self-hosted deployment: the mention popup would show "No results" for a document that existed and was searchable a moment later. The indexing-delay mechanism above is read from the code and matched against the `ActionsPopup` precedent; the timing window varies with index load and I have not characterised it beyond "seconds".
