### PR TITLE
fix(presentation): pass absolute URLs through getPreviewThumbnail

### DIFF
--- a/packages/presentation/src/___tests___/preview.test.ts
+++ b/packages/presentation/src/___tests___/preview.test.ts
@@ -1,0 +1,58 @@
+//
+// Copyright © 2026 Hardcore Engineering Inc.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+jest.mock('../file', () => ({
+  getCurrentWorkspaceUuid: () => 'ws-uuid',
+  getFileUrl: (file: string) => (file.includes('://') ? file : `/files/ws-uuid?file=${encodeURIComponent(file)}`),
+  getFileStorage: () => ({})
+}))
+
+jest.mock('@hcengineering/platform', () => {
+  const actual = jest.requireActual('@hcengineering/platform')
+  return { ...actual, getMetadata: () => 'https://preview.example.com' }
+})
+
+import { getPreviewThumbnail, getSrcSet } from '../preview'
+
+describe('getPreviewThumbnail', () => {
+  it('routes a blob id through the preview service', () => {
+    expect(getPreviewThumbnail('blob-id', 100, 200, 2)).toEqual(
+      'https://preview.example.com/image/fit=cover,width=100,height=200,dpr=2/ws-uuid/blob-id'
+    )
+  })
+
+  it('percent-encodes a blob id that needs it', () => {
+    expect(getPreviewThumbnail('a b/c', 100, 200, 2)).toEqual(
+      'https://preview.example.com/image/fit=cover,width=100,height=200,dpr=2/ws-uuid/a%20b%2Fc'
+    )
+  })
+
+  it('passes an absolute http URL through unchanged', () => {
+    const url = 'https://cdn.example.com/thumbnails/cover.png'
+    expect(getPreviewThumbnail(url, 100, 200, 2)).toEqual(url)
+  })
+
+  it('passes an absolute URL with a query string through unchanged', () => {
+    const url = 'https://cdn.example.com/thumbnails/cover.png?token=abc'
+    expect(getPreviewThumbnail(url, 300, 300, 1)).toEqual(url)
+  })
+
+  it('agrees with getSrcSet on what counts as an absolute URL', () => {
+    // blobToSrcSet already bails out of the preview-service path for '://' refs;
+    // getPreviewThumbnail must recognise exactly the same refs.
+    const url = 'https://cdn.example.com/thumbnails/cover.png'
+    expect(getSrcSet(url as any, 100, 200)).toEqual('')
+    expect(getPreviewThumbnail(url, 100, 200, 2)).toEqual(url)
+  })
+})

--- a/packages/presentation/src/preview.ts
+++ b/packages/presentation/src/preview.ts
@@ -90,6 +90,12 @@ function blobToSrcSet (blob: Ref<Blob>, width: number | undefined, height: numbe
 }
 
 export function getPreviewThumbnail (file: string, width: number, height: number, dpr?: number): string {
+  // Absolute URLs pass through unchanged, same as getFileUrl (blobToSrcSet
+  // guards on '://' too but returns '' — a thumbnail src wants the passthrough)
+  if (file.includes('://')) {
+    return file
+  }
+
   return getImagePreviewUrl(
     encodeURIComponent(getCurrentWorkspaceUuid()),
     encodeURIComponent(file),


### PR DESCRIPTION
## Problem

`packages/presentation` has three functions that turn a blob ref into a URL, and they disagree about what to do when the ref is already an absolute URL.

`getFileUrl` (`file.ts:55`) passes it through:

```ts
if (file.includes('://')) {
  return file
}
```

`blobToSrcSet` (`preview.ts:52`) also recognises it, and returns `''` — correctly, because there is no srcset to build for an external URL.

`getPreviewThumbnail` (`preview.ts:92`) has **no guard at all**:

```ts
export function getPreviewThumbnail (file: string, width: number, height: number, dpr?: number): string {
  return getImagePreviewUrl(
    encodeURIComponent(getCurrentWorkspaceUuid()),
    encodeURIComponent(file),
    …
```

So an absolute URL is percent-encoded and pasted into the preview service's path, producing something like:

```
https://preview.example.com/image/fit=cover,width=100,height=200,dpr=2/<ws>/https%3A%2F%2Fcdn.example.com%2Fcover.png
```

which is not a thumbnail of anything.

## Fix

Add the passthrough, matching `getFileUrl` — a thumbnail needs a usable `src`, so passthrough rather than `blobToSrcSet`'s empty string is the right analogue:

```diff
 export function getPreviewThumbnail (file: string, width: number, height: number, dpr?: number): string {
+  // Absolute URLs pass through unchanged, same as getFileUrl (blobToSrcSet
+  // guards on '://' too but returns '' — a thumbnail src wants the passthrough)
+  if (file.includes('://')) {
+    return file
+  }
+
   return getImagePreviewUrl(
```

## Verification

Five cases in `packages/presentation/src/___tests___/preview.test.ts`, alongside the four suites already in that directory:

- a plain blob id is routed through the preview service
- a blob id needing percent-encoding is still encoded (so the guard does not change the normal path)
- an absolute URL passes through byte-for-byte
- an absolute URL with a query string passes through byte-for-byte
- `getPreviewThumbnail` agrees with `getSrcSet` about what counts as an absolute ref

The last one is the point of the change rather than a restatement of it: the three functions disagreeing is the actual defect, and that case pins them together. Three of the five fail with the guard removed.

⚠️ **These tests will not run in CI as things stand.** `packages/presentation` has `jest.config.js`, the jest devDependencies, and four existing suites, but no `test` / `_phase:test` script — and `rush`'s phases are declared `ignoreMissingScript: true`, so the whole package is skipped silently. I have opened that separately as a one-line-per-package build change. Either land that first, or fold those two lines into this PR — happy either way, just say which you prefer.

Verified against `develop` @ `1be6047c8`: `getFileUrl`'s guard at `file.ts:55` and `blobToSrcSet`'s at `preview.ts:52` are both still there, `getPreviewThumbnail` at `:92` still has none.

## Note on scope

This was originally prepared together with three unrelated error-handling fixes on the same read path (a `TextViewer` fetch with no `try`/`catch`, an `ImageViewer` `<img>` with no `on:error`, and an embed nodeview promise with no `.catch`). I have split those into a separate PR, since they are a different concern and mixing them would make both harder to review.
