### PR TITLE
fix(view,text-editor): give the blob read path a failure state

### DIFF
--- a/plugins/text-editor-resources/src/components/extension/embed/embed.ts
+++ b/plugins/text-editor-resources/src/components/extension/embed/embed.ts
@@ -120,6 +120,9 @@ export const EmbedNode = BaseEmbedNode.extend<EmbedNodeOptions>({
       let handle: EmbedNodeViewHandle | undefined
 
       void providerPromise
+        .catch((err): undefined => {
+          console.warn('Failed to build embed view', err)
+        })
         .then((view) => {
           view = view ?? StubEmbedNodeView
           handle = view(editor, root, getPos)

--- a/plugins/view-resources/src/components/viewer/ImageViewer.svelte
+++ b/plugins/view-resources/src/components/viewer/ImageViewer.svelte
@@ -14,8 +14,8 @@
 -->
 <script lang="ts">
   import { type Blob, type Ref, type BlobMetadata } from '@hcengineering/core'
-  import { DrawingBoard, getBlobRef, imageSizeToRatio } from '@hcengineering/presentation'
-  import { Loading } from '@hcengineering/ui'
+  import presentation, { DrawingBoard, getBlobRef, imageSizeToRatio } from '@hcengineering/presentation'
+  import { Label, Loading } from '@hcengineering/ui'
 
   export let value: Ref<Blob>
   export let name: string
@@ -40,41 +40,55 @@
   $: height = imageHeight != null ? `min(${imageHeight}px, ${fit ? '100%' : '80vh'})` : '100%'
 
   let loading = true
+  let error = false
   function _setLoading (newState: boolean): void {
     loading = newState
     setLoading?.(loading)
   }
 
-  $: if (value !== undefined) _setLoading(true)
+  $: if (value !== undefined) {
+    error = false
+    _setLoading(true)
+  }
 </script>
 
 {#await getBlobRef(value, name) then blobRef}
-  {#if loading}
+  {#if error}
     <div class="flex-center w-full h-full clear-mins">
-      <Loading />
+      <Label label={presentation.string.FailedToPreview} />
     </div>
+  {:else}
+    {#if loading}
+      <div class="flex-center w-full h-full clear-mins">
+        <Loading />
+      </div>
+    {/if}
+    <DrawingBoard
+      {imageWidth}
+      {imageHeight}
+      {drawings}
+      {createDrawing}
+      active={drawingAvailable && !loading}
+      readonly={drawingAvailable && !drawingEditable}
+      class="flex-center clear-mins w-full h-full"
+      style={`max-width:${width};max-height:${height}`}
+    >
+      <img
+        on:load={() => {
+          _setLoading(false)
+        }}
+        on:error={() => {
+          error = true
+          _setLoading(false)
+        }}
+        class="object-contain mx-auto"
+        style:max-width={width}
+        style:max-height={height}
+        src={blobRef.src}
+        srcset={blobRef.srcset}
+        alt={name}
+        style:height={loading ? '0' : ''}
+      />
+    </DrawingBoard>
   {/if}
-  <DrawingBoard
-    {imageWidth}
-    {imageHeight}
-    {drawings}
-    {createDrawing}
-    active={drawingAvailable && !loading}
-    readonly={drawingAvailable && !drawingEditable}
-    class="flex-center clear-mins w-full h-full"
-    style={`max-width:${width};max-height:${height}`}
-  >
-    <img
-      on:load={() => {
-        _setLoading(false)
-      }}
-      class="object-contain mx-auto"
-      style:max-width={width}
-      style:max-height={height}
-      src={blobRef.src}
-      srcset={blobRef.srcset}
-      alt={name}
-      style:height={loading ? '0' : ''}
-    />
-  </DrawingBoard>
 {/await}

--- a/plugins/view-resources/src/components/viewer/TextViewer.svelte
+++ b/plugins/view-resources/src/components/viewer/TextViewer.svelte
@@ -14,8 +14,8 @@
 -->
 <script lang="ts">
   import { type Blob, type Ref } from '@hcengineering/core'
-  import { getFileUrl } from '@hcengineering/presentation'
-  import { Loading, Scroller } from '@hcengineering/ui'
+  import presentation, { getFileUrl } from '@hcengineering/presentation'
+  import { Label, Loading, Scroller } from '@hcengineering/ui'
 
   export let value: Ref<Blob>
   export let name: string
@@ -24,22 +24,36 @@
   $: void fetchFile(value, name)
 
   let loading = true
+  let error = false
   let text: string | undefined = undefined
 
   async function fetchFile (value: Ref<Blob>, name: string): Promise<void> {
     loading = true
+    error = false
 
-    const src = getFileUrl(value, name)
-    const res = await fetch(src)
-    text = await res.text()
-
-    loading = false
+    try {
+      const src = getFileUrl(value, name)
+      const res = await fetch(src)
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`)
+      }
+      text = await res.text()
+    } catch (err) {
+      console.warn('Failed to fetch file', err)
+      error = true
+    } finally {
+      loading = false
+    }
   }
 </script>
 
 {#if loading}
   <div class="flex-center w-full h-full clear-mins">
     <Loading />
+  </div>
+{:else if error}
+  <div class="flex-center w-full h-full clear-mins">
+    <Label label={presentation.string.FailedToPreview} />
   </div>
 {:else}
   <div class="container h-full w-full" class:fit>


### PR DESCRIPTION
## Problem

Three places on the blob read path have no failure state at all. In each case a failed fetch leaves the UI stuck rather than showing the "Failed to preview" state the codebase already has.

**1. `TextViewer.svelte:24-36` awaits `fetch` with no `try`/`catch`:**

```ts
async function fetchFile (value: Ref<Blob>, name: string): Promise<void> {
  loading = true

  const src = getFileUrl(value, name)
  const res = await fetch(src)
  text = await res.text()

  loading = false
}
```

If the fetch rejects, `loading = false` is never reached — so the spinner runs forever — and the rejection is unhandled. A non-2xx response is worse than that: it does not reject, so `res.text()` succeeds and the error body is rendered *as the file's contents*.

**2. `ImageViewer.svelte` has `on:load` but no `on:error`.** Same eternal spinner: `_setLoading(false)` only ever runs from `on:load`, so a broken image leaves the loading state set and the `<img>` pinned at `height: 0`.

**3. `embed.ts:122` has `.then` and `.finally` but no `.catch`:**

```ts
void providerPromise
  .then((view) => {
    view = view ?? StubEmbedNodeView
```

A rejected provider promise is an unhandled rejection, and the nodeview never falls back to `StubEmbedNodeView` — so the embed renders as nothing at all, rather than as the stub link it is designed to degrade to.

## Fix

Each path now settles into a state that already exists in the codebase — `presentation.string.FailedToPreview` for the two viewers (already defined at `packages/presentation/src/plugin.ts:138` and translated in `lang/en.json`, so no new i18n), and the existing stub view for the embed.

- **`TextViewer`** — wrap in `try`/`catch`/`finally`, treat `!res.ok` as an error rather than rendering the body, and add an `{:else if error}` branch showing `FailedToPreview`.
- **`ImageViewer`** — add `error` state, an `on:error` handler on the `<img>`, and an error branch. The `error` flag resets alongside `_setLoading(true)` when `value` changes, so navigating from a broken image to a good one recovers.
- **`embed.ts`** — add a `.catch` that warns and returns `undefined`, which the existing `view = view ?? StubEmbedNodeView` line then turns into the stub.

## Scope and residual risk

- No behaviour change on the success path in any of the three.
- The `ImageViewer` diff looks larger than it is: adding the `{#if error}` branch re-indents the existing `DrawingBoard` block into the `{:else}`. The only substantive changes are the `error` variable, the `on:error` handler, and the reset.
- `TextViewer` now treats a non-2xx response as a failure rather than rendering the response body as file contents. That is a deliberate behaviour change and the one thing here worth a second opinion — it is the right call for a *file* viewer, but it does mean a server that returns a 404 page with useful text will now show "Failed to preview" instead of that text.
- The two `console.warn`s are the only new output. If you would rather they went through a measure context, say so and I will change them.

## Verification

Verified against `develop` @ `1be6047c8`: `TextViewer.svelte:33` is still a bare `await fetch`, `ImageViewer.svelte` still has zero `on:error` handlers, and `embed.ts:122` still has no `.catch` on `providerPromise`.

**No automated tests.** `plugins/view-resources` and `plugins/text-editor-resources` have no jest projects, and all three behaviours are DOM-level failure paths in Svelte components. Manual check for each: point the viewer at a blob id that does not resolve and confirm the "Failed to preview" label appears instead of a permanent spinner; give the embed node a URL whose provider match rejects and confirm the stub link renders.

## Note on scope

This was originally prepared together with an absolute-URL guard for `getPreviewThumbnail` on the same read path. I have split that into a separate PR — it is a different concern, and it ships with unit tests whereas this one cannot.
