### PR TITLE
fix(love): allow rejoining a room the client is still recorded in

### DIFF
--- a/plugins/love-resources/src/components/RoomPopup.svelte
+++ b/plugins/love-resources/src/components/RoomPopup.svelte
@@ -32,7 +32,7 @@
   import ShareScreenButton from './meeting/controls/ShareScreenButton.svelte'
   import LeaveRoomButton from './meeting/controls/LeaveRoomButton.svelte'
   import MeetingHeader from './meeting/MeetingHeader.svelte'
-  import { joinMeeting } from '../meetings'
+  import { joinMeeting, reconnectMeeting } from '../meetings'
 
   export let room: Room
 
@@ -53,8 +53,14 @@
 
   const dispatch = createEventDispatcher()
 
+  // A stale record (still "in" the room, but no LiveKit session - e.g. after
+  // a reload mid-call) must re-establish the media, not knock again.
   async function connect (): Promise<void> {
-    await joinMeeting(room)
+    if (joined) {
+      await reconnectMeeting(room)
+    } else {
+      await joinMeeting(room)
+    }
     dispatch('close')
   }
 
@@ -121,7 +127,8 @@
     {/if}
     {#if joined}
       <LeaveRoomButton {room} noLabel={false} size="medium" on:leave={() => dispatch('close')} />
-    {:else}
+    {/if}
+    {#if !joined || !$lkSessionConnected}
       <ModernButton
         icon={love.icon.EnterRoom}
         label={love.string.EnterRoom}

--- a/plugins/love-resources/src/meetings.ts
+++ b/plugins/love-resources/src/meetings.ts
@@ -85,6 +85,21 @@ export async function joinMeeting (room: Room): Promise<void> {
   await connectToMeeting(room)
 }
 
+/**
+ * Re-establish the call for a room this client is already recorded in.
+ *
+ * After a reload mid-call the ParticipantInfo still points at the room while
+ * no LiveKit session exists, so `joinMeeting` (which would knock again) is
+ * the wrong entry point: the person is already in, only the media is gone.
+ */
+export async function reconnectMeeting (room: Room): Promise<void> {
+  if (get(myInfo)?.room !== room._id) {
+    await joinMeeting(room)
+    return
+  }
+  await connectToMeeting(room)
+}
+
 export async function joinOrCreateMeetingByInvite (roomId: Ref<Room>): Promise<void> {
   if (currentMeetingRoom === roomId) return
 


### PR DESCRIPTION
### Description of the issue

`ParticipantInfo` (who is in which Love room) is written only by the person's own client, on join and on leave, and dropped by the server only when the person goes fully offline. If the client goes away mid-call — page reload, crash, laptop lid, network loss — the LiveKit participant is dropped but the record keeps pointing at the room.

The person then reloads and sees themselves "in" the room with no audio/video. `RoomPopup` hides **Enter room** because `$myInfo.room === room._id`, and the microphone/camera controls need `$lkSessionConnected`, so there is no way to get the call back. Everyone else keeps seeing them as a member of the room.

### Steps to reproduce

1. Join a video room (e.g. All hands) from the office view; confirm audio works.
2. Reload the page (or kill the tab) while in the call.
3. Open the room popup after the reload.

### Expected behaviour

The person can re-establish the call (or leave the room).

### Actual behaviour

The popup shows the person as a member, offers only **Leave**, and no media is connected. Server side, the LiveKit log shows `participant closing … CLIENT_REQUEST_LEAVE` while the `ParticipantInfo` still has `room` set to the video room.

### Fix

- `RoomPopup.svelte`: show **Enter room** whenever no LiveKit session is connected, not only when the record says the person is out.
- `meetings.ts`: new exported `reconnectMeeting(room)`, which connects directly when the record already places the person in that room. `joinMeeting` is not used for this case because it would send a knock/join request again for Knock rooms and offices. `connectToMeeting`'s `moveToMeetingRoom` already returns early when the room is unchanged, so rejoining is only a fresh token and LiveKit connect.

Deliberately no automatic reset on startup: a second tab of the same user would reset the first tab's live call, and the record's `sessionId` cannot identify the owning tab (it is refreshed on every transactor `Reconnected`).

A companion PR makes the Love service reset stale records on LiveKit `participant_left` / `room_finished` webhooks, so other members stop seeing the ghost without the person doing anything.

### Testing

Reproduced on a self-hosted v0.7.432 instance (LiveKit self-hosted). Verified the failure mode from the transactor and livekit-server logs and the transactor REST API; verified that the same `ParticipantInfo` update the client's own `kick()` sends clears the state.

Developed with AI assistance; reviewed and tested by the author.